### PR TITLE
hal: clock: add rtc files to unify clock control

### DIFF
--- a/components/esp_hw_support/port/esp32/rtc_clk.c
+++ b/components/esp_hw_support/port/esp32/rtc_clk.c
@@ -34,6 +34,8 @@
 #include "sdkconfig.h"
 #include "rtc_clk_common.h"
 
+#define MHZ (1000000)
+
 /* Frequency of the 8M oscillator is 8.5MHz +/- 5%, at the default DCAP setting */
 #define RTC_FAST_CLK_FREQ_8M        8500000
 #define RTC_SLOW_CLK_FREQ_150K      150000

--- a/components/esp_hw_support/port/esp32/rtc_clk_common.h
+++ b/components/esp_hw_support/port/esp32/rtc_clk_common.h
@@ -17,8 +17,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define MHZ (1000000)
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/components/esp_hw_support/port/esp32/rtc_clk_init.c
+++ b/components/esp_hw_support/port/esp32/rtc_clk_init.c
@@ -29,6 +29,8 @@
 #include "sdkconfig.h"
 #include "rtc_clk_common.h"
 
+#define MHZ (1000000)
+
 /* Number of 8M/256 clock cycles to use for XTAL frequency estimation.
  * 10 cycles will take approximately 300 microseconds.
  */

--- a/components/esp_hw_support/port/esp32c3/rtc_clk_init.c
+++ b/components/esp_hw_support/port/esp32c3/rtc_clk_init.c
@@ -30,6 +30,8 @@
 #include "rtc_clk_common.h"
 #include "esp_rom_uart.h"
 
+#define MHZ (1000000)
+
 static const char *TAG = "rtc_clk_init";
 
 void rtc_clk_init(rtc_clk_config_t cfg)

--- a/components/esp_hw_support/port/esp32c3/rtc_time.c
+++ b/components/esp_hw_support/port/esp32c3/rtc_time.c
@@ -19,6 +19,8 @@
 #include "soc/timer_group_reg.h"
 #include "esp_rom_sys.h"
 
+#define MHZ (1000000)
+
 /* Calibration of RTC_SLOW_CLK is performed using a special feature of TIMG0.
  * This feature counts the number of XTAL clock cycles within a given number of
  * RTC_SLOW_CLK cycles.

--- a/components/esp_hw_support/port/esp32s2/rtc_clk_common.h
+++ b/components/esp_hw_support/port/esp32s2/rtc_clk_common.h
@@ -17,10 +17,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifndef __ZEPHYR__
-#define MHZ (1000000)
-#endif
-
 #define DPORT_CPUPERIOD_SEL_80		0
 #define DPORT_CPUPERIOD_SEL_160		1
 #define DPORT_CPUPERIOD_SEL_240		2

--- a/components/esp_hw_support/port/esp32s2/rtc_clk_init.c
+++ b/components/esp_hw_support/port/esp32s2/rtc_clk_init.c
@@ -29,6 +29,8 @@
 #include "sdkconfig.h"
 #include "rtc_clk_common.h"
 
+#define MHZ (1000000)
+
 static const char* TAG = "rtc_clk_init";
 
 void rtc_clk_init(rtc_clk_config_t cfg)

--- a/components/esp_hw_support/port/esp32s2/rtc_time.c
+++ b/components/esp_hw_support/port/esp32s2/rtc_time.c
@@ -18,6 +18,8 @@
 #include "soc/rtc_cntl_reg.h"
 #include "soc/timer_group_reg.h"
 
+#define MHZ (1000000)
+
 /* Calibration of RTC_SLOW_CLK is performed using a special feature of TIMG0.
  * This feature counts the number of XTAL clock cycles within a given number of
  * RTC_SLOW_CLK cycles.

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -1,12 +1,9 @@
-# At the moment there is only one supported ESP32 SoC, and it is not
-# supported to omit the esp-dif HAL library, so we don't check for a
-# KConfig option to enable the HAL
-#
-# In the future it might look like this:
-# if(CONFIG_ESP_DIF_LIBRARY)
-# to allow users to disable the HAL
+# SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_SOC_ESP32)
+
+  zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
+
   zephyr_include_directories(
     include
     include/bt
@@ -107,15 +104,16 @@ if(CONFIG_SOC_ESP32)
     ../../components/spi_flash/flash_ops.c
     ../../components/esp32/spiram.c
     ../../components/esp32/spiram_psram.c
-    ../../components/esp_hw_support/port/esp32/rtc_init.c
-    ../../components/soc/esp32/gpio_periph.c
     ../../components/esp32/cache_sram_mmu.c
     ../../components/bootloader_support/src/bootloader_common.c
     )
 
   zephyr_sources(
     ../../components/soc/esp32/gpio_periph.c
-    ../../components/soc/src/esp32/rtc_clk.c
+    ../../components/esp_hw_support/port/esp32/rtc_clk.c
+    ../../components/esp_hw_support/port/esp32/rtc_init.c
+    ../../components/esp_hw_support/port/esp32/rtc_time.c
+    ../../components/esp_hw_support/port/esp32/rtc_clk_init.c
     ../../components/esp32/clk.c
     ../../components/esp_timer/src/ets_timer_legacy.c
     ../../components/esp_timer/src/esp_timer.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_SOC_ESP32C3)
+
+  zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
+
   zephyr_include_directories(
     include
     include/bt
@@ -91,6 +94,10 @@ if(CONFIG_SOC_ESP32C3)
   zephyr_sources(
     ../../components/soc/esp32c3/gpio_periph.c
     ../../components/esp_timer/src/ets_timer_legacy.c
+	../../components/esp_hw_support/port/esp32c3/rtc_clk.c
+    ../../components/esp_hw_support/port/esp32c3/rtc_init.c
+    ../../components/esp_hw_support/port/esp32c3/rtc_time.c
+    ../../components/esp_hw_support/port/esp32c3/rtc_clk_init.c
     ../../components/esp32c3/clk.c
     ../../components/esp_timer/src/esp_timer.c
     ../../components/esp_timer/src/esp_timer_impl_systimer.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_SOC_ESP32S2)
+
+  zephyr_compile_options(-Wno-unused-variable)
+
   zephyr_include_directories(
     include
     include/crypto
@@ -37,6 +40,8 @@ if(CONFIG_SOC_ESP32S2)
     ../../components/spi_flash/include
     ../../components/spi_flash/private_include
     ../../components/bootloader_support/include
+	../../components/efuse/include
+	../../components/efuse/esp32s2/include
     )
 
     zephyr_link_libraries(
@@ -74,7 +79,10 @@ if(CONFIG_SOC_ESP32S2)
 
   zephyr_sources(
     ../../components/soc/esp32s2/gpio_periph.c
-    ../../components/esp_hw_support/port/esp32s2/rtc_clk.c
+	../../components/esp_hw_support/port/esp32s2/rtc_clk.c
+	../../components/esp_hw_support/port/esp32s2/rtc_init.c
+	../../components/esp_hw_support/port/esp32s2/rtc_time.c
+	../../components/esp_hw_support/port/esp32s2/rtc_clk_init.c
     ../../components/esp32s2/clk.c
     ../../components/esp_hw_support/port/esp32s2/regi2c_ctrl.c
     ../../components/driver/periph_ctrl.c


### PR DESCRIPTION
Also add cmakes flags to overcome warnings

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>