### PR TITLE
zephyr: update include paths to use <zephyr/...>

### DIFF
--- a/components/bootloader_support/src/bootloader_common.c
+++ b/components/bootloader_support/src/bootloader_common.c
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #if defined(__ZEPHYR__)
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #endif
 #include <stdbool.h>

--- a/components/bootloader_support/src/bootloader_common.c
+++ b/components/bootloader_support/src/bootloader_common.c
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #if defined(__ZEPHYR__)
-#include <zephyr.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
 #endif
 #include <stdbool.h>
 #include <assert.h>

--- a/components/driver/periph_ctrl.c
+++ b/components/driver/periph_ctrl.c
@@ -15,7 +15,7 @@
 #include "hal/clk_gate_ll.h"
 #include "esp_attr.h"
 #include "driver/periph_ctrl.h"
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 static unsigned int periph_spinlock;
 

--- a/components/driver/periph_ctrl.c
+++ b/components/driver/periph_ctrl.c
@@ -15,7 +15,7 @@
 #include "hal/clk_gate_ll.h"
 #include "esp_attr.h"
 #include "driver/periph_ctrl.h"
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 static unsigned int periph_spinlock;
 

--- a/components/esp32/clk.c
+++ b/components/esp32/clk.c
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #ifdef __ZEPHYR__
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #endif
 #include <stdint.h>
 #include <sys/param.h>

--- a/components/esp32/clk.c
+++ b/components/esp32/clk.c
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #ifdef __ZEPHYR__
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #endif
 #include <stdint.h>
 #include <sys/param.h>

--- a/components/esp32/spiram.c
+++ b/components/esp32/spiram.c
@@ -18,8 +18,8 @@ we add more types of external RAM memory, this can be made into a more intellige
 // limitations under the License.
 
 #if defined(__ZEPHYR__)
-#include <zephyr.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
 #endif
 #include <stdint.h>
 #include <string.h>

--- a/components/esp32/spiram.c
+++ b/components/esp32/spiram.c
@@ -18,7 +18,7 @@ we add more types of external RAM memory, this can be made into a more intellige
 // limitations under the License.
 
 #if defined(__ZEPHYR__)
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #endif
 #include <stdint.h>

--- a/components/esp32/spiram_psram.c
+++ b/components/esp32/spiram_psram.c
@@ -17,7 +17,7 @@
 // limitations under the License.
 
 #if defined(__ZEPHYR__)
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #endif
 #include "sdkconfig.h"

--- a/components/esp32/spiram_psram.c
+++ b/components/esp32/spiram_psram.c
@@ -17,8 +17,8 @@
 // limitations under the License.
 
 #if defined(__ZEPHYR__)
-#include <zephyr.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
 #endif
 #include "sdkconfig.h"
 #include "string.h"

--- a/components/esp32s2/clk.c
+++ b/components/esp32s2/clk.c
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #ifdef __ZEPHYR__
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #endif
 #include <stdint.h>
 #include <sys/param.h>

--- a/components/esp32s2/clk.c
+++ b/components/esp32s2/clk.c
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #ifdef __ZEPHYR__
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #endif
 #include <stdint.h>
 #include <sys/param.h>

--- a/components/esp32s2/spiram.c
+++ b/components/esp32s2/spiram.c
@@ -18,8 +18,8 @@ we add more types of external RAM memory, this can be made into a more intellige
 // limitations under the License.
 
 #if defined(__ZEPHYR__)
-#include <zephyr.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
 #endif
 #include <stdint.h>
 #include <string.h>

--- a/components/esp32s2/spiram.c
+++ b/components/esp32s2/spiram.c
@@ -18,7 +18,7 @@ we add more types of external RAM memory, this can be made into a more intellige
 // limitations under the License.
 
 #if defined(__ZEPHYR__)
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #endif
 #include <stdint.h>

