### PR TITLE
tools: kconfig_new: confgen: use ZEPHYR_BASE variable instead of env var

### DIFF
--- a/tools/kconfig_new/confgen.py
+++ b/tools/kconfig_new/confgen.py
@@ -39,7 +39,7 @@ ZEPHYR_BASE = Path(os.environ.get('ZEPHYR_BASE', THIS_ZEPHYR))
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "west_commands"))
 
 # use zephyr kconfiglib
-sys.path.insert(0, os.path.join(os.environ['ZEPHYR_BASE'], "scripts", "kconfig"))
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "kconfig"))
 
 import gen_kconfig_doc  # noqa: E402
 import kconfiglib  # noqa: E402


### PR DESCRIPTION
Use the already existing ZEPHYR_BASE variable instead of trying to get it from the environment variable again.

Fixes: #100

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>