### PR TITLE
linker: remove newlib linker

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -53,7 +53,6 @@ if(CONFIG_SOC_ESP32)
         -T${CMAKE_CURRENT_SOURCE_DIR}/adapter/src/linker/esp32.rom.alias.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../components/esp_rom/esp32/ld/esp32.rom.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../components/esp_rom/esp32/ld/esp32.rom.libgcc.ld
-        -T${CMAKE_CURRENT_SOURCE_DIR}/../components/esp_rom/esp32/ld/esp32.rom.newlib-funcs.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../components/esp32/ld/esp32.peripherals.ld
       )
 


### PR DESCRIPTION
This shall be included once newlib support gets in place
and PSRAM workaround is verified.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>