--- a/components/esp32s2/spiram_psram.c
+++ b/components/esp32s2/spiram_psram.c
@@ -17,7 +17,7 @@
 // limitations under the License.
 
 #if defined(__ZEPHYR__)
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #endif
 #include "sdkconfig.h"

--- a/components/esp32s2/spiram_psram.c
+++ b/components/esp32s2/spiram_psram.c
@@ -17,8 +17,8 @@
 // limitations under the License.
 
 #if defined(__ZEPHYR__)
-#include <zephyr.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
 #endif
 #include "sdkconfig.h"
 #include "string.h"

--- a/components/esp_timer/src/esp_timer.c
+++ b/components/esp_timer/src/esp_timer.c
@@ -32,13 +32,13 @@
 #include "esp_timer_impl.h"
 #include "sdkconfig.h"
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include "esp_private/startup_internal.h"
 #include "esp_private/esp_timer_private.h"
 #include "esp_private/system_internal.h"
 #define LOG_MODULE_NAME esp_timer
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 

--- a/components/esp_timer/src/esp_timer.c
+++ b/components/esp_timer/src/esp_timer.c
@@ -32,7 +32,7 @@
 #include "esp_timer_impl.h"
 #include "sdkconfig.h"
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #include "esp_private/startup_internal.h"
 #include "esp_private/esp_timer_private.h"

--- a/components/esp_timer/src/esp_timer_impl_lac.c
+++ b/components/esp_timer/src/esp_timer_impl_lac.c
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <zephyr.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
 
 #if defined(__ZEPHYR__)
 #include <stdlib.h>

--- a/components/esp_timer/src/esp_timer_impl_lac.c
+++ b/components/esp_timer/src/esp_timer_impl_lac.c
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 #if defined(__ZEPHYR__)

--- a/components/esp_timer/src/esp_timer_impl_systimer.c
+++ b/components/esp_timer/src/esp_timer_impl_systimer.c
@@ -25,7 +25,7 @@
 #include "hal/systimer_ll.h"
 #include "hal/systimer_types.h"
 #include "hal/systimer_hal.h"
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #ifdef CONFIG_SOC_ESP32C3
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>

