### PR TITLE
hal: remove unused newlib file dependency

### DIFF
--- a/components/esp_timer/src/esp_timer_impl_lac.c
+++ b/components/esp_timer/src/esp_timer_impl_lac.c
@@ -23,12 +23,25 @@
 #include "esp_attr.h"
 #include "esp_intr_alloc.h"
 #include "esp_log.h"
-#include "esp32/clk.h"
 #include "driver/periph_ctrl.h"
 #include "soc/soc.h"
 #include "soc/timer_group_reg.h"
 #include "soc/rtc.h"
 #include "freertos/FreeRTOS.h"
+
+#if CONFIG_IDF_TARGET_ESP32
+#include "esp32/rom/rtc.h"
+#include "esp32/clk.h"
+#elif CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/rtc.h"
+#include "esp32s2/clk.h"
+#elif CONFIG_IDF_TARGET_ESP32S3
+#include "esp32s3/rom/rtc.h"
+#include "esp32s3/clk.h"
+#elif CONFIG_IDF_TARGET_ESP32C3
+#include "esp32c3/rom/rtc.h"
+#include "esp32c3/clk.h"
+#endif
 
 /**
  * @file esp_timer_lac.c
@@ -252,7 +265,7 @@ esp_err_t esp_timer_impl_init(intr_handler_t alarm_handler)
 
     // Set the step for the sleep mode when the timer will work
     // from a slow_clk frequency instead of the APB frequency.
-    uint32_t slowclk_ticks_per_us = esp_clk_slowclk_cal_get() * TICKS_PER_US;
+    uint32_t slowclk_ticks_per_us = REG_READ(RTC_SLOW_CLK_CAL_REG) * TICKS_PER_US;
     REG_SET_FIELD(RTC_STEP_REG, TIMG_LACT_RTC_STEP_LEN, slowclk_ticks_per_us);
 
     irq_enable(ETS_TG0_T1_INUM);

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -109,7 +109,6 @@ if(CONFIG_SOC_ESP32)
     ../../components/esp_timer/src/ets_timer_legacy.c
     ../../components/esp_timer/src/esp_timer.c
     ../../components/esp_timer/src/esp_timer_impl_lac.c
-    ../../components/newlib/port/esp_time_impl.c
     ../../components/driver/periph_ctrl.c
     ../../components/log/log_noos.c
     ../../components/log/log.c


### PR DESCRIPTION
esp_time_impl.c file uses newlib calls
that are not available in Zephyr.

It also removes the same source from build as
it it not used at all.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>