### PR TITLE
hal: esp32c3: add timer group hal

### DIFF
--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -91,6 +91,8 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/hal/i2c_hal.c
     )
 
+  zephyr_library_sources_ifdef(CONFIG_COUNTER_ESP32     ../../components/hal/timer_hal.c)
+
   zephyr_sources(
     ../../components/soc/esp32c3/gpio_periph.c
     ../../components/esp_timer/src/ets_timer_legacy.c


### PR DESCRIPTION
to enable timer driver for esp32c3

Signed-off-by: Felipe Neves <felipe.neves@espressif.com>