### PR TITLE
wifi: fix wrong void return value

### DIFF
--- a/zephyr/adapter/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/adapter/src/wifi/esp_wifi_adapter.c
@@ -568,7 +568,7 @@ int32_t nvs_open(const char *name, uint32_t open_mode, uint32_t *out_handle)
 
 void nvs_close(uint32_t handle)
 {
-	return 0;
+	return;
 }
 
 int32_t nvs_commit(uint32_t handle)


### PR DESCRIPTION
function should not return int value

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>