### PR TITLE
hal: esp32xx: power management: HAL support

### DIFF
--- a/components/driver/include/driver/uart.h
+++ b/components/driver/include/driver/uart.h
@@ -10,6 +10,7 @@
 extern "C" {
 #endif
 
+#if !defined(__ZEPHYR__)
 #include "esp_err.h"
 #include "esp_intr_alloc.h"
 #include "soc/soc_caps.h"
@@ -19,6 +20,7 @@ extern "C" {
 #include "freertos/queue.h"
 #include "freertos/ringbuf.h"
 #include "hal/uart_types.h"
+#endif // __ZEPHYR__
 
 // Valid UART port number
 #define UART_NUM_0             (0) /*!< UART port 0 */
@@ -28,6 +30,7 @@ extern "C" {
 #endif
 #define UART_NUM_MAX           (SOC_UART_NUM) /*!< UART port max */
 
+#if !defined(__ZEPHYR__)
 /* @brief When calling `uart_set_pin`, instead of GPIO number, `UART_PIN_NO_CHANGE`
  *        can be provided to keep the currently allocated pin.
  */
@@ -866,6 +869,7 @@ esp_err_t uart_set_loop_back(uart_port_t uart_num, bool loop_back_en);
   *
   */
 void uart_set_always_rx_timeout(uart_port_t uart_num, bool always_rx_timeout_en);
+#endif // __ZEPHYR__
 
 #ifdef __cplusplus
 }

--- a/components/esp_hw_support/port/esp32/rtc_sleep.c
+++ b/components/esp_hw_support/port/esp32/rtc_sleep.c
@@ -264,7 +264,7 @@ uint32_t rtc_deep_sleep_start(uint32_t wakeup_opt, uint32_t reject_opt)
     const unsigned CRC_LEN = 0x7ff;
     const unsigned RTC_MEM_PID = 1;
 
-    asm volatile(
+    __asm__ volatile(
                  "movi a2, 0\n" // trigger a stack spill on working register if needed
 
                  /* Start CRC calculation */

--- a/components/esp_hw_support/port/esp32c3/rtc_sleep.c
+++ b/components/esp_hw_support/port/esp32c3/rtc_sleep.c
@@ -194,7 +194,7 @@ uint32_t rtc_deep_sleep_start(uint32_t wakeup_opt, uint32_t reject_opt)
     const unsigned CRC_START_ADDR = 0;
     const unsigned CRC_LEN = 0x7ff;
 
-    asm volatile(
+    __asm__ volatile(
                  /* Start CRC calculation */
                  "sw %1, 0(%0)\n" // set RTC_MEM_CRC_ADDR & RTC_MEM_CRC_LEN
                  "or t0, %1, %2\n"

--- a/components/esp_hw_support/port/esp32s2/rtc_sleep.c
+++ b/components/esp_hw_support/port/esp32s2/rtc_sleep.c
@@ -198,7 +198,7 @@ uint32_t rtc_deep_sleep_start(uint32_t wakeup_opt, uint32_t reject_opt)
     const unsigned CRC_START_ADDR = 0;
     const unsigned CRC_LEN = 0x7ff;
 
-    asm volatile(
+    __asm__ volatile(
                  "movi a2, 0\n" // trigger a stack spill on working register if needed
 
                  /* Start CRC calculation */

--- a/components/esp_hw_support/sleep_retention.c
+++ b/components/esp_hw_support/sleep_retention.c
@@ -173,7 +173,7 @@ esp_err_t esp_sleep_cpu_pd_low_init(bool enable)
             if (buf) {
                 memset(buf, 0, SOC_RTC_CNTL_CPU_PD_RETENTION_MEM_SIZE + RTC_HAL_DMA_LINK_NODE_SIZE);
                 s_retention.retent.cpu_pd_mem = rtc_cntl_hal_dma_link_init(buf,
-                                      buf + RTC_HAL_DMA_LINK_NODE_SIZE, SOC_RTC_CNTL_CPU_PD_RETENTION_MEM_SIZE, NULL);
+                                      (uint32_t *)buf + RTC_HAL_DMA_LINK_NODE_SIZE, SOC_RTC_CNTL_CPU_PD_RETENTION_MEM_SIZE, NULL);
             } else {
                 return ESP_ERR_NO_MEM;
             }

--- a/components/esp_system/port/brownout.c
+++ b/components/esp_system/port/brownout.c
@@ -28,8 +28,9 @@
 #include "hal/cpu_hal.h"
 
 #include "hal/brownout_hal.h"
-
+#if !defined(__ZEPHYR__)
 #include "sdkconfig.h"
+#endif
 
 #if defined(CONFIG_ESP32_BROWNOUT_DET_LVL)
 #define BROWNOUT_DET_LVL CONFIG_ESP32_BROWNOUT_DET_LVL

--- a/components/esp_system/port/soc/esp32/clk.c
+++ b/components/esp_system/port/soc/esp32/clk.c
@@ -13,7 +13,9 @@
 #include "bootloader_clock.h"
 #include "hal/wdt_hal.h"
 
+#if !defined(__ZEPHYR__)
 #include "driver/spi_common_internal.h" // [refactor-todo]: for spicommon_periph_in_use
+#endif
 
 #include "esp_log.h"
 
@@ -21,7 +23,12 @@
 #include "esp_rom_uart.h"
 #include "esp_rom_sys.h"
 
+#if !defined(__ZEPHYR__)
 #include "sdkconfig.h"
+#else
+#include "stubs.h"
+#define CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ   ESP_SOC_DEFAULT_CPU_FREQ_MHZ
+#endif
 
 static const char* TAG = "clk";
 

--- a/components/esp_system/port/soc/esp32c3/clk.c
+++ b/components/esp_system/port/soc/esp32c3/clk.c
@@ -6,7 +6,9 @@
 
 #include <stdint.h>
 #include <sys/cdefs.h>
+#if !defined(__ZEPHYR__)
 #include <sys/time.h>
+#endif
 #include <sys/param.h>
 #include "sdkconfig.h"
 #include "esp_attr.h"
@@ -28,6 +30,9 @@
 #include "soc/syscon_reg.h"
 #include "esp_rom_uart.h"
 #include "esp_rom_sys.h"
+#if defined(__ZEPHYR__)
+#include "stubs.h"
+#endif
 
 /* Number of cycles to wait from the 32k XTAL oscillator to consider it running.
  * Larger values increase startup delay. Smaller values may cause false positive
@@ -46,6 +51,10 @@
  * than a crystal.
  */
 #define EXT_OSC_FLAG    BIT(3)
+
+#if defined(__ZEPHYR__)
+#define CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ   ESP_SOC_DEFAULT_CPU_FREQ_MHZ
+#endif
 
 /* This is almost the same as rtc_slow_freq_t, except that we define
  * an extra enum member for the external 32k oscillator.

--- a/components/esp_system/port/soc/esp32s2/clk.c
+++ b/components/esp_system/port/soc/esp32s2/clk.c
@@ -6,9 +6,15 @@
 
 #include <stdint.h>
 #include <sys/cdefs.h>
+#if !defined(__ZEPHYR__)
 #include <sys/time.h>
+#endif
 #include <sys/param.h>
+
+#if !defined(__ZEPHYR__)
 #include "sdkconfig.h"
+#endif
+
 #include "esp_attr.h"
 #include "esp_log.h"
 #include "esp32s2/clk.h"
@@ -27,6 +33,11 @@
 #include "bootloader_clock.h"
 #include "soc/syscon_reg.h"
 #include "hal/clk_gate_ll.h"
+
+#if defined(__ZEPHYR__)
+#include "stubs.h"
+#define CONFIG_ESP32S2_DEFAULT_CPU_FREQ_MHZ   ESP_SOC_DEFAULT_CPU_FREQ_MHZ
+#endif
 
 static const char *TAG = "clk";
 

--- a/components/hal/esp32s2/brownout_hal.c
+++ b/components/hal/esp32s2/brownout_hal.c
@@ -19,6 +19,9 @@
 #include "regi2c_ctrl.h"
 #include "regi2c_brownout.h"
 
+#if defined(__ZEPHYR__)
+#include "stubs.h"
+#endif
 
 void brownout_hal_config(const brownout_hal_config_t *cfg)
 {

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -28,6 +28,7 @@ if(CONFIG_SOC_ESP32 OR CONFIG_SOC_ESP32_NET)
     ../../components/soc/include
     ../../components/soc/src/esp32/include
     ../../components/driver/include
+    ../../components/driver/esp32/include
     ../../components/esp_phy/include
     ../../components/esp_phy/include/esp32
     ../../components/esp_phy/esp32/include
@@ -37,6 +38,8 @@ if(CONFIG_SOC_ESP32 OR CONFIG_SOC_ESP32_NET)
     ../../components/efuse/esp32/include
     ../../components/efuse/esp32/private_include
     ../../components/esp_system/include
+    ../../components/esp_system/port/include
+    ../../components/esp_system/port/public_compat
     ../../components/esp_wifi/esp32/include
     ../../components/esp_timer/include
     ../../components/esp_timer/private_include
@@ -152,6 +155,13 @@ if(CONFIG_SOC_ESP32 OR CONFIG_SOC_ESP32_NET)
     ../../components/hal/pcnt_hal.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_PM
+    ../../components/esp_hw_support/port/esp32/rtc_sleep.c
+    ../../components/esp_hw_support/sleep_modes.c
+    ../../components/hal/rtc_io_hal.c
+    )
+
   zephyr_sources(
     ../../components/soc/esp32/gpio_periph.c
     ../../components/soc/esp32/rtc_io_periph.c
@@ -162,6 +172,7 @@ if(CONFIG_SOC_ESP32 OR CONFIG_SOC_ESP32_NET)
     ../../components/esp_hw_support/port/esp32/rtc_time.c
     ../../components/esp_hw_support/port/esp32/rtc_clk_init.c
     ../../components/esp_hw_support/mac_addr.c
+    ../../components/esp_system/port/soc/esp32/clk.c
     ../../components/esp_timer/src/ets_timer_legacy.c
     ../../components/esp_timer/src/esp_timer.c
     ../../components/esp_timer/src/esp_timer_impl_lac.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -20,6 +20,9 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/esp_hw_support/include/soc
     ../../components/esp_hw_support/include
 
+    ../../components/esp_system/port/include
+    ../../components/esp_system/port/public_compat
+
     ../../components/riscv/include
     ../../components/hal/include
     ../../components/hal/esp32c3/include
@@ -128,10 +131,20 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/hal/ledc_hal.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_PM
+    ../esp_shared/components/driver/gpio.c
+    ../../components/esp_hw_support/sleep_modes.c
+    ../../components/esp_hw_support/sleep_retention.c
+    ../../components/esp_system/esp_err.c
+    ../../components/hal/esp32c3/rtc_cntl_hal.c
+    )
+
   zephyr_sources(
     ../../components/soc/esp32c3/gpio_periph.c
     ../../components/esp_timer/src/esp_timer_impl_systimer.c
     ../../components/esp_timer/src/ets_timer_legacy.c
+    ../../components/esp_hw_support/port/esp32c3/rtc_sleep.c
     ../../components/esp_hw_support/regi2c_ctrl.c
     ../../components/esp_hw_support/esp_clk.c
     ../../components/esp_hw_support/port/esp32c3/rtc_clk.c
@@ -139,6 +152,7 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/esp_hw_support/port/esp32c3/rtc_time.c
     ../../components/esp_hw_support/port/esp32c3/rtc_clk_init.c
     ../../components/esp_hw_support/mac_addr.c
+    ../../components/esp_system/port/soc/esp32c3/clk.c
     ../../components/esp_timer/src/esp_timer.c
     ../../components/esp_timer/src/esp_timer_impl_systimer.c
     ../../components/hal/systimer_hal.c

--- a/zephyr/esp32c3/include/stubs.h
+++ b/zephyr/esp32c3/include/stubs.h
@@ -14,4 +14,6 @@
 #define typeof  __typeof__
 #endif
 
+#define ESP_SOC_DEFAULT_CPU_FREQ_MHZ (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / 1000000)
+
 #endif /* _STUBS_H_ */

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -28,7 +28,10 @@ if(CONFIG_SOC_ESP32S2)
     ../../components/soc/include
     ../../components/soc/include/soc
     ../../components/driver/include
+    ../../components/driver/esp32s2/include
     ../../components/esp_system/include
+    ../../components/esp_system/port/include
+    ../../components/esp_system/port/public_compat
     ../../components/esp_wifi/esp32s2/include
     ../../components/esp_wifi/include
     ../../components/esp_phy/include
@@ -144,6 +147,14 @@ if(CONFIG_SOC_ESP32S2)
     ../../components/hal/pcnt_hal.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_PM
+    ../../components/esp_hw_support/sleep_modes.c
+    ../../components/esp_system/port/brownout.c
+    ../../components/hal/esp32s2/brownout_hal.c
+    ../../components/hal/esp32s2/touch_sensor_hal.c
+    )
+
   zephyr_sources(
     ../../components/soc/esp32s2/gpio_periph.c
     ../../components/soc/esp32s2/rtc_io_periph.c
@@ -154,15 +165,16 @@ if(CONFIG_SOC_ESP32S2)
     ../../components/esp_hw_support/port/esp32s2/rtc_init.c
     ../../components/esp_hw_support/port/esp32s2/rtc_time.c
     ../../components/esp_hw_support/port/esp32s2/rtc_clk_init.c
+    ../../components/esp_hw_support/port/esp32s2/rtc_sleep.c
     ../../components/esp_hw_support/mac_addr.c
     ../../components/esp_hw_support/port/esp32s2/regi2c_ctrl.c
+    ../../components/esp_system/port/soc/esp32s2/clk.c
     ../../components/driver/periph_ctrl.c
     ../../components/hal/interrupt_controller_hal.c
     ../../components/hal/esp32s2/interrupt_descriptor_table.c
     ../../components/esp_timer/src/ets_timer_legacy.c
     ../../components/esp_timer/src/esp_timer_impl_lac.c
     ../../components/esp_timer/src/esp_timer.c
-    ../../components/driver/periph_ctrl.c
     ../../components/log/log_noos.c
     ../../components/log/log.c
     ../../components/efuse/esp32s2/esp_efuse_fields.c

--- a/zephyr/esp32s2/include/stubs.h
+++ b/zephyr/esp32s2/include/stubs.h
@@ -14,4 +14,6 @@
 #define typeof  __typeof__
 #endif
 
+#define ESP_SOC_DEFAULT_CPU_FREQ_MHZ (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / 1000000)
+
 #endif /* _STUBS_H_ */

--- a/zephyr/esp_shared/components/driver/gpio.c
+++ b/zephyr/esp_shared/components/driver/gpio.c
@@ -1,0 +1,337 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <esp_types.h>
+#include "esp_err.h"
+#include <zephyr/kernel.h>
+#include "driver/gpio.h"
+#include "driver/rtc_io.h"
+#include "soc/soc.h"
+#include "soc/periph_defs.h"
+#include "soc/soc_caps.h"
+#include "soc/gpio_periph.h"
+#include "esp_log.h"
+#include "esp_check.h"
+#include "hal/gpio_hal.h"
+#include "esp_rom_gpio.h"
+
+static const char *GPIO_TAG = "gpio";
+#define GPIO_CHECK(a, str, ret_val) ESP_RETURN_ON_FALSE(a, ret_val, GPIO_TAG, "%s", str)
+
+#define GPIO_ISR_CORE_ID_UNINIT    (3)
+
+//default value for SOC_GPIO_SUPPORT_RTC_INDEPENDENT is 0
+#ifndef SOC_GPIO_SUPPORT_RTC_INDEPENDENT
+#define SOC_GPIO_SUPPORT_RTC_INDEPENDENT 0
+#endif
+
+typedef struct {
+    gpio_isr_t fn;   /*!< isr function */
+    void *args;      /*!< isr function args */
+} gpio_isr_func_t;
+
+typedef struct {
+    gpio_hal_context_t *gpio_hal;
+    unsigned int gpio_spinlock;
+    uint32_t isr_core_id;
+    gpio_isr_func_t *gpio_isr_func;
+    gpio_isr_handle_t gpio_isr_handle;
+} gpio_context_t;
+
+static gpio_hal_context_t _gpio_hal = {
+    .dev = GPIO_HAL_GET_HW(GPIO_PORT_0)
+};
+
+static gpio_context_t gpio_context = {
+    .gpio_hal = &_gpio_hal,
+    .gpio_spinlock = 0,
+    .isr_core_id = GPIO_ISR_CORE_ID_UNINIT,
+    .gpio_isr_func = NULL,
+};
+
+esp_err_t gpio_pullup_en(gpio_num_t gpio_num)
+{
+    GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
+
+    if (!rtc_gpio_is_valid_gpio(gpio_num) || SOC_GPIO_SUPPORT_RTC_INDEPENDENT) {
+	gpio_context.gpio_spinlock = irq_lock();
+        gpio_hal_pullup_en(gpio_context.gpio_hal, gpio_num);
+	irq_unlock(gpio_context.gpio_spinlock);
+    } else {
+#if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
+        rtc_gpio_pullup_en(gpio_num);
+#else
+        abort(); // This should be eliminated as unreachable, unless a programming error has occured
+#endif
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t gpio_pullup_dis(gpio_num_t gpio_num)
+{
+    GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
+
+    if (!rtc_gpio_is_valid_gpio(gpio_num) || SOC_GPIO_SUPPORT_RTC_INDEPENDENT) {
+	gpio_context.gpio_spinlock = irq_lock();
+        gpio_hal_pullup_dis(gpio_context.gpio_hal, gpio_num);
+	irq_unlock(gpio_context.gpio_spinlock);
+    } else {
+#if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
+        rtc_gpio_pullup_dis(gpio_num);
+#else
+        abort(); // This should be eliminated as unreachable, unless a programming error has occured
+#endif
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t gpio_pulldown_en(gpio_num_t gpio_num)
+{
+    GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
+
+    if (!rtc_gpio_is_valid_gpio(gpio_num) || SOC_GPIO_SUPPORT_RTC_INDEPENDENT) {
+	gpio_context.gpio_spinlock = irq_lock();
+        gpio_hal_pulldown_en(gpio_context.gpio_hal, gpio_num);
+	irq_unlock(gpio_context.gpio_spinlock);
+    } else {
+#if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
+        rtc_gpio_pulldown_en(gpio_num);
+#else
+        abort(); // This should be eliminated as unreachable, unless a programming error has occured
+#endif
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t gpio_pulldown_dis(gpio_num_t gpio_num)
+{
+    GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
+
+    if (!rtc_gpio_is_valid_gpio(gpio_num) || SOC_GPIO_SUPPORT_RTC_INDEPENDENT) {
+	gpio_context.gpio_spinlock = irq_lock();
+        gpio_hal_pulldown_dis(gpio_context.gpio_hal, gpio_num);
+	irq_unlock(gpio_context.gpio_spinlock);
+    } else {
+#if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
+        rtc_gpio_pulldown_dis(gpio_num);
+#else
+        abort(); // This should be eliminated as unreachable, unless a programming error has occured
+#endif
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t gpio_wakeup_enable(gpio_num_t gpio_num, gpio_int_type_t intr_type)
+{
+    GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
+    esp_err_t ret = ESP_OK;
+
+    if ((intr_type == GPIO_INTR_LOW_LEVEL) || (intr_type == GPIO_INTR_HIGH_LEVEL)) {
+#if SOC_RTCIO_WAKE_SUPPORTED
+        if (rtc_gpio_is_valid_gpio(gpio_num)) {
+            ret = rtc_gpio_wakeup_enable(gpio_num, intr_type);
+        }
+#endif
+        gpio_context.gpio_spinlock = irq_lock();
+        gpio_hal_wakeup_enable(gpio_context.gpio_hal, gpio_num, intr_type);
+#if SOC_GPIO_SUPPORT_SLP_SWITCH && CONFIG_ESP32C3_LIGHTSLEEP_GPIO_RESET_WORKAROUND
+        gpio_hal_sleep_sel_dis(gpio_context.gpio_hal, gpio_num);
+#endif
+        irq_unlock(gpio_context.gpio_spinlock);
+    } else {
+        ESP_LOGE(GPIO_TAG, "GPIO wakeup only supports level mode, but edge mode set. gpio_num:%u", gpio_num);
+        ret = ESP_ERR_INVALID_ARG;
+    }
+
+    return ret;
+}
+
+esp_err_t gpio_wakeup_disable(gpio_num_t gpio_num)
+{
+    GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
+    esp_err_t ret = ESP_OK;
+#if SOC_RTCIO_WAKE_SUPPORTED
+    if (rtc_gpio_is_valid_gpio(gpio_num)) {
+        ret = rtc_gpio_wakeup_disable(gpio_num);
+    }
+#endif
+    gpio_context.gpio_spinlock = irq_lock();
+    gpio_hal_wakeup_disable(gpio_context.gpio_hal, gpio_num);
+#if SOC_GPIO_SUPPORT_SLP_SWITCH && CONFIG_ESP32C3_LIGHTSLEEP_GPIO_RESET_WORKAROUND
+    gpio_hal_sleep_sel_en(gpio_context.gpio_hal, gpio_num);
+#endif
+    irq_unlock(gpio_context.gpio_spinlock);
+    return ret;
+}
+
+esp_err_t gpio_hold_en(gpio_num_t gpio_num)
+{
+    GPIO_CHECK(GPIO_IS_VALID_OUTPUT_GPIO(gpio_num), "Only output-capable GPIO support this function", ESP_ERR_NOT_SUPPORTED);
+    int ret = ESP_OK;
+
+    if (rtc_gpio_is_valid_gpio(gpio_num)) {
+#if SOC_RTCIO_HOLD_SUPPORTED
+        ret = rtc_gpio_hold_en(gpio_num);
+#endif
+    } else if (GPIO_HOLD_MASK[gpio_num]) {
+	gpio_context.gpio_spinlock = irq_lock();
+        gpio_hal_hold_en(gpio_context.gpio_hal, gpio_num);
+	irq_unlock(gpio_context.gpio_spinlock);
+    } else {
+        ret = ESP_ERR_NOT_SUPPORTED;
+    }
+
+    return ret;
+}
+
+esp_err_t gpio_hold_dis(gpio_num_t gpio_num)
+{
+    GPIO_CHECK(GPIO_IS_VALID_OUTPUT_GPIO(gpio_num), "Only output-capable GPIO support this function", ESP_ERR_NOT_SUPPORTED);
+    int ret = ESP_OK;
+
+    if (rtc_gpio_is_valid_gpio(gpio_num)) {
+#if SOC_RTCIO_HOLD_SUPPORTED
+        ret = rtc_gpio_hold_dis(gpio_num);
+#endif
+    }else if (GPIO_HOLD_MASK[gpio_num]) {
+        gpio_context.gpio_spinlock = irq_lock();
+        gpio_hal_hold_dis(gpio_context.gpio_hal, gpio_num);
+        irq_unlock(gpio_context.gpio_spinlock);
+    } else {
+        ret = ESP_ERR_NOT_SUPPORTED;
+    }
+
+    return ret;
+}
+
+void gpio_deep_sleep_hold_en(void)
+{
+    gpio_context.gpio_spinlock = irq_lock();
+    gpio_hal_deep_sleep_hold_en(gpio_context.gpio_hal);
+    irq_unlock(gpio_context.gpio_spinlock);
+}
+
+void gpio_deep_sleep_hold_dis(void)
+{
+    gpio_context.gpio_spinlock = irq_lock();
+    gpio_hal_deep_sleep_hold_dis(gpio_context.gpio_hal);
+    irq_unlock(gpio_context.gpio_spinlock);
+}
+
+#if SOC_GPIO_SUPPORT_FORCE_HOLD
+
+esp_err_t gpio_force_hold_all()
+{
+#if SOC_RTCIO_HOLD_SUPPORTED
+    rtc_gpio_force_hold_all();
+#endif
+    gpio_context.gpio_spinlock = irq_lock();
+    gpio_hal_force_hold_all(gpio_context.gpio_hal);
+    irq_unlock(gpio_context.gpio_spinlock);
+    return ESP_OK;
+}
+
+esp_err_t gpio_force_unhold_all()
+{
+#if SOC_RTCIO_HOLD_SUPPORTED
+    rtc_gpio_force_hold_dis_all();
+#endif
+    gpio_context.gpio_spinlock = irq_lock();
+    gpio_hal_force_unhold_all();
+    irq_unlock(gpio_context.gpio_spinlock);
+    return ESP_OK;
+}
+#endif
+
+void gpio_iomux_in(uint32_t gpio, uint32_t signal_idx)
+{
+    gpio_hal_iomux_in(gpio_context.gpio_hal, gpio, signal_idx);
+}
+
+void gpio_iomux_out(uint8_t gpio_num, int func, bool oen_inv)
+{
+    gpio_hal_iomux_out(gpio_context.gpio_hal, gpio_num, func, (uint32_t)oen_inv);
+}
+
+#if SOC_GPIO_SUPPORT_SLP_SWITCH
+esp_err_t gpio_sleep_sel_en(gpio_num_t gpio_num)
+{
+    GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
+
+    gpio_context.gpio_spinlock = irq_lock();
+    gpio_hal_sleep_sel_en(gpio_context.gpio_hal, gpio_num);
+    irq_unlock(gpio_context.gpio_spinlock);
+
+    return ESP_OK;
+}
+
+esp_err_t gpio_sleep_sel_dis(gpio_num_t gpio_num)
+{
+    GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
+
+    gpio_context.gpio_spinlock = irq_lock();
+    gpio_hal_sleep_sel_dis(gpio_context.gpio_hal, gpio_num);
+    irq_unlock(gpio_context.gpio_spinlock);
+
+    return ESP_OK;
+}
+
+#if CONFIG_GPIO_ESP32_SUPPORT_SWITCH_SLP_PULL
+esp_err_t gpio_sleep_pupd_config_apply(gpio_num_t gpio_num)
+{
+    GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
+    gpio_hal_sleep_pupd_config_apply(gpio_context.gpio_hal, gpio_num);
+    return ESP_OK;
+}
+
+esp_err_t gpio_sleep_pupd_config_unapply(gpio_num_t gpio_num)
+{
+    GPIO_CHECK(GPIO_IS_VALID_GPIO(gpio_num), "GPIO number error", ESP_ERR_INVALID_ARG);
+    gpio_hal_sleep_pupd_config_unapply(gpio_context.gpio_hal, gpio_num);
+    return ESP_OK;
+}
+#endif // CONFIG_GPIO_ESP32_SUPPORT_SWITCH_SLP_PULL
+#endif // SOC_GPIO_SUPPORT_SLP_SWITCH
+
+#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
+esp_err_t gpio_deep_sleep_wakeup_enable(gpio_num_t gpio_num, gpio_int_type_t intr_type)
+{
+    if (!gpio_hal_is_valid_deepsleep_wakeup_gpio(gpio_num)) {
+        ESP_LOGE(GPIO_TAG, "GPIO %d does not support deep sleep wakeup", gpio_num);
+        return ESP_ERR_INVALID_ARG;
+    }
+    if ((intr_type != GPIO_INTR_LOW_LEVEL) && (intr_type != GPIO_INTR_HIGH_LEVEL)) {
+        ESP_LOGE(GPIO_TAG, "GPIO wakeup only supports level mode, but edge mode set. gpio_num:%u", gpio_num);
+        return ESP_ERR_INVALID_ARG;
+    }
+    gpio_context.gpio_spinlock = irq_lock();
+    gpio_hal_deepsleep_wakeup_enable(gpio_context.gpio_hal, gpio_num, intr_type);
+#if SOC_GPIO_SUPPORT_SLP_SWITCH && CONFIG_ESP32C3_LIGHTSLEEP_GPIO_RESET_WORKAROUND
+    gpio_hal_sleep_sel_dis(gpio_context.gpio_hal, gpio_num);
+#endif
+    irq_unlock(gpio_context.gpio_spinlock);
+    return ESP_OK;
+}
+
+esp_err_t gpio_deep_sleep_wakeup_disable(gpio_num_t gpio_num)
+{
+    if (!gpio_hal_is_valid_deepsleep_wakeup_gpio(gpio_num)) {
+        ESP_LOGE(GPIO_TAG, "GPIO %d does not support deep sleep wakeup", gpio_num);
+        return ESP_ERR_INVALID_ARG;
+    }
+    gpio_context.gpio_spinlock = irq_lock();
+    gpio_hal_deepsleep_wakeup_disable(gpio_context.gpio_hal, gpio_num);
+#if SOC_GPIO_SUPPORT_SLP_SWITCH && CONFIG_ESP32C3_LIGHTSLEEP_GPIO_RESET_WORKAROUND
+    gpio_hal_sleep_sel_en(gpio_context.gpio_hal, gpio_num);
+#endif
+    irq_unlock(gpio_context.gpio_spinlock);
+    return ESP_OK;
+}
+#endif // SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP

--- a/zephyr/esp_shared/include/stubs.h
+++ b/zephyr/esp_shared/include/stubs.h
@@ -14,4 +14,6 @@
 #define typeof  __typeof__
 #endif
 
+#define ESP_SOC_DEFAULT_CPU_FREQ_MHZ (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / 1000000)
+
 #endif /* _STUBS_H_ */


### PR DESCRIPTION
HAL changes to bring Power Management support for Espressif SoCs on Zephyr RTOS.