### PR TITLE
compiler: remove esp_compiler from zephyr build

### DIFF
--- a/components/esp_common/include/esp_err.h
+++ b/components/esp_common/include/esp_err.h
@@ -9,7 +9,10 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <assert.h>
+
+#ifndef __ZEPHYR__
 #include "esp_compiler.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This is only necessary for bootloader build.
This also fixes CI to failure due to redefinition.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>