### PR TITLE
soc: esp32s2: add new alias used in mcuboot feature

### DIFF
--- a/zephyr/esp32s2/src/linker/esp32s2.rom.alias.ld
+++ b/zephyr/esp32s2/src/linker/esp32s2.rom.alias.ld
@@ -12,6 +12,7 @@ PROVIDE ( esp_rom_Cache_Disable_ICache = Cache_Disable_ICache );
 PROVIDE ( esp_rom_Cache_Disable_DCache = Cache_Disable_DCache );
 PROVIDE ( esp_rom_Cache_Allocate_SRAM = Cache_Allocate_SRAM );
 PROVIDE ( esp_rom_Cache_Suspend_ICache = Cache_Suspend_ICache );
+PROVIDE ( esp_rom_Cache_Ibus_MMU_Set = Cache_Ibus_MMU_Set );
 PROVIDE ( esp_rom_Cache_Set_ICache_Mode = Cache_Set_ICache_Mode );
 PROVIDE ( esp_rom_Cache_Invalidate_ICache_All = Cache_Invalidate_ICache_All );
 PROVIDE ( esp_rom_Cache_Resume_ICache = Cache_Resume_ICache );


### PR DESCRIPTION
Add alias to force the esp_rom prefix.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>