### PR TITLE
hal: use s/<zephyr/zephyr.h>/<zephyr/kernel.h>

### DIFF
--- a/components/wpa_supplicant/port/include/os.h
+++ b/components/wpa_supplicant/port/include/os.h
@@ -14,7 +14,7 @@
 
 #ifndef OS_H
 #define OS_H
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include "esp_types.h"
 #include <string.h>
 #include <stdio.h>

--- a/zephyr/esp_shared/include/host_flash/cache_utils.h
+++ b/zephyr/esp_shared/include/host_flash/cache_utils.h
@@ -15,7 +15,7 @@
 #include "esp32c3/rom/cache.h"
 #endif
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 void IRAM_ATTR esp32_spiflash_start(void);
 


### PR DESCRIPTION
<zephyr/zephyr.h> is just a shim to <zephyr/kernel.h>.

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>