--- a/components/esp_timer/src/esp_timer_impl_systimer.c
+++ b/components/esp_timer/src/esp_timer_impl_systimer.c
@@ -25,10 +25,10 @@
 #include "hal/systimer_ll.h"
 #include "hal/systimer_types.h"
 #include "hal/systimer_hal.h"
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #ifdef CONFIG_SOC_ESP32C3
-#include <drivers/interrupt_controller/intc_esp32c3.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 #endif
 
 /**

--- a/components/esp_wifi/src/phy_init.c
+++ b/components/esp_wifi/src/phy_init.c
@@ -55,8 +55,8 @@
 #include "soc/syscon_reg.h"
 #endif
 
-#include <zephyr.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>

--- a/components/esp_wifi/src/phy_init.c
+++ b/components/esp_wifi/src/phy_init.c
@@ -55,7 +55,7 @@
 #include "soc/syscon_reg.h"
 #endif
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <stddef.h>
 #include <stdlib.h>

--- a/components/log/log_noos.c
+++ b/components/log/log_noos.c
@@ -18,11 +18,11 @@
 #ifdef CONFIG_IDF_TARGET_ESP32C3
 #include "hal/cpu_hal.h"  // for cpu_hal_get_cycle_count()
 #ifdef __ZEPHYR__
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #endif
 #else 
 #ifdef __ZEPHYR__
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #endif
 #include "hal/cpu_hal.h"  // for cpu_hal_get_cycle_count()
 #endif

--- a/components/log/log_noos.c
+++ b/components/log/log_noos.c
@@ -18,11 +18,11 @@
 #ifdef CONFIG_IDF_TARGET_ESP32C3
 #include "hal/cpu_hal.h"  // for cpu_hal_get_cycle_count()
 #ifdef __ZEPHYR__
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #endif
 #else 
 #ifdef __ZEPHYR__
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #endif
 #include "hal/cpu_hal.h"  // for cpu_hal_get_cycle_count()
 #endif

--- a/components/spi_flash/flash_mmap.c
+++ b/components/spi_flash/flash_mmap.c
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #if defined(__ZEPHYR__)
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #endif 
 
 #include <stdlib.h>

--- a/components/spi_flash/flash_mmap.c
+++ b/components/spi_flash/flash_mmap.c
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #if defined(__ZEPHYR__)
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #endif 
 
 #include <stdlib.h>

--- a/components/wpa_supplicant/port/include/os.h
+++ b/components/wpa_supplicant/port/include/os.h
@@ -14,7 +14,7 @@
 
 #ifndef OS_H
 #define OS_H
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include "esp_types.h"
 #include <string.h>
 #include <stdio.h>

--- a/zephyr/esp32/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32/src/bt/esp_bt_adapter.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <random/rand32.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/random/rand32.h>
 
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(esp32_bt_adapter, LOG_LEVEL_DBG);
 
 #include "sdkconfig.h"

--- a/zephyr/esp32/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32/src/bt/esp_bt_adapter.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/random/rand32.h>
 

--- a/zephyr/esp32/src/heap_caps.c
+++ b/zephyr/esp32/src/heap_caps.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <string.h>
-#include <sys/math_extras.h>
+#include <zephyr/sys/math_extras.h>
 #include <esp32/spiram.h>
 #include <esp_attr.h>
 

--- a/zephyr/esp32/src/heap_caps.c
+++ b/zephyr/esp32/src/heap_caps.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <string.h>
 #include <zephyr/sys/math_extras.h>
 #include <esp32/spiram.h>

--- a/zephyr/esp32/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32/src/wifi/esp_wifi_adapter.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/random/rand32.h>
 

--- a/zephyr/esp32/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32/src/wifi/esp_wifi_adapter.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <random/rand32.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/random/rand32.h>
 
 #define CONFIG_POSIX_FS
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include "esp_wifi.h"

--- a/zephyr/esp32/src/wpa_supplicant/port/os_xtensa.c
+++ b/zephyr/esp32/src/wpa_supplicant/port/os_xtensa.c
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include "esp_system.h"
 #include "utils/common.h"
-#include <random/rand32.h>
+#include <zephyr/random/rand32.h>
 
 int os_get_time(struct os_time *t)
 {

--- a/zephyr/esp32c3/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32c3/src/bt/esp_bt_adapter.c
@@ -28,7 +28,7 @@
 #include <rom/efuse.h>
 #include <riscv/interrupt.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/random/rand32.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>

--- a/zephyr/esp32c3/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32c3/src/bt/esp_bt_adapter.c
@@ -28,12 +28,12 @@
 #include <rom/efuse.h>
 #include <riscv/interrupt.h>
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <random/rand32.h>
-#include <drivers/interrupt_controller/intc_esp32c3.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/random/rand32.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(esp32_bt_adapter, CONFIG_LOG_DEFAULT_LEVEL);
 
 #define BTDM_INIT_PERIOD                    (5000)    /* ms */

