### PR TITLE
hal: esp32c3: add rtc clock files

### DIFF
--- a/components/esp_hw_support/port/esp32c3/rtc_clk.c
+++ b/components/esp_hw_support/port/esp32c3/rtc_clk.c
@@ -31,8 +31,11 @@
 #include "soc_log.h"
 #include "rtc_clk_common.h"
 #include "esp_rom_sys.h"
-
 static const char *TAG = "rtc_clk";
+
+#ifdef __ZEPHYR__
+#define MHZ (1000000)
+#endif
 
 #define RTC_PLL_FREQ_320M   320
 #define RTC_PLL_FREQ_480M   480

--- a/components/esp_hw_support/port/esp32c3/rtc_clk_common.h
+++ b/components/esp_hw_support/port/esp32c3/rtc_clk_common.h
@@ -14,7 +14,9 @@
 
 #pragma once
 
+#ifndef __ZEPHYR__
 #define MHZ (1000000)
+#endif
 
 #define DPORT_CPUPERIOD_SEL_80      0
 #define DPORT_CPUPERIOD_SEL_160     1

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -13,6 +13,7 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/esp32c3/include
     
     ../../components/esp_hw_support/port/esp32c3/private_include
+    ../../components/esp_hw_support/port/esp32c3
     ../../components/esp_hw_support/include
 
     ../../components/riscv/include


### PR DESCRIPTION
to enable support of esp32c3 clock control driver

Signed-off-by: Felipe Neves <felipe.neves@espressif.com>