### PR TITLE
macro: convert ESP macro to use Zephyr's logging

### DIFF
--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -16,6 +16,9 @@
 #include "esp_err.h"
 #include "esp_log.h"
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(esp32, CONFIG_LOG_DEFAULT_LEVEL);
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -129,7 +132,7 @@ extern "C" {
 #define ESP_RETURN_ON_ERROR(x, log_tag, format, ...) do {                                                  \
         esp_err_t err_rc_ = (x);                                                                           \
         if (unlikely(err_rc_ != ESP_OK)) {                                                                 \
-            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
+            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
             return err_rc_;                                                                                \
         }                                                                                                  \
     } while(0)
@@ -140,7 +143,6 @@ extern "C" {
 #define ESP_RETURN_ON_ERROR_ISR(x, log_tag, format, ...) do {                                              \
         esp_err_t err_rc_ = (x);                                                                           \
         if (unlikely(err_rc_ != ESP_OK)) {                                                                 \
-            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);  \
             return err_rc_;                                                                                \
         }                                                                                                  \
     } while(0)
@@ -152,7 +154,7 @@ extern "C" {
 #define ESP_GOTO_ON_ERROR(x, goto_tag, log_tag, format, ...) do {                                          \
         esp_err_t err_rc_ = (x);                                                                           \
         if (unlikely(err_rc_ != ESP_OK)) {                                                                 \
-            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
+            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
             ret = err_rc_;                                                                                 \
             goto goto_tag;                                                                                 \
         }                                                                                                  \
@@ -164,7 +166,6 @@ extern "C" {
 #define ESP_GOTO_ON_ERROR_ISR(x, goto_tag, log_tag, format, ...) do {                                      \
         esp_err_t err_rc_ = (x);                                                                           \
         if (unlikely(err_rc_ != ESP_OK)) {                                                                 \
-            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);  \
             ret = err_rc_;                                                                                 \
             goto goto_tag;                                                                                 \
         }                                                                                                  \
@@ -176,7 +177,7 @@ extern "C" {
  */
 #define ESP_RETURN_ON_FALSE(a, err_code, log_tag, format, ...) do {                                        \
         if (unlikely(!(a))) {                                                                              \
-            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
+            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
             return err_code;                                                                               \
         }                                                                                                  \
     } while(0)
@@ -186,7 +187,6 @@ extern "C" {
  */
 #define ESP_RETURN_ON_FALSE_ISR(a, err_code, log_tag, format, ...) do {                                    \
         if (unlikely(!(a))) {                                                                              \
-            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);  \
             return err_code;                                                                               \
         }                                                                                                  \
     } while(0)
@@ -197,7 +197,7 @@ extern "C" {
  */
 #define ESP_GOTO_ON_FALSE(a, err_code, goto_tag, log_tag, format, ...) do {                                \
         if (unlikely(!(a))) {                                                                              \
-            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
+            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
             ret = err_code;                                                                                \
             goto goto_tag;                                                                                 \
         }                                                                                                  \
@@ -208,7 +208,6 @@ extern "C" {
  */
 #define ESP_GOTO_ON_FALSE_ISR(a, err_code, goto_tag, log_tag, format, ...) do {                            \
         if (unlikely(!(a))) {                                                                              \
-            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);  \
             ret = err_code;                                                                                \
             goto goto_tag;                                                                                 \
         }                                                                                                  \
@@ -222,7 +221,7 @@ extern "C" {
 #define ESP_RETURN_ON_ERROR(x, log_tag, format, ...) do {                                       \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
-            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
+            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
             return err_rc_;                                                                     \
         }                                                                                       \
     } while(0)
@@ -233,7 +232,6 @@ extern "C" {
 #define ESP_RETURN_ON_ERROR_ISR(x, log_tag, format, ...) do {                                   \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
-            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);  \
             return err_rc_;                                                                     \
         }                                                                                       \
     } while(0)
@@ -245,7 +243,7 @@ extern "C" {
 #define ESP_GOTO_ON_ERROR(x, goto_tag, log_tag, format, ...) do {                               \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
-            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
+            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
             ret = err_rc_;                                                                      \
             goto goto_tag;                                                                      \
         }                                                                                       \
@@ -257,7 +255,6 @@ extern "C" {
 #define ESP_GOTO_ON_ERROR_ISR(x, goto_tag, log_tag, format, ...) do {                           \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
-            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);  \
             ret = err_rc_;                                                                      \
             goto goto_tag;                                                                      \
         }                                                                                       \
@@ -269,7 +266,7 @@ extern "C" {
  */
 #define ESP_RETURN_ON_FALSE(a, err_code, log_tag, format, ...) do {                             \
         if (unlikely(!(a))) {                                                                   \
-            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
+            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
             return err_code;                                                                    \
         }                                                                                       \
     } while(0)
@@ -279,7 +276,6 @@ extern "C" {
  */
 #define ESP_RETURN_ON_FALSE_ISR(a, err_code, log_tag, format, ...) do {                         \
         if (unlikely(!(a))) {                                                                   \
-            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);  \
             return err_code;                                                                    \
         }                                                                                       \
     } while(0)
@@ -290,7 +286,7 @@ extern "C" {
  */
 #define ESP_GOTO_ON_FALSE(a, err_code, goto_tag, log_tag, format, ...) do {                     \
         if (unlikely(!(a))) {                                                                   \
-            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
+            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
             ret = err_code;                                                                     \
             goto goto_tag;                                                                      \
         }                                                                                       \
@@ -301,7 +297,6 @@ extern "C" {
  */
 #define ESP_GOTO_ON_FALSE_ISR(a, err_code, goto_tag, log_tag, format, ...) do {                 \
         if (unlikely(!(a))) {                                                                   \
-            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);  \
             ret = err_code;                                                                     \
             goto goto_tag;                                                                      \
         }                                                                                       \


### PR DESCRIPTION
Make sure hal MACROS as such as ESP_RETURN_ON_ERROR uses Zephyr Logging subsystem instead of esp-idf interface.

This shall be the output when errors in `hal_espressif` sources: (here tested in hello_world sample):  
```c
*** Booting Zephyr OS build v3.2.0-rc3-93-ge477d706943a  ***
Hello World! esp32
[00:00:00.425,000] <err> esp32: main(13): error
```
Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>