### PR TITLE
hal: uart: remove file dependency

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -118,7 +118,6 @@ if(CONFIG_SOC_ESP32 OR CONFIG_SOC_ESP32_NET)
 
   zephyr_sources_ifdef(
     CONFIG_UART_ESP32
-    ../../components/soc/esp32/uart_periph.c
     ../../components/hal/uart_hal.c
     ../../components/hal/uart_hal_iram.c
     )

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -108,7 +108,6 @@ if(CONFIG_SOC_ESP32C3)
 
   zephyr_sources_ifdef(
     CONFIG_UART_ESP32
-    ../../components/soc/esp32c3/uart_periph.c
     ../../components/hal/uart_hal.c
     ../../components/hal/uart_hal_iram.c
     )

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -114,7 +114,6 @@ if(CONFIG_SOC_ESP32S2)
 
   zephyr_sources_ifdef(
     CONFIG_UART_ESP32
-    ../../components/soc/esp32s2/uart_periph.c
     ../../components/hal/uart_hal.c
     ../../components/hal/uart_hal_iram.c
     )


### PR DESCRIPTION
which is no longer required since refactorings done
on the UART driver to bring pinctrl support.