### PR TITLE
drop IRAM_ATTR attribute from forward declaration

### DIFF
--- a/components/esp_hw_support/port/esp32/spiram_psram.c
+++ b/components/esp_hw_support/port/esp32/spiram_psram.c
@@ -205,7 +205,7 @@ typedef struct {
     uint32_t dummyBitLen;
 } psram_cmd_t;
 
-static void IRAM_ATTR psram_cache_init(psram_cache_mode_t psram_cache_mode, psram_vaddr_mode_t vaddrmode);
+static void psram_cache_init(psram_cache_mode_t psram_cache_mode, psram_vaddr_mode_t vaddrmode);
 
 static uint8_t s_psram_cs_io = (uint8_t)-1;
 

--- a/components/esp_hw_support/port/esp32s2/spiram_psram.c
+++ b/components/esp_hw_support/port/esp32s2/spiram_psram.c
@@ -162,7 +162,7 @@ typedef enum {
 typedef esp_rom_spi_cmd_t psram_cmd_t;
 
 static uint32_t s_psram_id = 0;
-static void IRAM_ATTR psram_cache_init(psram_cache_mode_t psram_cache_mode, psram_vaddr_mode_t vaddrmode);
+static void psram_cache_init(psram_cache_mode_t psram_cache_mode, psram_vaddr_mode_t vaddrmode);
 extern void esp_rom_spi_set_op_mode(int spi_num, esp_rom_spiflash_read_mode_t mode);
 
 static uint8_t s_psram_cs_io = (uint8_t)-1;

--- a/components/spi_flash/esp32/flash_ops_esp32.c
+++ b/components/spi_flash/esp32/flash_ops_esp32.c
@@ -32,7 +32,7 @@ static inline void IRAM_ATTR spi_flash_guard_end(void)
     }
 }
 
-extern void IRAM_ATTR flash_rom_init(void);
+extern void flash_rom_init(void);
 esp_rom_spiflash_result_t IRAM_ATTR spi_flash_write_encrypted_chip(size_t dest_addr, const void *src, size_t size)
 {
     const uint8_t *ssrc = (const uint8_t *)src;

--- a/components/spi_flash/esp32c3/flash_ops_esp32c3.c
+++ b/components/spi_flash/esp32c3/flash_ops_esp32c3.c
@@ -30,7 +30,7 @@ static const char *TAG = "spiflash_c3";
 #define SPICACHE SPIMEM0
 #define SPIFLASH SPIMEM1
 
-extern void IRAM_ATTR flash_rom_init(void);
+extern void flash_rom_init(void);
 esp_rom_spiflash_result_t IRAM_ATTR spi_flash_write_encrypted_chip(size_t dest_addr, const void *src, size_t size)
 {
     const spi_flash_guard_funcs_t *ops = spi_flash_guard_get();

--- a/components/spi_flash/esp32s2/flash_ops_esp32s2.c
+++ b/components/spi_flash/esp32s2/flash_ops_esp32s2.c
@@ -30,7 +30,7 @@ static const char *TAG = "spiflash_s2";
 #define SPICACHE SPIMEM0
 #define SPIFLASH SPIMEM1
 
-extern void IRAM_ATTR flash_rom_init(void);
+extern void flash_rom_init(void);
 esp_rom_spiflash_result_t IRAM_ATTR spi_flash_write_encrypted_chip(size_t dest_addr, const void *src, size_t size)
 {
     const spi_flash_guard_funcs_t *ops = spi_flash_guard_get();

--- a/components/spi_flash/flash_ops.c
+++ b/components/spi_flash/flash_ops.c
@@ -60,7 +60,7 @@
 #include "host_flash/cache_utils.h"
 #endif
 
-esp_rom_spiflash_result_t IRAM_ATTR spi_flash_write_encrypted_chip(size_t dest_addr, const void *src, size_t size);
+esp_rom_spiflash_result_t spi_flash_write_encrypted_chip(size_t dest_addr, const void *src, size_t size);
 
 /* bytes erased by SPIEraseBlock() ROM function */
 #define BLOCK_ERASE_SIZE 65536

--- a/zephyr/esp32/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32/src/bt/esp_bt_adapter.c
@@ -109,7 +109,7 @@ struct osi_funcs_t {
 	int32_t (*_queue_send_from_isr)(void *queue, void *item, void *hptw);
 	int32_t (*_queue_recv)(void *queue, void *item, uint32_t block_time_ms);
 	int32_t (*_queue_recv_from_isr)(void *queue, void *item, void *hptw);
-	int32_t (*_task_create)(void *task_func, const char *name, uint32_t stack_depth, void *param, 
+	int32_t (*_task_create)(void *task_func, const char *name, uint32_t stack_depth, void *param,
 							uint32_t prio, void *task_handle, uint32_t core_id);
 	void (*_task_delete)(void *task_handle);
 	bool (*_is_in_isr)(void);
@@ -207,13 +207,13 @@ extern char _data_end_btdm[];
 extern uint32_t _data_start_btdm_rom;
 extern uint32_t _data_end_btdm_rom;
 
-static void IRAM_ATTR task_yield_from_isr(void);
+static void task_yield_from_isr(void);
 static void *semphr_create_wrapper(uint32_t max, uint32_t init);
 static void semphr_delete_wrapper(void *semphr);
-static int32_t IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw);
-static int32_t IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr, void *hptw);
-static int32_t  semphr_take_wrapper(void *semphr, uint32_t block_time_ms);
-static int32_t  semphr_give_wrapper(void *semphr);
+static int32_t semphr_take_from_isr_wrapper(void *semphr, void *hptw);
+static int32_t semphr_give_from_isr_wrapper(void *semphr, void *hptw);
+static int32_t semphr_take_wrapper(void *semphr, uint32_t block_time_ms);
+static int32_t semphr_give_wrapper(void *semphr);
 static void *mutex_create_wrapper(void);
 static void mutex_delete_wrapper(void *mutex);
 static int32_t mutex_lock_wrapper(void *mutex);
@@ -221,19 +221,19 @@ static int32_t mutex_unlock_wrapper(void *mutex);
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size);
 static void queue_delete_wrapper(void *queue);
 static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_ms);
-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw);
+static int32_t queue_send_from_isr_wrapper(void *queue, void *item, void *hptw);
 static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_ms);
