### PR TITLE
esp32: counter: replaces CMakeLists.txt config macro name

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -57,7 +57,7 @@ if(CONFIG_SOC_ESP32)
     ../components/spi_flash/flash_ops.c
     )
 
-  zephyr_library_sources_ifdef(CONFIG_TIMER_ESP32   ../components/soc/src/hal/timer_hal.c) 
+  zephyr_library_sources_ifdef(CONFIG_COUNTER_ESP32   ../components/soc/src/hal/timer_hal.c) 
   
   zephyr_sources_ifdef(
     CONFIG_ESP32_SPIM   


### PR DESCRIPTION
Zephyr community uses COUNTER instead of TIMER.
This commit replaces the config macro name to avoid confusion.

Signed-off-by: Glauber Maroto Ferreira <glauber.ferreira@espressif.com>