### PR TITLE
esp_timer: fix undefined reference

### DIFF
--- a/components/esp_timer/src/esp_timer.c
+++ b/components/esp_timer/src/esp_timer.c
@@ -333,7 +333,7 @@ static void timer_task(void* arg)
 {
     while (true){
         int __attribute__((unused)) res = k_sem_take(&s_timer_semaphore, K_FOREVER);
-        assert(res == pdTRUE);
+        assert(res == 0);
         timer_process_alarm(ESP_TIMER_TASK);
     }
 }


### PR DESCRIPTION
fix unknown symbol error during /tests build

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>