### PR TITLE
wdt: added hal sources

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -99,6 +99,11 @@ if(CONFIG_SOC_ESP32)
     )
 
   zephyr_sources_ifdef(
+    CONFIG_WDT_ESP32
+    ../../components/hal/wdt_hal_iram.c
+    )
+
+  zephyr_sources_ifdef(
     CONFIG_ESP_SPIRAM
     ../esp_shared/src/host_flash/cache_utils.c
     ../../components/spi_flash/flash_ops.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -91,6 +91,11 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/hal/i2c_hal.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_WDT_ESP32
+    ../../components/hal/wdt_hal_iram.c
+    )
+
   zephyr_library_sources_ifdef(CONFIG_COUNTER_ESP32     ../../components/hal/timer_hal.c)
 
   zephyr_sources(

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -97,6 +97,11 @@ if(CONFIG_SOC_ESP32S2)
     ../../components/hal/i2c_hal.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_WDT_ESP32
+    ../../components/hal/wdt_hal_iram.c
+    )
+
   zephyr_sources(
     ../../components/soc/esp32s2/gpio_periph.c
     ../../components/esp_hw_support/port/esp32s2/rtc_clk.c


### PR DESCRIPTION
Add proper wdt_hal source files to enable
driver unification.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>