### PR TITLE
bugfix: array out of bounds build warning

### DIFF
--- a/components/driver/periph_ctrl.c
+++ b/components/driver/periph_ctrl.c
@@ -10,7 +10,7 @@
 
 static unsigned int periph_spinlock;
 
-static uint8_t ref_counts[PERIPH_MODULE_MAX] = {0};
+static uint8_t ref_counts[PERIPH_MODULE_MAX + 1] = {0};
 
 void periph_module_enable(periph_module_t periph)
 {


### PR DESCRIPTION
After SDK 0.15.0 update, array out of bounds warning
came up. This fix the warning with no harm to hal.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>