### PR TITLE
hal: esp32: SPIRAM: fix guard functions reference

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -97,6 +97,7 @@ if(CONFIG_SOC_ESP32)
 
   zephyr_sources_ifdef(
     CONFIG_ESP_SPIRAM
+    ../esp_shared/src/host_flash/cache_utils.c
     ../../components/spi_flash/flash_ops.c
     ../../components/esp32/spiram.c
     ../../components/esp32/spiram_psram.c


### PR DESCRIPTION
fixes SPIRAM reference to guard functions at
cache_utils.c

Signed-off-by: Glauber Maroto Ferreira <glauber.ferreira@espressif.com>