### PR TITLE
blobs: Add blobs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ dependencies.lock
 
 # managed_components for examples
 managed_components
+
+# zephyr blobs
+zephyr/blobs/


### PR DESCRIPTION
When hal_espressif is integrated as git submodule, the blobs cause a dirty status, which cannot be fixed in the top repository.