### PR TITLE
clock: Fix build issues when building non Zephyr apps

### DIFF
--- a/components/esp32/clk.c
+++ b/components/esp32/clk.c
@@ -12,39 +12,57 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifdef __ZEPHYR__
 #include <zephyr.h>
+#endif
 #include <stdint.h>
 #include <sys/param.h>
 #include "esp_attr.h"
 #include "soc/rtc.h"
 #include "esp32/clk.h"
 
+#ifndef __ZEPHYR__
+#define MHZ (1000000)
+#endif
+
 // g_ticks_us defined in ROMs for PRO and APP CPU
 extern uint32_t g_ticks_per_us_pro;
-#ifndef CONFIG_SMP
+#ifdef CONFIG_SMP
 extern uint32_t g_ticks_per_us_app;
 #endif
 
 int IRAM_ATTR esp_clk_cpu_freq(void)
 {
+#ifdef __ZEPHYR__
     return MHZ(g_ticks_per_us_pro);
+#else
+    return g_ticks_per_us_pro * MHZ;
+#endif
 }
 
 int IRAM_ATTR esp_clk_apb_freq(void)
 {
+#ifdef __ZEPHYR__
     return MHZ(MIN(g_ticks_per_us_pro, 80));
+#else
+    return MIN(g_ticks_per_us_pro, 80) * MHZ;
+#endif
 }
 
 int IRAM_ATTR esp_clk_xtal_freq(void)
 {
+#ifdef __ZEPHYR__
     return MHZ(rtc_clk_xtal_freq_get());
+#else
+    return rtc_clk_xtal_freq_get() * MHZ;
+#endif
 }
 
 void IRAM_ATTR ets_update_cpu_frequency(uint32_t ticks_per_us)
 {
     /* Update scale factors used by esp_rom_delay_us */
     g_ticks_per_us_pro = ticks_per_us;
-#ifndef CONFIG_SMP
+#ifdef CONFIG_SMP
     g_ticks_per_us_app = ticks_per_us;
 #endif
 }

--- a/components/esp32s2/clk.c
+++ b/components/esp32s2/clk.c
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifdef __ZEPHYR__
 #include <zephyr.h>
+#endif
 #include <stdint.h>
 #include <sys/param.h>
 
@@ -20,22 +22,38 @@
 #include "soc/rtc.h"
 #include "esp32s2/clk.h"
 
+#ifndef __ZEPHYR__
+#define MHZ (1000000)
+#endif
+
 // g_ticks_us defined in ROMs
 extern uint32_t g_ticks_per_us_pro;
 
 int IRAM_ATTR esp_clk_cpu_freq(void)
 {
+#ifdef __ZEPHYR__
     return MHZ(g_ticks_per_us_pro);
+#else
+    return g_ticks_per_us_pro * MHZ;
+#endif
 }
 
 int IRAM_ATTR esp_clk_apb_freq(void)
 {
+#ifdef __ZEPHYR__
     return MHZ(MIN(g_ticks_per_us_pro, 80));
+#else
+    return MIN(g_ticks_per_us_pro, 80) * MHZ;
+#endif
 }
 
 int IRAM_ATTR esp_clk_xtal_freq(void)
 {
+#ifdef __ZEPHYR__
     return MHZ(rtc_clk_xtal_freq_get());
+#else
+    return rtc_clk_xtal_freq_get() * MHZ;
+#endif
 }
 
 void IRAM_ATTR ets_update_cpu_frequency(uint32_t ticks_per_us)

--- a/components/esp32s3/clk.c
+++ b/components/esp32s3/clk.c
@@ -24,17 +24,29 @@ extern uint32_t g_ticks_per_us_pro;
 
 int IRAM_ATTR esp_clk_cpu_freq(void)
 {
+#ifdef __ZEPHYR__
     return MHZ(g_ticks_per_us_pro);
+#else
+    return g_ticks_per_us_pro * MHZ;
+#endif
 }
 
 int IRAM_ATTR esp_clk_apb_freq(void)
 {
+#ifdef __ZEPHYR__
     return MHZ(MIN(g_ticks_per_us_pro, 80));
+#else
+    return MIN(g_ticks_per_us_pro, 80) * MHZ;
+#endif
 }
 
 int IRAM_ATTR esp_clk_xtal_freq(void)
 {
+#ifdef __ZEPHYR__
     return MHZ(rtc_clk_xtal_freq_get());
+#else
+    return rtc_clk_xtal_freq_get() * MHZ;
+#endif
 }
 
 void IRAM_ATTR ets_update_cpu_frequency(uint32_t ticks_per_us)


### PR DESCRIPTION
MCUboot build issues were observed as Zephyr specific files are included in build