### PR TITLE
crypto: fix building warnings due to mbedtls updates

### DIFF
--- a/components/wpa_supplicant/src/ap/wpa_auth.c
+++ b/components/wpa_supplicant/src/ap/wpa_auth.c
@@ -20,7 +20,11 @@
 #include "common/wpa_common.h"
 
 #include "crypto/aes_wrap.h"
+#ifdef __ZEPHYR__
+#include "crypto.h"
+#else
 #include "crypto/crypto.h"
+#endif
 #include "crypto/sha1.h"
 #include "crypto/sha256.h"
 #include "crypto/random.h"

--- a/components/wpa_supplicant/src/common/sae.c
+++ b/components/wpa_supplicant/src/common/sae.c
@@ -10,7 +10,11 @@
 
 #include "utils/includes.h"
 #include "utils/common.h"
+#ifdef __ZEPHYR__
+#include "crypto.h"
+#else
 #include "crypto/crypto.h"
+#endif
 #include "crypto/sha256.h"
 #include "crypto/random.h"
 #include "crypto/dh_groups.h"

--- a/components/wpa_supplicant/src/rsn_supp/wpa.c
+++ b/components/wpa_supplicant/src/rsn_supp/wpa.c
@@ -24,7 +24,11 @@
 #include "esp_supplicant/esp_wpas_glue.h"
 #include "esp_supplicant/esp_wifi_driver.h"
 
+#ifdef __ZEPHYR__
+#include "crypto.h"
+#else
 #include "crypto/crypto.h"
+#endif
 #include "crypto/sha1.h"
 #include "crypto/aes_wrap.h"
 #include "crypto/ccmp.h"

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -36,6 +36,7 @@ if(CONFIG_SOC_ESP32S2)
     ../../components/wpa_supplicant/include
     ../../components/wpa_supplicant/port/include
     ../../components/wpa_supplicant/src
+    ../../components/wpa_supplicant/src/crypto
     ../../components/wpa_supplicant/include/esp_supplicant
     ../../components/spi_flash/include
     ../../components/spi_flash/private_include


### PR DESCRIPTION
This PR fixes build warnings added by commit
26d7a929d4eae6d0198a1b4035d26d75feed6fc9 in main repository.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>