-static int32_t IRAM_ATTR queue_recv_from_isr_wrapper(void *queue, void *item, void *hptw);
+static int32_t queue_recv_from_isr_wrapper(void *queue, void *item, void *hptw);
 static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t stack_depth, void *param, uint32_t prio, void *task_handle, uint32_t core_id);
 static void task_delete_wrapper(void *task_handle);
-static int IRAM_ATTR cause_sw_intr_to_core_wrapper(int core_id, int intr_no);
+static int cause_sw_intr_to_core_wrapper(int core_id, int intr_no);
 static void *malloc_internal_wrapper(size_t size);
-static int32_t IRAM_ATTR read_mac_wrapper(uint8_t mac[6]);
-static void IRAM_ATTR srand_wrapper(unsigned int seed);
-static int IRAM_ATTR rand_wrapper(void);
-static uint32_t IRAM_ATTR btdm_lpcycles_2_us(uint32_t cycles);
-static uint32_t IRAM_ATTR btdm_us_2_lpcycles(uint32_t us);
-static bool IRAM_ATTR btdm_sleep_check_duration(uint32_t *slot_cnt);
+static int32_t read_mac_wrapper(uint8_t mac[6]);
+static void srand_wrapper(unsigned int seed);
+static int rand_wrapper(void);
+static uint32_t btdm_lpcycles_2_us(uint32_t cycles);
+static uint32_t btdm_us_2_lpcycles(uint32_t us);
+static bool btdm_sleep_check_duration(uint32_t *slot_cnt);
 static void btdm_sleep_enter_phase1_wrapper(uint32_t lpcycles);
 static void btdm_sleep_enter_phase2_wrapper(void);
 static void btdm_sleep_exit_phase3_wrapper(void);
@@ -255,8 +255,8 @@ static int coex_register_wifi_channel_change_callback_wrapper(void *cb);
 static void set_isr_wrapper(int32_t n, void *f, void *arg);
 static void intr_on(unsigned int mask);
 static void esp_bt_free(void *mem);
