### PR TITLE
gpio: add rtc_io interface

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -111,6 +111,7 @@ if(CONFIG_SOC_ESP32)
 
   zephyr_sources(
     ../../components/soc/esp32/gpio_periph.c
+    ../../components/soc/esp32/rtc_io_periph.c
     ../../components/esp_hw_support/port/esp32/rtc_clk.c
     ../../components/esp_hw_support/port/esp32/rtc_init.c
     ../../components/esp_hw_support/port/esp32/rtc_time.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -104,6 +104,7 @@ if(CONFIG_SOC_ESP32S2)
 
   zephyr_sources(
     ../../components/soc/esp32s2/gpio_periph.c
+    ../../components/soc/esp32s2/rtc_io_periph.c
     ../../components/esp_hw_support/port/esp32s2/rtc_clk.c
     ../../components/esp_hw_support/port/esp32s2/rtc_init.c
     ../../components/esp_hw_support/port/esp32s2/rtc_time.c


### PR DESCRIPTION
This enables handling pins properly as some
gpios are configured over RTC registers.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>