### PR TITLE
Revert "toolchain: use zephyr defined toolchain"

### DIFF
--- a/tools/cmake/project.cmake
+++ b/tools/cmake/project.cmake
@@ -292,8 +292,7 @@ macro(project project_name)
     # TEST_EXLUDE_COMPONENTS, TESTS_ALL, BUILD_TESTS
     __project_init(components test_components)
 
-    # Let toolchain be defined by Zephyr environment
-    # __target_set_toolchain()
+    __target_set_toolchain()
 
     if(CCACHE_ENABLE)
         find_program(CCACHE_FOUND ccache)


### PR DESCRIPTION
This reverts commit 55099bd86fe28ac457d4b0705331be72752c2786.