### PR TITLE
hal: esp32c3: handle wifi and bt using interrupt allocator driver

### DIFF
--- a/components/esp_timer/private_include/esp_timer_impl.h
+++ b/components/esp_timer/private_include/esp_timer_impl.h
@@ -26,7 +26,12 @@
 
 #include <stdint.h>
 #include "esp_err.h"
+
+#ifndef __ZEPHYR__
 #include "esp_intr_alloc.h"
+#else 
+typedef void (*intr_handler_t)(void *arg);
+#endif
 
 /**
  * @brief Initialize platform specific layer of esp_timer

--- a/components/esp_timer/src/esp_timer_impl_systimer.c
+++ b/components/esp_timer/src/esp_timer_impl_systimer.c
@@ -15,6 +15,9 @@
 #include "esp_timer_impl.h"
 #include "esp_err.h"
 #include "esp_timer.h"
+#ifndef CONFIG_SOC_ESP32C3
+#include "esp_intr_alloc.h"
+#endif
 #include "esp_attr.h"
 #include "esp_log.h"
 #include "soc/periph_defs.h"
@@ -23,7 +26,10 @@
 #include "hal/systimer_types.h"
 #include "hal/systimer_hal.h"
 #include <zephyr.h>
+
+#ifdef CONFIG_SOC_ESP32C3
 #include <drivers/interrupt_controller/intc_esp32c3.h>
+#endif
 
 /**
  * @file esp_timer_systimer.c

--- a/components/esp_timer/src/esp_timer_impl_systimer.c
+++ b/components/esp_timer/src/esp_timer_impl_systimer.c
@@ -16,7 +16,6 @@
 #include "esp_err.h"
 #include "esp_timer.h"
 #include "esp_attr.h"
-#include "esp_intr_alloc.h"
 #include "esp_log.h"
 #include "soc/periph_defs.h"
 #include "freertos/FreeRTOS.h"
@@ -24,6 +23,7 @@
 #include "hal/systimer_types.h"
 #include "hal/systimer_hal.h"
 #include <zephyr.h>
+#include <drivers/interrupt_controller/intc_esp32c3.h>
 
 /**
  * @file esp_timer_systimer.c
@@ -102,10 +102,11 @@ esp_err_t esp_timer_impl_init(intr_handler_t alarm_handler)
 {
     s_alarm_handler = alarm_handler;
 
-    esp_rom_intr_matrix_set(0,
-        ETS_SYSTIMER_TARGET2_EDGE_INTR_SOURCE,
-        SYS_TIMER_ESP_IRQ);
-    IRQ_CONNECT(SYS_TIMER_ESP_IRQ, 0, esp_timer_alarm_isr, NULL, 0);
+    esp_intr_alloc(ETS_SYSTIMER_TARGET2_EDGE_INTR_SOURCE,
+        0,
+        (isr_handler_t)esp_timer_alarm_isr,
+        NULL,
+        NULL);
 
     systimer_hal_connect_alarm_counter(SYSTIMER_ALARM_2, SYSTIMER_COUNTER_0);
     systimer_hal_enable_counter(SYSTIMER_COUNTER_0);

--- a/zephyr/esp32c3/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32c3/src/bt/esp_bt_adapter.c
@@ -379,6 +379,12 @@ static void interrupt_set_wrapper(int cpu_no, int intr_source, int intr_num, int
 	ARG_UNUSED(intr_num);
 	ARG_UNUSED(cpu_no);
 	bt_interrupt_source = intr_source;
+
+	/* This workaround is required for BT since interrupt
+	 * allocator driver does not change the priority and uses the
+	 * default one
+	 */ 
+	esprv_intc_int_set_priority(intr_num, intr_prio);
 }
 
 static void interrupt_clear_wrapper(int intr_source, int intr_num)

--- a/zephyr/esp32c3/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32c3/src/bt/esp_bt_adapter.c
@@ -31,6 +31,7 @@
 #include <zephyr.h>
 #include <sys/printk.h>
 #include <random/rand32.h>
+#include <drivers/interrupt_controller/intc_esp32c3.h>
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(esp32_bt_adapter, CONFIG_LOG_DEFAULT_LEVEL);
@@ -322,6 +323,7 @@ static const struct osi_funcs_t osi_funcs_ro = {
 };
 
 static DRAM_ATTR struct osi_funcs_t *osi_funcs_p;
+static DRAM_ATTR int bt_interrupt_source;
 static DRAM_ATTR uint32_t btdm_lpcycle_us = 0;
 static DRAM_ATTR uint8_t btdm_lpcycle_us_frac = 0;
 static DRAM_ATTR esp_bt_controller_status_t btdm_controller_status = ESP_BT_CONTROLLER_STATUS_IDLE;
@@ -373,11 +375,10 @@ void IRAM_ATTR btdm_backup_dma_copy_wrapper(uint32_t reg, uint32_t mem_addr, uin
 
 static void interrupt_set_wrapper(int cpu_no, int intr_source, int intr_num, int intr_prio)
 {
+	ARG_UNUSED(intr_prio);
+	ARG_UNUSED(intr_num);
 	ARG_UNUSED(cpu_no);
-
-	intr_matrix_set(0,intr_source, intr_num);
-	esprv_intc_int_set_priority(intr_num, intr_prio);
-	esprv_intc_int_set_type(intr_num, 0);
+	bt_interrupt_source = intr_source;
 }
 
 static void interrupt_clear_wrapper(int intr_source, int intr_num)
@@ -386,20 +387,24 @@ static void interrupt_clear_wrapper(int intr_source, int intr_num)
 
 static void interrupt_handler_set_wrapper(int n, intr_handler_t fn, void *arg)
 {
-	irq_disable(n);
-	irq_connect_dynamic(n, 15 ,(void (*)(const void *))fn, arg, 0);
+	ARG_UNUSED(n);
+	esp_intr_alloc(bt_interrupt_source,
+		0,
+		(isr_handler_t)fn,
+		arg,
+		NULL);
 }
 
 static void interrupt_on_wrapper(int intr_num)
 {
 	ARG_UNUSED(intr_num);
-	esprv_intc_int_enable(intr_num);
+	esp_intr_enable(bt_interrupt_source);
 }
 
 static void interrupt_off_wrapper(int intr_num)
 {
 	ARG_UNUSED(intr_num);
-	esprv_intc_int_disable(intr_num);
+	esp_intr_disable(bt_interrupt_source);
 }
 
 static void IRAM_ATTR interrupt_disable(void)


### PR DESCRIPTION
This PR fixes the potential break of the wifi and bt subsystems in esp32c3 after interrupt allocator driver got merged in Zephyr main branch by removing the manual interrupt handling and placing the interrupt setting using the zephyr interrupt allocator driver.