### PR TITLE
hal: bt: uses the interrupt allocator in bluetooth

### DIFF
--- a/zephyr/esp32c3/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32c3/src/bt/esp_bt_adapter.c
@@ -11,7 +11,6 @@
 #include "sdkconfig.h"
 #include "esp_system.h"
 #include "esp_types.h"
-#include "esp_intr_alloc.h"
 #include "esp_attr.h"
 #include "esp_phy_init.h"
 #include "esp_bt.h"
@@ -26,12 +25,13 @@
 #include "esp_coexist_internal.h"
 #include "esp32c3/rom/rom_layout.h"
 #include "esp32c3/rom/ets_sys.h"
+#include <rom/efuse.h>
 #include <riscv/interrupt.h>
 
 #include <zephyr.h>
 #include <sys/printk.h>
 #include <random/rand32.h>
-#include <rom/efuse.h>
+#include <drivers/interrupt_controller/intc_esp32c3.h>
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(esp32_bt_adapter, CONFIG_LOG_DEFAULT_LEVEL);
@@ -323,7 +323,7 @@ static const struct osi_funcs_t osi_funcs_ro = {
 };
 
 static DRAM_ATTR struct osi_funcs_t *osi_funcs_p;
-
+static DRAM_ATTR int bt_interrupt_source;
 static DRAM_ATTR uint32_t btdm_lpcycle_us = 0;
 static DRAM_ATTR uint8_t btdm_lpcycle_us_frac = 0;
 static DRAM_ATTR esp_bt_controller_status_t btdm_controller_status = ESP_BT_CONTROLLER_STATUS_IDLE;
@@ -375,9 +375,10 @@ void IRAM_ATTR btdm_backup_dma_copy_wrapper(uint32_t reg, uint32_t mem_addr, uin
 
 static void interrupt_set_wrapper(int cpu_no, int intr_source, int intr_num, int intr_prio)
 {
-	(void)intr_prio;
-	intr_matrix_set(0,intr_source, intr_num);
-	esprv_intc_int_set_type(intr_num, 0);
+	ARG_UNUSED(intr_prio);
+	ARG_UNUSED(intr_num);
+	ARG_UNUSED(cpu_no);
+	bt_interrupt_source = intr_source;
 }
 
 static void interrupt_clear_wrapper(int intr_source, int intr_num)
@@ -386,18 +387,24 @@ static void interrupt_clear_wrapper(int intr_source, int intr_num)
 
 static void interrupt_handler_set_wrapper(int n, intr_handler_t fn, void *arg)
 {
-	irq_disable(n);
-	irq_connect_dynamic(n, 15 ,(irq_handler_t)fn, arg, 0);
+	ARG_UNUSED(n);
+	esp_intr_alloc(bt_interrupt_source,
+		0,
+		(isr_handler_t)fn,
+		arg,
+		NULL);
 }
 
 static void interrupt_on_wrapper(int intr_num)
 {
-	esprv_intc_int_enable(1 << intr_num);
+	ARG_UNUSED(intr_num);
+	esp_intr_enable(bt_interrupt_source);
 }
 
 static void interrupt_off_wrapper(int intr_num)
 {
-	esprv_intc_int_disable(1<<intr_num);
+	ARG_UNUSED(intr_num);
+	esp_intr_disable(bt_interrupt_source);
 }
 
 static void IRAM_ATTR interrupt_disable(void)


### PR DESCRIPTION
This PR changes the bluetooth adapter to replace the hardcoded interrupt management functions with the new interrupt allocator APIs from esp32c3 interrupc controller driver from Zephyr kernel. 