### PR TITLE
wifi: rename private enums to avoid redefinition and errors

### DIFF
--- a/components/esp_wifi/include/esp_wifi_types.h
+++ b/components/esp_wifi/include/esp_wifi_types.h
@@ -15,11 +15,11 @@ extern "C" {
 #endif
 
 typedef enum {
-    WIFI_MODE_NULL = 0,  /**< null mode */
-    WIFI_MODE_STA,       /**< WiFi station mode */
-    WIFI_MODE_AP,        /**< WiFi soft-AP mode */
-    WIFI_MODE_APSTA,     /**< WiFi station + soft-AP mode */
-    WIFI_MODE_MAX
+    ESP32_WIFI_MODE_NULL = 0,  /**< null mode */
+    ESP32_WIFI_MODE_STA,       /**< WiFi station mode */
+    ESP32_WIFI_MODE_AP,        /**< WiFi soft-AP mode */
+    ESP32_WIFI_MODE_APSTA,     /**< WiFi station + soft-AP mode */
+    ESP32_WIFI_MODE_MAX
 } wifi_mode_t;
 
 typedef enum {


### PR DESCRIPTION
After Zephyr's wifi updates, a few declarations became
redefined, causing build to fail. This adds ESP32 prefix
into those private enums to fix it.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>