### PR TITLE
uart: add signal sources map

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -109,6 +109,13 @@ if(CONFIG_SOC_ESP32)
     ../../components/bootloader_support/src/bootloader_common.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_UART_ESP32
+    ../../components/soc/esp32/uart_periph.c
+    ../../components/hal/uart_hal.c
+    ../../components/hal/uart_hal_iram.c
+    )
+
   zephyr_sources(
     ../../components/soc/esp32/gpio_periph.c
     ../../components/soc/esp32/rtc_io_periph.c
@@ -125,8 +132,6 @@ if(CONFIG_SOC_ESP32)
     ../../components/log/log.c
     ../../components/hal/interrupt_controller_hal.c
     ../../components/hal/esp32/interrupt_descriptor_table.c
-    ../../components/hal/uart_hal.c
-    ../../components/hal/uart_hal_iram.c
     ../esp_shared/src/common/esp_system_api.c
     src/common/dport_access.c
     src/stubs.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -98,6 +98,13 @@ if(CONFIG_SOC_ESP32C3)
 
   zephyr_library_sources_ifdef(CONFIG_COUNTER_ESP32     ../../components/hal/timer_hal.c)
 
+  zephyr_sources_ifdef(
+    CONFIG_UART_ESP32
+    ../../components/soc/esp32c3/uart_periph.c
+    ../../components/hal/uart_hal.c
+    ../../components/hal/uart_hal_iram.c
+    )
+
   zephyr_sources(
     ../../components/soc/esp32c3/gpio_periph.c
     ../../components/esp_timer/src/ets_timer_legacy.c
@@ -111,8 +118,6 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/hal/esp32c3/systimer_hal.c
     ../../components/esp_hw_support/port/esp32c3/rtc_clk.c
     ../../components/driver/periph_ctrl.c
-    ../../components/hal/uart_hal.c
-    ../../components/hal/uart_hal_iram.c
     ../../components/esp32c3/clk.c
     ../../components/log/log_noos.c
     ../../components/log/log.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -102,6 +102,13 @@ if(CONFIG_SOC_ESP32S2)
     ../../components/hal/wdt_hal_iram.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_UART_ESP32
+    ../../components/soc/esp32s2/uart_periph.c
+    ../../components/hal/uart_hal.c
+    ../../components/hal/uart_hal_iram.c
+    )
+
   zephyr_sources(
     ../../components/soc/esp32s2/gpio_periph.c
     ../../components/soc/esp32s2/rtc_io_periph.c
@@ -118,8 +125,6 @@ if(CONFIG_SOC_ESP32S2)
     ../../components/esp_timer/src/esp_timer_impl_lac.c
     ../../components/esp_timer/src/esp_timer.c
     ../../components/driver/periph_ctrl.c
-    ../../components/hal/uart_hal.c
-    ../../components/hal/uart_hal_iram.c
     ../../components/log/log_noos.c
     ../../components/log/log.c
     ../esp_shared/src/common/esp_system_api.c


### PR DESCRIPTION
This clears UART driver from keeping routing
signals hardcode in uart driver

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>