### PR TITLE
flash: add missing cache include

### DIFF
--- a/zephyr/esp_shared/include/host_flash/cache_utils.h
+++ b/zephyr/esp_shared/include/host_flash/cache_utils.h
@@ -12,6 +12,7 @@
 #include "esp32s2/rom/cache.h"
 #elif defined(CONFIG_SOC_ESP32C3)
 #include "soc/soc.h"
+#include "esp32c3/rom/cache.h"
 #endif
 
 #include <zephyr.h>


### PR DESCRIPTION
Remove build warning due to implicity declaration.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>