-static void IRAM_ATTR interrupt_l3_disable(void);
-static void IRAM_ATTR interrupt_l3_restore(void);
+static void interrupt_l3_disable(void);
+static void interrupt_l3_restore(void);
 
 /* Local variable definition
  ***************************************************************************
@@ -385,7 +385,7 @@ static void IRAM_ATTR interrupt_l3_disable(void)
 	if (global_nested_counter == 0) {
 		global_int_lock = irq_lock();
 	}
-	
+
 	if (global_nested_counter < 0xFFFFFFFF) {
 		global_nested_counter++;
 	}

--- a/zephyr/esp32c3/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32c3/src/bt/esp_bt_adapter.c
@@ -221,15 +221,15 @@ extern void ets_backup_dma_copy(uint32_t reg, uint32_t mem_addr, uint32_t num, b
 static void interrupt_set_wrapper(int cpu_no, int intr_source, int intr_num, int intr_prio);
 static void interrupt_clear_wrapper(int intr_source, int intr_num);
 static void interrupt_handler_set_wrapper(int n, intr_handler_t fn, void *arg);
-static void IRAM_ATTR interrupt_disable(void);
-static void IRAM_ATTR interrupt_restore(void);
-static void IRAM_ATTR task_yield_from_isr(void);
+static void interrupt_disable(void);
+static void interrupt_restore(void);
+static void task_yield_from_isr(void);
 static void *semphr_create_wrapper(uint32_t max, uint32_t init);
 static void semphr_delete_wrapper(void *semphr);
-static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw);
-static int IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr, void *hptw);
-static int  semphr_take_wrapper(void *semphr, uint32_t block_time_ms);
-static int  semphr_give_wrapper(void *semphr);
+static int semphr_take_from_isr_wrapper(void *semphr, void *hptw);
+static int semphr_give_from_isr_wrapper(void *semphr, void *hptw);
+static int semphr_take_wrapper(void *semphr, uint32_t block_time_ms);
+static int semphr_give_wrapper(void *semphr);
 static void *mutex_create_wrapper(void);
 static void mutex_delete_wrapper(void *mutex);
 static int mutex_lock_wrapper(void *mutex);
@@ -237,19 +237,19 @@ static int mutex_unlock_wrapper(void *mutex);
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size);
 static void queue_delete_wrapper(void *queue);
 static int queue_send_wrapper(void *queue, void *item, uint32_t block_time_ms);
-static int IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw);
+static int queue_send_from_isr_wrapper(void *queue, void *item, void *hptw);
 static int queue_recv_wrapper(void *queue, void *item, uint32_t block_time_ms);
-static int IRAM_ATTR queue_recv_from_isr_wrapper(void *queue, void *item, void *hptw);
+static int queue_recv_from_isr_wrapper(void *queue, void *item, void *hptw);
 static int task_create_wrapper(void *task_func, const char *name, uint32_t stack_depth, void *param, uint32_t prio, void *task_handle, uint32_t core_id);
 static void task_delete_wrapper(void *task_handle);
-static bool IRAM_ATTR is_in_isr_wrapper(void);
+static bool is_in_isr_wrapper(void);
 static void *malloc_internal_wrapper(size_t size);
-static int IRAM_ATTR read_mac_wrapper(uint8_t mac[6]);
-static void IRAM_ATTR srand_wrapper(unsigned int seed);
-static int IRAM_ATTR rand_wrapper(void);
-static uint32_t IRAM_ATTR btdm_lpcycles_2_hus(uint32_t cycles, uint32_t *error_corr);
-static uint32_t IRAM_ATTR btdm_hus_2_lpcycles(uint32_t hus);
-static bool IRAM_ATTR btdm_sleep_check_duration(uint32_t *slot_cnt);
+static int read_mac_wrapper(uint8_t mac[6]);
+static void srand_wrapper(unsigned int seed);
+static int rand_wrapper(void);
+static uint32_t btdm_lpcycles_2_hus(uint32_t cycles, uint32_t *error_corr);
+static uint32_t btdm_hus_2_lpcycles(uint32_t hus);
+static bool btdm_sleep_check_duration(uint32_t *slot_cnt);
 static void btdm_sleep_enter_phase1_wrapper(uint32_t lpcycles);
 static void btdm_sleep_enter_phase2_wrapper(void);
 static void btdm_sleep_exit_phase3_wrapper(void);
@@ -341,7 +341,7 @@ static struct k_heap bt_heap;
 static DRAM_ATTR uint8_t btdm_lpclk_sel;
 static DRAM_ATTR struct k_sem *s_wakeup_req_sem = NULL;
 
-static void esp_bt_free(void *mem) 
+static void esp_bt_free(void *mem)
 {
 	k_heap_free(&bt_heap, mem);
 }
@@ -383,7 +383,7 @@ static void interrupt_set_wrapper(int cpu_no, int intr_source, int intr_num, int
 	/* This workaround is required for BT since interrupt
 	 * allocator driver does not change the priority and uses the
 	 * default one
-	 */ 
+	 */
 	esprv_intc_int_set_priority(intr_num, intr_prio);
 }
 
@@ -412,11 +412,11 @@ static void interrupt_off_wrapper(int intr_num)
 }
 
 static void IRAM_ATTR interrupt_disable(void)
-{	
+{
 	if (global_nested_counter == 0) {
 		global_int_lock = irq_lock();
 	}
-	
+
 	if (global_nested_counter < 0xFFFFFFFF) {
 		global_nested_counter++;
 	}
@@ -744,7 +744,7 @@ static void btdm_sleep_enter_phase2_wrapper(void)
 {
 	if (btdm_controller_get_sleep_mode() == ESP_BT_SLEEP_MODE_1) {
 		esp_phy_disable();
-	} 
+	}
 }
 
 static void btdm_sleep_exit_phase3_wrapper(void)
@@ -967,7 +967,7 @@ esp_err_t esp_bt_controller_init(esp_bt_controller_config_t *cfg)
 
 error:
 	if (s_wakeup_req_sem) {
-		semphr_delete_wrapper(s_wakeup_req_sem); 
+		semphr_delete_wrapper(s_wakeup_req_sem);
 		s_wakeup_req_sem = NULL;
 	}
 	return err;


### PR DESCRIPTION
This also removes the IRAM_ATTR attribute from ff declaration from hal_v4.4.1 branch.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>