### PR TITLE
hal: esp32: spi_flash: adds support for SPI Flash operations

### DIFF
--- a/components/spi_flash/flash_ops.c
+++ b/components/spi_flash/flash_ops.c
@@ -45,6 +45,10 @@
 #include "esp_attr.h"
 #include "esp_timer.h"
 
+#if defined(__ZEPHYR__)
+#include "common/cache_utils.h"
+#endif
+
 esp_rom_spiflash_result_t IRAM_ATTR spi_flash_write_encrypted_chip(size_t dest_addr, const void *src, size_t size);
 
 /* bytes erased by SPIEraseBlock() ROM function */
@@ -85,6 +89,15 @@ static bool is_safe_write_address(size_t addr, size_t size);
 static void spi_flash_os_yield(void);
 
 const DRAM_ATTR spi_flash_guard_funcs_t g_flash_guard_default_ops = {
+#if defined(__ZEPHYR__)
+    .start                  = esp32_spiflash_start,
+    .end                    = esp32_spiflash_end,
+    .op_lock                = 0,
+    .op_unlock              = 0,
+#if !CONFIG_SPI_FLASH_DANGEROUS_WRITE_ALLOWED
+    .is_safe_write_address  = 0
+#endif
+#else
     .start                  = spi_flash_disable_interrupts_caches_and_other_cpu,
     .end                    = spi_flash_enable_interrupts_caches_and_other_cpu,
     .op_lock                = spi_flash_op_lock,
@@ -93,6 +106,7 @@ const DRAM_ATTR spi_flash_guard_funcs_t g_flash_guard_default_ops = {
     .is_safe_write_address  = is_safe_write_address,
 #endif
     .yield                  = spi_flash_os_yield,
+#endif // __ZEPHYR__
 };
 
 const DRAM_ATTR spi_flash_guard_funcs_t g_flash_guard_no_os_ops = {

--- a/zephyr/adapter/include/common/cache_utils.h
+++ b/zephyr/adapter/include/common/cache_utils.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <zephyr.h>
+
+#define DPORT_CACHE_MASK 0x3f
+
+static uint32_t s_cache_ops_saved_state[2];
+static unsigned int s_intr_saved_state;
+
+static void IRAM_ATTR esp32_disable_cache(uint32_t cpuid, uint32_t *saved_state)
+{
+	uint32_t ret = 0;
+
+	if (cpuid == PRO_CPU_NUM) {
+		ret |= DPORT_GET_PERI_REG_BITS2(DPORT_PRO_CACHE_CTRL1_REG, DPORT_CACHE_MASK, 0);
+		while (DPORT_GET_PERI_REG_BITS2(DPORT_PRO_DCACHE_DBUG0_REG, DPORT_PRO_CACHE_STATE, DPORT_PRO_CACHE_STATE_S) != 1) {
+			;
+		}
+		DPORT_SET_PERI_REG_BITS(DPORT_PRO_CACHE_CTRL_REG, 1, 0, DPORT_PRO_CACHE_ENABLE_S);
+	} else   {
+		ret |= DPORT_GET_PERI_REG_BITS2(DPORT_APP_CACHE_CTRL1_REG, DPORT_CACHE_MASK, 0);
+		while (DPORT_GET_PERI_REG_BITS2(DPORT_APP_DCACHE_DBUG0_REG, DPORT_APP_CACHE_STATE, DPORT_APP_CACHE_STATE_S) != 1) {
+			;
+		}
+		DPORT_SET_PERI_REG_BITS(DPORT_APP_CACHE_CTRL_REG, 1, 0, DPORT_APP_CACHE_ENABLE_S);
+	}
+	*saved_state = ret;
+}
+
+static void IRAM_ATTR esp32_restore_cache(uint32_t cpuid, uint32_t saved_state)
+{
+	if (cpuid == PRO_CPU_NUM) {
+		DPORT_SET_PERI_REG_BITS(DPORT_PRO_CACHE_CTRL_REG, 1, 1, DPORT_PRO_CACHE_ENABLE_S);
+		DPORT_SET_PERI_REG_BITS(DPORT_PRO_CACHE_CTRL1_REG, DPORT_CACHE_MASK, saved_state, 0);
+	} else   {
+		DPORT_SET_PERI_REG_BITS(DPORT_APP_CACHE_CTRL_REG, 1, 1, DPORT_APP_CACHE_ENABLE_S);
+		DPORT_SET_PERI_REG_BITS(DPORT_APP_CACHE_CTRL1_REG, DPORT_CACHE_MASK, saved_state, 0);
+	}
+}
+
+void IRAM_ATTR esp32_spiflash_start(void)
+{
+	k_sched_lock();
+
+	s_intr_saved_state = irq_lock();
+
+	int cpu_id = arch_curr_cpu()->id;
+	esp32_disable_cache(cpu_id, &s_cache_ops_saved_state[cpu_id]);
+
+#ifdef CONFIG_SMP
+	int other_cpu = (cpu_id == PRO_CPU_NUM) ? APP_CPU_NUM : PRO_CPU_NUM;
+	esp32_disable_cache(other_cpu, &s_cache_ops_saved_state[other_cpu]);
+#endif
+}
+
+void IRAM_ATTR esp32_spiflash_end(void)
+{
+	int cpu_id = arch_curr_cpu()->id;
+
+	esp32_restore_cache(cpu_id, s_cache_ops_saved_state[cpu_id]);
+
+#ifdef CONFIG_SMP
+	int other_cpu = (cpu_id == PRO_CPU_NUM) ? APP_CPU_NUM : PRO_CPU_NUM;
+	esp32_restore_cache(other_cpu, s_cache_ops_saved_state[other_cpu]);
+#endif
+	irq_unlock(s_intr_saved_state);
+
+	k_sched_unlock();
+}
+


### PR DESCRIPTION
Includes:

- SPI Flash guard functions
- Common cache state control API

Signed-off-by: Glauber Maroto Ferreira <glauber.ferreira@espressif.com>