### PR TITLE
cmake: fix timer config naming

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -84,7 +84,7 @@ if(CONFIG_SOC_ESP32 OR CONFIG_SOC_ESP32_NET)
     CONFIG_SPI_FLASH_USE_LEGACY_IMPL
     )
 
-  zephyr_library_sources_ifdef(CONFIG_COUNTER_ESP32     ../../components/hal/timer_hal.c)
+  zephyr_library_sources_ifdef(CONFIG_COUNTER_TMR_ESP32     ../../components/hal/timer_hal.c)
 
   zephyr_sources_ifdef(
     CONFIG_ESP32_SPIM

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -104,7 +104,7 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/hal/wdt_hal_iram.c
     )
 
-  zephyr_library_sources_ifdef(CONFIG_COUNTER_ESP32     ../../components/hal/timer_hal.c)
+  zephyr_library_sources_ifdef(CONFIG_COUNTER_TMR_ESP32 ../../components/hal/timer_hal.c)
 
   zephyr_sources_ifdef(
     CONFIG_UART_ESP32

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -78,7 +78,7 @@ if(CONFIG_SOC_ESP32S2)
     CONFIG_SPI_FLASH_USE_LEGACY_IMPL
     )
 
-  zephyr_library_sources_ifdef(CONFIG_COUNTER_ESP32     ../../components/hal/timer_hal.c)
+  zephyr_library_sources_ifdef(CONFIG_COUNTER_TMR_ESP32 ../../components/hal/timer_hal.c)
 
   zephyr_sources_ifdef(
     CONFIG_ESP32_SPIM


### PR DESCRIPTION
Update naming configuration for ESP32 timer/counter

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>