### PR TITLE
driver: gdma: add source files to build

### DIFF
--- a/components/hal/esp32c3/include/hal/gdma_ll.h
+++ b/components/hal/esp32c3/include/hal/gdma_ll.h
@@ -10,6 +10,11 @@
 #include "soc/gdma_struct.h"
 #include "soc/gdma_reg.h"
 
+#if defined(__ZEPHYR__)
+#include <stddef.h>
+#include "stubs.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -86,6 +86,7 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/hal/spi_hal_iram.c
     ../../components/soc/lldesc.c
     ../../components/soc/esp32c3/spi_periph.c
+    ../../components/hal/gdma_hal.c
     )
 
   zephyr_sources_ifdef(


### PR DESCRIPTION
Add gdma driver source files to zephyr build.

Signed-off-by: Lucas Tamborrino <lucas.tamborrino@espressif.com>