### PR TITLE
esp32c3: add usb uart rom functions

### DIFF
--- a/zephyr/esp32c3/src/linker/esp32c3.rom.alias.ld
+++ b/zephyr/esp32c3/src/linker/esp32c3.rom.alias.ld
@@ -15,3 +15,5 @@ PROVIDE ( esp_rom_cache_set_idrom_mmu_size = Cache_Set_IDROM_MMU_Size );
 PROVIDE ( esp_rom_Cache_Invalidate_Addr = Cache_Invalidate_Addr );
 PROVIDE ( esp_rom_gpio_matrix_in  = gpio_matrix_in );
 PROVIDE ( esp_rom_gpio_matrix_out = gpio_matrix_out );
+PROVIDE ( esp_rom_usb_uart_rx_one_char = usb_uart_rx_one_char);
+PROVIDE ( esp_rom_usb_uart_tx_one_char = usb_uart_tx_one_char);


### PR DESCRIPTION
to make them visible in zephyr side.

Signed-off-by: Felipe Neves <felipe.neves@espressif.com>