--- a/zephyr/esp32c3/src/common/esp_read_mac.c
+++ b/zephyr/esp32c3/src/common/esp_read_mac.c
@@ -6,7 +6,7 @@
 
 #include "esp_system.h"
 #include <rom/efuse.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 esp_err_t esp_read_mac(uint8_t *mac, esp_mac_type_t type)
 {

--- a/zephyr/esp32c3/src/common/esp_read_mac.c
+++ b/zephyr/esp32c3/src/common/esp_read_mac.c
@@ -6,7 +6,7 @@
 
 #include "esp_system.h"
 #include <rom/efuse.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 esp_err_t esp_read_mac(uint8_t *mac, esp_mac_type_t type)
 {

--- a/zephyr/esp32c3/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32c3/src/wifi/esp_wifi_adapter.c
@@ -31,7 +31,7 @@
 #include <riscv/interrupt.h>
 
 #include <soc.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/random/rand32.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>

--- a/zephyr/esp32c3/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32c3/src/wifi/esp_wifi_adapter.c
@@ -31,12 +31,12 @@
 #include <riscv/interrupt.h>
 
 #include <soc.h>
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <random/rand32.h>
-#include <drivers/interrupt_controller/intc_esp32c3.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/random/rand32.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 K_THREAD_STACK_DEFINE(wifi_stack, 4096);

--- a/zephyr/esp32c3/src/wpa_supplicant/port/os_riscv.c
+++ b/zephyr/esp32c3/src/wpa_supplicant/port/os_riscv.c
@@ -28,7 +28,7 @@
 #include "esp_system.h"
 #include "utils/common.h"
 #include <zephyr/random/rand32.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 int os_get_time(struct os_time *t)
 {

--- a/zephyr/esp32c3/src/wpa_supplicant/port/os_riscv.c
+++ b/zephyr/esp32c3/src/wpa_supplicant/port/os_riscv.c
@@ -27,8 +27,8 @@
 #include <string.h>
 #include "esp_system.h"
 #include "utils/common.h"
-#include <random/rand32.h>
-#include <zephyr.h>
+#include <zephyr/random/rand32.h>
+#include <zephyr/zephyr.h>
 
 int os_get_time(struct os_time *t)
 {

--- a/zephyr/esp32s2/src/heap_caps.c
+++ b/zephyr/esp32s2/src/heap_caps.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <string.h>
-#include <sys/math_extras.h>
+#include <zephyr/sys/math_extras.h>
 #include <esp32s2/spiram.h>
 #include <esp_attr.h>
 #include <esp_heap_caps_adapter.h>

--- a/zephyr/esp32s2/src/heap_caps.c
+++ b/zephyr/esp32s2/src/heap_caps.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <string.h>
 #include <zephyr/sys/math_extras.h>
 #include <esp32s2/spiram.h>

--- a/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <random/rand32.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/random/rand32.h>
 
 #define CONFIG_POSIX_FS
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include "esp_system.h"

--- a/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/random/rand32.h>
 

--- a/zephyr/esp32s2/src/wpa_supplicant/port/os_xtensa.c
+++ b/zephyr/esp32s2/src/wpa_supplicant/port/os_xtensa.c
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include "esp_system.h"
 #include "utils/common.h"
-#include <random/rand32.h>
+#include <zephyr/random/rand32.h>
 
 int os_get_time(struct os_time *t)
 {

--- a/zephyr/esp_shared/include/host_flash/cache_utils.h
+++ b/zephyr/esp_shared/include/host_flash/cache_utils.h
@@ -15,7 +15,7 @@
 #include "esp32c3/rom/cache.h"
 #endif
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 void IRAM_ATTR esp32_spiflash_start(void);
 

--- a/zephyr/esp_shared/src/common/esp_system_api.c
+++ b/zephyr/esp_shared/src/common/esp_system_api.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include "string.h"
 #include "soc/efuse_reg.h"

--- a/zephyr/esp_shared/src/common/esp_system_api.c
+++ b/zephyr/esp_shared/src/common/esp_system_api.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
 #include "string.h"
 #include "soc/efuse_reg.h"
 #include "esp_log.h"

--- a/zephyr/esp_shared/src/host_flash/cache_utils.c
+++ b/zephyr/esp_shared/src/host_flash/cache_utils.c
@@ -5,7 +5,7 @@
  */
 
 #include "host_flash/cache_utils.h"
-#include <drivers/interrupt_controller/intc_esp32.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 
 #define DPORT_CACHE_BIT(cpuid, regid) DPORT_ ## cpuid ## regid
 


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.