### PR TITLE
hal: esp32c3: add gpio infra support

### DIFF
--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -59,6 +59,7 @@ if(CONFIG_SOC_ESP32C3)
     )
 
   zephyr_sources(
+    ../../components/soc/esp32c3/gpio_periph.c
     ../../components/hal/esp32c3/systimer_hal.c
     ../../components/esp_hw_support/port/esp32c3/rtc_clk.c
     ../../components/driver/periph_ctrl.c


### PR DESCRIPTION
To enable usage of esp32c3 in the gpio driver

Signed-off-by: Felipe Neves <felipe.neves@espressif.com>