### PR TITLE
hal: esp32c3: add spi hal files

### DIFF
--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -61,6 +61,14 @@ if(CONFIG_SOC_ESP32C3)
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp32c3/ld/esp32c3.peripherals.ld
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_ESP32_SPIM
+    ../../components/hal/spi_hal.c
+    ../../components/hal/spi_hal_iram.c
+    ../../components/soc/lldesc.c
+    ../../components/soc/esp32c3/spi_periph.c
+    )
+
   zephyr_compile_definitions(
     __ets__
     ESP_PLATFORM


### PR DESCRIPTION
to support spi driver for esp32c3

Signed-off-by: Felipe Neves <felipe.neves@espressif.com>