### PR TITLE
timer: fix LAC timer log error

### DIFF
--- a/components/esp_timer/src/esp_timer_impl_lac.c
+++ b/components/esp_timer/src/esp_timer_impl_lac.c
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <zephyr.h>
+#include <logging/log.h>
 #include "sys/param.h"
 #include "esp_timer_impl.h"
 #include "esp_timer.h"


### PR DESCRIPTION
add missing logging include

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>