### PR TITLE
hal: log: fix macro redefinition on esp32

### DIFF
--- a/components/log/log_noos.c
+++ b/components/log/log_noos.c
@@ -14,11 +14,19 @@
 
 #include <assert.h>
 #include "esp_log_private.h"
-#include "hal/cpu_hal.h"  // for cpu_hal_get_cycle_count()
 
+#ifdef CONFIG_IDF_TARGET_ESP32C3
+#include "hal/cpu_hal.h"  // for cpu_hal_get_cycle_count()
 #ifdef __ZEPHYR__
 #include <zephyr.h>
 #endif
+#else 
+#ifdef __ZEPHYR__
+#include <zephyr.h>
+#endif
+#include "hal/cpu_hal.h"  // for cpu_hal_get_cycle_count()
+#endif
+
 
 static int s_lock = 0;
 


### PR DESCRIPTION
change include order of zephyr header file
depending on the selected target.

Signed-off-by: Felipe Neves <felipe.neves@espressif.com>