### PR TITLE
hal: esp32s2: coding guidelines observation

### DIFF
--- a/zephyr/esp32s2/include/stubs.h
+++ b/zephyr/esp32s2/include/stubs.h
@@ -14,4 +14,11 @@
 #define typeof  __typeof__
 #endif
 
+/*
+ * Used in Zephyr's soc.c during cache initialization.
+ * This function prototype is declared here to avoid Zephyr's coding guidelines
+ * checks violation (rule 21.2: "Should not use a reserved identifier")
+ */
+extern void abort(void);
+
 #endif /* _STUBS_H_ */


### PR DESCRIPTION
The declaration of the abort() function prototype is necessary to avoid an
"implicit function declaration" warning. However, when declared on Zephyr,
it triggers a coding guideline violation (reserved identifier rule) on CI.

That's why the declaration is moved to hal_espressif.