### PR TITLE
toolchain: use zephyr defined toolchain

### DIFF
--- a/tools/cmake/project.cmake
+++ b/tools/cmake/project.cmake
@@ -292,7 +292,8 @@ macro(project project_name)
     # TEST_EXLUDE_COMPONENTS, TESTS_ALL, BUILD_TESTS
     __project_init(components test_components)
 
-    __target_set_toolchain()
+    # Let toolchain be defined by Zephyr environment
+    # __target_set_toolchain()
 
     if(CCACHE_ENABLE)
         find_program(CCACHE_FOUND ccache)


### PR DESCRIPTION
skip idf selection of the toolchain and let
compiler be defined by zephyr cmake

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>