### PR TITLE
Remove imports broken in Python 3.9

### DIFF
--- a/tools/kconfig_new/confgen.py
+++ b/tools/kconfig_new/confgen.py
@@ -28,7 +28,6 @@ import os.path
 import re
 import sys
 import tempfile
-from future.utils import iteritems
 
 import gen_kconfig_doc
 
@@ -184,21 +183,6 @@ class DeprecatedOptions(object):
                         f_o.write('#define {}{} {}{}\n'.format(self.config_prefix, dep_opt, self.config_prefix, new_opt))
 
 
-def dict_enc_for_env(dic, encoding=sys.getfilesystemencoding() or 'utf-8'):
-    """
-    This function can be deleted after dropping support for Python 2.
-    There is no rule for it that environment variables cannot be Unicode but usually people try to avoid it.
-    The upstream kconfiglib cannot detect strings properly if the environment variables are "unicode". This is problem
-    only in Python 2.
-    """
-    if sys.version_info[0] >= 3:
-        return dic
-    ret = dict()
-    for (key, value) in iteritems(dic):
-        ret[key.encode(encoding)] = value.encode(encoding)
-    return ret
-
-
 def main():
     parser = argparse.ArgumentParser(description='confgen.py v%s - Config Generation Tool' % __version__, prog=os.path.basename(sys.argv[0]))
 
@@ -255,8 +239,7 @@ def main():
         os.environ[name] = value
 
     if args.env_file is not None:
-        env = json.load(args.env_file)
-        os.environ.update(dict_enc_for_env(env))
+        os.environ.update(json.load(args.env_file))
 
     config = kconfiglib.Kconfig(args.kconfig)
     config.warn_assign_redun = False

--- a/tools/kconfig_new/confserver.py
+++ b/tools/kconfig_new/confserver.py
@@ -68,8 +68,7 @@ def main():
         os.environ[name] = value
 
     if args.env_file is not None:
-        env = json.load(args.env_file)
-        os.environ.update(confgen.dict_enc_for_env(env))
+        os.environ.update(json.load(args.env_file))
 
     run_server(args.kconfig, args.config, args.sdkconfig_rename)
 

--- a/tools/ldgen/ldgen.py
+++ b/tools/ldgen/ldgen.py
@@ -46,8 +46,7 @@ def _update_environment(args):
         os.environ[name] = value
 
     if args.env_file is not None:
-        env = json.load(args.env_file)
-        os.environ.update(confgen.dict_enc_for_env(env))
+        os.environ.update(json.load(args.env_file))
 
 
 def main():


### PR DESCRIPTION
The current steps for building Zephyr OS for esp32 don't seem to work with Python 3.9 due to ImportErrors. I removed the offending imports because the west documentation says Python 3 and the imports look to be for Python 2 backward compatibility. An alternative that would probably maintain Python 2 compatibility would be to move the import to just after the first return statement in dict_enc_for_env.