### PR TITLE
hal: s/zephyr.h/kernel.h

### DIFF
--- a/components/esp_hw_support/regi2c_ctrl.c
+++ b/components/esp_hw_support/regi2c_ctrl.c
@@ -5,7 +5,7 @@
  */
 
 #ifdef __ZEPHYR__
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #endif
 
 #include "regi2c_ctrl.h"

--- a/components/hal/esp32/include/hal/interrupt_controller_ll.h
+++ b/components/hal/esp32/include/hal/interrupt_controller_ll.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <stdint.h>
 #include "soc/soc_caps.h"
 #include "soc/soc.h"

--- a/components/hal/esp32s2/include/hal/interrupt_controller_ll.h
+++ b/components/hal/esp32s2/include/hal/interrupt_controller_ll.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <stdint.h>
 #include "soc/soc_caps.h"
 #include "soc/soc.h"


### PR DESCRIPTION
Replace <zephyr/zephyr.h> with <zephyr/kernel.h>, as it will be
deprecated soon.