### PR TITLE
Feature/esp32 adc

### DIFF
--- a/components/driver/adc.c
+++ b/components/driver/adc.c
@@ -703,7 +703,7 @@ int adc1_get_raw(adc1_channel_t channel)
     adc_hal_set_calibration_param(ADC_NUM_1, cal_val);
 
     ADC_REG_LOCK_ENTER();
-    adc_hal_set_atten(ADC_NUM_2, channel, atten);
+    adc_hal_set_atten(ADC_NUM_1, channel, atten);
     adc_hal_convert(ADC_NUM_1, channel, &raw_out);
     ADC_REG_LOCK_EXIT();
 

--- a/components/efuse/esp32c3/esp_efuse_rtc_calib.c
+++ b/components/efuse/esp32c3/esp_efuse_rtc_calib.c
@@ -39,7 +39,7 @@ uint32_t esp_efuse_rtc_calib_get_init_code(int version, uint32_t adc_unit, int a
     assert(init_code_size == 10);
 
     uint32_t init_code = 0;
-    ESP_ERROR_CHECK(esp_efuse_read_field_blob(init_code_efuse, &init_code, init_code_size));
+    esp_efuse_read_field_blob(init_code_efuse, &init_code, init_code_size);
     return init_code + 1000;    // version 1 logic
 }
 
@@ -70,7 +70,7 @@ esp_err_t esp_efuse_rtc_calib_get_cal_voltage(int version, int atten, uint32_t* 
     assert(cal_vol_efuse[0]->bit_count == 10);
 
     uint32_t cal_vol = 0;
-    ESP_ERROR_CHECK(esp_efuse_read_field_blob(cal_vol_efuse, &cal_vol, cal_vol_efuse[0]->bit_count));
+    esp_efuse_read_field_blob(cal_vol_efuse, &cal_vol, cal_vol_efuse[0]->bit_count);
 
     *out_digi = 2000 + ((cal_vol & BIT(9))? -(cal_vol & ~BIT9): cal_vol);
     *out_vol_mv = calib_vol_expected_mv;

--- a/components/hal/adc_hal.c
+++ b/components/hal/adc_hal.c
@@ -180,6 +180,7 @@ static adc_ll_controller_t get_controller(adc_ll_num_t unit, adc_hal_work_mode_t
 #endif
         }
     }
+	return (adc_ll_controller_t) 0; /* make compiler happy */
 }
 
 void adc_hal_set_controller(adc_ll_num_t unit, adc_hal_work_mode_t work_mode)
@@ -212,6 +213,7 @@ static adc_ll_digi_convert_mode_t get_convert_mode(adc_digi_convert_mode_t conve
             abort();
     }
 #endif
+	return (adc_ll_digi_convert_mode_t) 0; /* make compiler happy */
 }
 
 /**

--- a/components/hal/esp32c3/include/hal/adc_hal_digi.h
+++ b/components/hal/esp32c3/include/hal/adc_hal_digi.h
@@ -17,7 +17,7 @@
 #include "hal/adc_ll.h"
 #include "hal/adc_types.h"
 
-#include_next "hal/adc_hal.h"
+#include "hal/adc_hal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CONFIG_SOC_ESP32 OR CONFIG_SOC_ESP32_NET)
     include/crypto
     ../esp_shared/include
     ../esp_shared/include/wifi
+    ../esp_shared/components/include
     ../../components/hal/include
     ../../components/hal/esp32/include
     ../../components/hal/platform_port/include
@@ -176,6 +177,15 @@ if(CONFIG_SOC_ESP32 OR CONFIG_SOC_ESP32_NET)
     ../../components/hal/wdt_hal_iram.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_ADC_ESP32
+    ../../components/hal/adc_hal.c
+    ../esp_shared/components/driver/adc_common.c
+    ../esp_shared/components/driver/rtc_io_hal.c
+    ../esp_shared/components/driver/rtc_io.c
+    src/esp_adc_cal/esp_adc_cal.c
+    )
+
   if (NOT CONFIG_SOC_ESP32_NET)
     zephyr_sources(
       ../../components/esp_system/port/soc/esp32/clk.c
@@ -184,6 +194,8 @@ if(CONFIG_SOC_ESP32 OR CONFIG_SOC_ESP32_NET)
   endif()
 
   zephyr_sources(
+    ../../components/soc/esp32/adc_periph.c
+    ../../components/soc/esp32/i2s_periph.c
     ../../components/soc/esp32/gpio_periph.c
     ../../components/soc/esp32/rtc_io_periph.c
     ../../components/esp_hw_support/regi2c_ctrl.c

--- a/zephyr/esp32/src/esp_adc_cal/esp_adc_cal.c
+++ b/zephyr/esp32/src/esp_adc_cal/esp_adc_cal.c
@@ -1,0 +1,354 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include "esp_types.h"
+#include "driver/adc.h"
+#include "soc/efuse_periph.h"
+#include "esp_err.h"
+#include "assert.h"
+#include "esp_adc_cal.h"
+
+/* ----------------------------- Configuration ------------------------------ */
+#ifdef CONFIG_ADC_CAL_EFUSE_TP_ENABLE
+#define EFUSE_TP_ENABLED        1
+#else
+#define EFUSE_TP_ENABLED        0
+#endif
+
+#ifdef CONFIG_ADC_CAL_EFUSE_VREF_ENABLE
+#define EFUSE_VREF_ENABLED      1
+#else
+#define EFUSE_VREF_ENABLED      0
+#endif
+
+#ifdef CONFIG_ADC_CAL_LUT_ENABLE
+#define LUT_ENABLED             1
+#else
+#define LUT_ENABLED             0
+#endif
+
+/* ESP32s with both Two Point Values and Vref burned into eFuse are required to
+ * also also burn the EFUSE_BLK3_PART_RESERVE flag. A limited set of ESP32s
+ * (not available through regular sales channel) DO NOT have the
+ * EFUSE_BLK3_PART_RESERVE burned. Moreover, this set of ESP32s represents Vref
+ * in Two's Complement format. If this is the case, modify the preprocessor
+ * definitions below as follows...
+ * #define CHECK_BLK3_FLAG         0        //Do not check BLK3 flag as it is not burned
+ * #define VREF_FORMAT             1        //eFuse Vref is in Two's Complement format
+ */
+#define CHECK_BLK3_FLAG         1
+#define VREF_FORMAT             0
+
+/* ------------------------------ eFuse Access ----------------------------- */
+#define BLK3_RESERVED_REG               EFUSE_BLK0_RDATA3_REG
+
+#define VREF_REG                        EFUSE_BLK0_RDATA4_REG
+#define VREF_MASK                       0x1F
+#define VREF_STEP_SIZE                  7
+#define VREF_OFFSET                     1100
+
+#define TP_REG                          EFUSE_BLK3_RDATA3_REG
+#define TP_LOW1_OFFSET                  278
+#define TP_LOW2_OFFSET                  421
+#define TP_LOW_MASK                     0x7F
+#define TP_LOW_VOLTAGE                  150
+#define TP_HIGH1_OFFSET                 3265
+#define TP_HIGH2_OFFSET                 3406
+#define TP_HIGH_MASK                    0x1FF
+#define TP_HIGH_VOLTAGE                 850
+#define TP_STEP_SIZE                    4
+
+/* ----------------------- Raw to Voltage Constants ------------------------- */
+#define LIN_COEFF_A_SCALE               65536
+#define LIN_COEFF_A_ROUND               (LIN_COEFF_A_SCALE/2)
+
+#define LUT_VREF_LOW                    1000
+#define LUT_VREF_HIGH                   1200
+#define LUT_ADC_STEP_SIZE               64
+#define LUT_POINTS                      20
+#define LUT_LOW_THRESH                  2880
+#define LUT_HIGH_THRESH                 (LUT_LOW_THRESH + LUT_ADC_STEP_SIZE)
+#define ADC_12_BIT_RES                  4096
+
+/* ------------------------ Characterization Constants ---------------------- */
+static const uint32_t adc1_tp_atten_scale[4] = {65504, 86975, 120389, 224310};
+static const uint32_t adc2_tp_atten_scale[4] = {65467, 86861, 120416, 224708};
+static const uint32_t adc1_tp_atten_offset[4] = {0, 1, 27, 54};
+static const uint32_t adc2_tp_atten_offset[4] = {0, 9, 26, 66};
+
+static const uint32_t adc1_vref_atten_scale[4] = {57431, 76236, 105481, 196602};
+static const uint32_t adc2_vref_atten_scale[4] = {57236, 76175, 105678, 197170};
+static const uint32_t adc1_vref_atten_offset[4] = {75, 78, 107, 142};
+static const uint32_t adc2_vref_atten_offset[4] = {63, 66, 89, 128};
+
+//20 Point lookup tables, covering ADC readings from 2880 to 4096, step size of 64
+static const uint32_t lut_adc1_low[LUT_POINTS] = {2240, 2297, 2352, 2405, 2457, 2512, 2564, 2616, 2664, 2709,
+                                                  2754, 2795, 2832, 2868, 2903, 2937, 2969, 3000, 3030, 3060};
+static const uint32_t lut_adc1_high[LUT_POINTS] = {2667, 2706, 2745, 2780, 2813, 2844, 2873, 2901, 2928, 2956,
+                                                   2982, 3006, 3032, 3059, 3084, 3110, 3135, 3160, 3184, 3209};
+static const uint32_t lut_adc2_low[LUT_POINTS] = {2238, 2293, 2347, 2399, 2451, 2507, 2561, 2613, 2662, 2710,
+                                                  2754, 2792, 2831, 2869, 2904, 2937, 2968, 2999, 3029, 3059};
+static const uint32_t lut_adc2_high[LUT_POINTS] = {2657, 2698, 2738, 2774, 2807, 2838, 2867, 2894, 2921, 2946,
+                                                   2971, 2996, 3020, 3043, 3067, 3092, 3116, 3139, 3162, 3185};
+
+/* ----------------------- EFuse Access Functions --------------------------- */
+static bool check_efuse_vref(void)
+{
+    //Check if Vref is burned in eFuse
+    return (REG_GET_FIELD(VREF_REG, EFUSE_RD_ADC_VREF) != 0) ? true : false;
+}
+
+static bool check_efuse_tp(void)
+{
+    //Check if Two Point values are burned in eFuse
+    if (CHECK_BLK3_FLAG && (REG_GET_FIELD(BLK3_RESERVED_REG, EFUSE_RD_BLK3_PART_RESERVE) == 0)) {
+        return false;
+    }
+    //All TP cal values must be non zero
+    if ((REG_GET_FIELD(TP_REG, EFUSE_RD_ADC1_TP_LOW) != 0) &&
+        (REG_GET_FIELD(TP_REG, EFUSE_RD_ADC2_TP_LOW) != 0) &&
+        (REG_GET_FIELD(TP_REG, EFUSE_RD_ADC1_TP_HIGH) != 0) &&
+        (REG_GET_FIELD(TP_REG, EFUSE_RD_ADC2_TP_HIGH) != 0)) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+static inline int decode_bits(uint32_t bits, uint32_t mask, bool is_twos_compl)
+{
+    int ret;
+    if (bits & (~(mask >> 1) & mask)) {      //Check sign bit (MSB of mask)
+        //Negative
+        if (is_twos_compl) {
+            ret = -(((~bits) + 1) & (mask >> 1));   //2's complement
+        } else {
+            ret = -(bits & (mask >> 1));    //Sign-magnitude
+        }
+    } else {
+        //Positive
+        ret = bits & (mask >> 1);
+    }
+    return ret;
+}
+
+static uint32_t read_efuse_vref(void)
+{
+    //eFuse stores deviation from ideal reference voltage
+    uint32_t ret = VREF_OFFSET;       //Ideal vref
+    uint32_t bits = REG_GET_FIELD(VREF_REG, EFUSE_ADC_VREF);
+    ret += decode_bits(bits, VREF_MASK, VREF_FORMAT) * VREF_STEP_SIZE;
+    return ret;     //ADC Vref in mV
+}
+
+static uint32_t read_efuse_tp_low(adc_unit_t adc_num)
+{
+    //ADC reading at 150mV stored in two's complement format
+    uint32_t ret;
+    uint32_t bits;
+
+    if (adc_num == ADC_UNIT_1) {
+        ret = TP_LOW1_OFFSET;
+        bits = REG_GET_FIELD(TP_REG, EFUSE_RD_ADC1_TP_LOW);
+    } else {
+        ret = TP_LOW2_OFFSET;
+        bits = REG_GET_FIELD(TP_REG, EFUSE_RD_ADC2_TP_LOW);
+    }
+    ret += decode_bits(bits, TP_LOW_MASK, true) * TP_STEP_SIZE;
+    return ret;     //Reading of ADC at 150mV
+}
+
+static uint32_t read_efuse_tp_high(adc_unit_t adc_num)
+{
+    //ADC reading at 850mV stored in two's complement format
+    uint32_t ret;
+    uint32_t bits;
+
+    if (adc_num == ADC_UNIT_1) {
+        ret = TP_HIGH1_OFFSET;
+        bits = REG_GET_FIELD(TP_REG, EFUSE_RD_ADC1_TP_HIGH);
+    } else {
+        ret = TP_HIGH2_OFFSET;
+        bits = REG_GET_FIELD(TP_REG, EFUSE_RD_ADC2_TP_HIGH);
+    }
+    ret += decode_bits(bits, TP_HIGH_MASK, true) * TP_STEP_SIZE;
+    return ret;     //Reading of ADC at 850mV
+}
+
+/* ----------------------- Characterization Functions ----------------------- */
+static void characterize_using_two_point(adc_unit_t adc_num,
+                                         adc_atten_t atten,
+                                         uint32_t high,
+                                         uint32_t low,
+                                         uint32_t *coeff_a,
+                                         uint32_t *coeff_b)
+{
+    const uint32_t *atten_scales;
+    const uint32_t *atten_offsets;
+
+    if (adc_num == ADC_UNIT_1) { //Using ADC 1
+        atten_scales = adc1_tp_atten_scale;
+        atten_offsets = adc1_tp_atten_offset;
+    } else {    //Using ADC 2
+        atten_scales = adc2_tp_atten_scale;
+        atten_offsets = adc2_tp_atten_offset;
+    }
+    //Characterize ADC-Voltage curve as y = (coeff_a * x) + coeff_b
+    uint32_t delta_x = high - low;
+    uint32_t delta_v = TP_HIGH_VOLTAGE - TP_LOW_VOLTAGE;
+    //Where coeff_a = (delta_v/delta_x) * atten_scale
+    *coeff_a = (delta_v * atten_scales[atten] + (delta_x / 2)) / delta_x;   //+(delta_x/2) for rounding
+    //Where coeff_b = high_v - ((delta_v/delta_x) * high_x) + atten_offset
+    *coeff_b = TP_HIGH_VOLTAGE - ((delta_v * high + (delta_x / 2)) / delta_x) + atten_offsets[atten];
+}
+
+static void characterize_using_vref(adc_unit_t adc_num,
+                                    adc_atten_t atten,
+                                    uint32_t vref,
+                                    uint32_t *coeff_a,
+                                    uint32_t *coeff_b)
+{
+    const uint32_t *atten_scales;
+    const uint32_t *atten_offsets;
+
+    if (adc_num == ADC_UNIT_1) { //Using ADC 1
+        atten_scales = adc1_vref_atten_scale;
+        atten_offsets = adc1_vref_atten_offset;
+    } else {    //Using ADC 2
+        atten_scales = adc2_vref_atten_scale;
+        atten_offsets = adc2_vref_atten_offset;
+    }
+    //Characterize ADC-Voltage curve as y = (coeff_a * x) + coeff_b
+    //Where coeff_a = (vref/4096) * atten_scale
+    *coeff_a = (vref * atten_scales[atten]) / (ADC_12_BIT_RES);
+    *coeff_b = atten_offsets[atten];
+}
+
+/* ------------------------ Conversion Functions --------------------------- */
+static uint32_t calculate_voltage_linear(uint32_t adc_reading, uint32_t coeff_a, uint32_t coeff_b)
+{
+    //Where voltage = coeff_a * adc_reading + coeff_b
+    return (((coeff_a * adc_reading) + LIN_COEFF_A_ROUND) / LIN_COEFF_A_SCALE) + coeff_b;
+}
+
+//Only call when ADC reading is above threshold
+static uint32_t calculate_voltage_lut(uint32_t adc, uint32_t vref, const uint32_t *low_vref_curve, const uint32_t *high_vref_curve)
+{
+    //Get index of lower bound points of LUT
+    uint32_t i = (adc - LUT_LOW_THRESH) / LUT_ADC_STEP_SIZE;
+
+    //Let the X Axis be Vref, Y axis be ADC reading, and Z be voltage
+    int x2dist = LUT_VREF_HIGH - vref;                 //(x2 - x)
+    int x1dist = vref - LUT_VREF_LOW;                  //(x - x1)
+    int y2dist = ((i + 1) * LUT_ADC_STEP_SIZE) + LUT_LOW_THRESH - adc;  //(y2 - y)
+    int y1dist = adc - ((i * LUT_ADC_STEP_SIZE) + LUT_LOW_THRESH);        //(y - y1)
+
+    //For points for bilinear interpolation
+    int q11 = low_vref_curve[i];                    //Lower bound point of low_vref_curve
+    int q12 = low_vref_curve[i + 1];                //Upper bound point of low_vref_curve
+    int q21 = high_vref_curve[i];                   //Lower bound point of high_vref_curve
+    int q22 = high_vref_curve[i + 1];               //Upper bound point of high_vref_curve
+
+    //Bilinear interpolation
+    //Where z = 1/((x2-x1)*(y2-y1)) * ( (q11*x2dist*y2dist) + (q21*x1dist*y2dist) + (q12*x2dist*y1dist) + (q22*x1dist*y1dist) )
+    int voltage = (q11 * x2dist * y2dist) + (q21 * x1dist * y2dist) + (q12 * x2dist * y1dist) + (q22 * x1dist * y1dist);
+    voltage += ((LUT_VREF_HIGH - LUT_VREF_LOW) * LUT_ADC_STEP_SIZE) / 2; //Integer division rounding
+    voltage /= ((LUT_VREF_HIGH - LUT_VREF_LOW) * LUT_ADC_STEP_SIZE);    //Divide by ((x2-x1)*(y2-y1))
+    return (uint32_t)voltage;
+}
+
+static inline uint32_t interpolate_two_points(uint32_t y1, uint32_t y2, uint32_t x_step, uint32_t x)
+{
+    //Interpolate between two points (x1,y1) (x2,y2) between 'lower' and 'upper' separated by 'step'
+    return ((y1 * x_step) + (y2 * x) - (y1 * x) + (x_step / 2)) / x_step;
+}
+
+/* ------------------------- Public API ------------------------------------- */
+esp_err_t esp_adc_cal_check_efuse(esp_adc_cal_value_t source)
+{
+    if (source == ESP_ADC_CAL_VAL_EFUSE_TP) {
+        return (check_efuse_tp()) ? ESP_OK : ESP_ERR_NOT_SUPPORTED;
+    } else if (source == ESP_ADC_CAL_VAL_EFUSE_VREF) {
+        return (check_efuse_vref()) ? ESP_OK : ESP_ERR_NOT_SUPPORTED;
+    } else {
+        return ESP_ERR_INVALID_ARG;
+    }
+}
+
+esp_adc_cal_value_t esp_adc_cal_characterize(adc_unit_t adc_num,
+                                             adc_atten_t atten,
+                                             adc_bits_width_t bit_width,
+                                             uint32_t default_vref,
+                                             esp_adc_cal_characteristics_t *chars)
+{
+    //Check parameters
+    assert((adc_num == ADC_UNIT_1) || (adc_num == ADC_UNIT_2));
+    assert(chars != NULL);
+    assert(bit_width < ADC_WIDTH_MAX);
+
+    //Check eFuse if enabled to do so
+    bool efuse_tp_present = check_efuse_tp();
+    bool efuse_vref_present = check_efuse_vref();
+    esp_adc_cal_value_t ret;
+
+    if (efuse_tp_present && EFUSE_TP_ENABLED) {
+        //Characterize based on Two Point values
+        uint32_t high = read_efuse_tp_high(adc_num);
+        uint32_t low = read_efuse_tp_low(adc_num);
+        characterize_using_two_point(adc_num, atten, high, low, &chars->coeff_a, &chars->coeff_b);
+        ret = ESP_ADC_CAL_VAL_EFUSE_TP;
+    } else if (efuse_vref_present && EFUSE_VREF_ENABLED) {
+        //Characterize based on eFuse Vref
+        uint32_t vref = read_efuse_vref();
+        characterize_using_vref(adc_num, atten, vref, &chars->coeff_a, &chars->coeff_b);
+        ret = ESP_ADC_CAL_VAL_EFUSE_VREF;
+    } else {
+        //Characterized based on default Vref
+        characterize_using_vref(adc_num, atten, default_vref, &chars->coeff_a, &chars->coeff_b);
+        ret = ESP_ADC_CAL_VAL_DEFAULT_VREF;
+    }
+
+    //Initialized remaining fields
+    chars->adc_num = adc_num;
+    chars->atten = atten;
+    chars->bit_width = bit_width;
+    chars->vref = (EFUSE_VREF_ENABLED && efuse_vref_present) ? read_efuse_vref() : default_vref;
+    //Initialize fields for lookup table if necessary
+    if (LUT_ENABLED && atten == ADC_ATTEN_DB_11) {
+        chars->low_curve = (adc_num == ADC_UNIT_1) ? lut_adc1_low : lut_adc2_low;
+        chars->high_curve = (adc_num == ADC_UNIT_1) ? lut_adc1_high : lut_adc2_high;
+    } else {
+        chars->low_curve = NULL;
+        chars->high_curve = NULL;
+    }
+    return ret;
+}
+
+uint32_t esp_adc_cal_raw_to_voltage(uint32_t adc_reading, const esp_adc_cal_characteristics_t *chars)
+{
+    assert(chars != NULL);
+
+    //Scale adc_rading if not 12 bits wide
+    adc_reading = (adc_reading << (ADC_WIDTH_BIT_12 - chars->bit_width));
+    if (adc_reading > ADC_12_BIT_RES - 1) {
+        adc_reading = ADC_12_BIT_RES - 1;    //Set to 12bit res max
+    }
+
+    if (LUT_ENABLED && (chars->atten == ADC_ATTEN_DB_11) && (adc_reading >= LUT_LOW_THRESH)) {  //Check if in non-linear region
+        //Use lookup table to get voltage in non linear portion of ADC_ATTEN_DB_11
+        uint32_t lut_voltage = calculate_voltage_lut(adc_reading, chars->vref, chars->low_curve, chars->high_curve);
+        if (adc_reading <= LUT_HIGH_THRESH) {   //If ADC is transitioning from linear region to non-linear region
+            //Linearly interpolate between linear voltage and lut voltage
+            uint32_t linear_voltage = calculate_voltage_linear(adc_reading, chars->coeff_a, chars->coeff_b);
+            return interpolate_two_points(linear_voltage, lut_voltage, LUT_ADC_STEP_SIZE, (adc_reading - LUT_LOW_THRESH));
+        } else {
+            return lut_voltage;
+        }
+    } else {
+        return calculate_voltage_linear(adc_reading, chars->coeff_a, chars->coeff_b);
+    }
+}

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -11,6 +11,7 @@ if(CONFIG_SOC_ESP32C3)
     include/crypto
     ../esp_shared/include
     ../esp_shared/include/wifi
+    ../esp_shared/components/include
     ../../components/esp_common/include
     ../../components/esp_pm/include
     ../../components/esp_rom/include
@@ -142,7 +143,20 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/driver/esp32c3/rtc_tempsensor.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_ADC_ESP32
+    ../../components/hal/adc_hal.c
+    ../../components/hal/esp32c3/adc_hal.c
+    ../esp_shared/components/driver/adc.c
+	../esp_shared/components/driver/adc_common.c
+    ../esp_shared/components/driver/rtc_io_hal.c
+    ../esp_shared/components/driver/rtc_io.c
+    ../esp_shared/components/esp_adc_cal/esp_adc_cal_common.c
+    src/esp_adc_cal/esp_adc_cal.c
+    )
+
   zephyr_sources(
+    ../../components/soc/esp32c3/adc_periph.c
     ../../components/soc/esp32c3/gpio_periph.c
     ../../components/esp_timer/src/esp_timer_impl_systimer.c
     ../../components/esp_timer/src/ets_timer_legacy.c
@@ -163,6 +177,7 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/log/log.c
     ../../components/efuse/esp32c3/esp_efuse_fields.c
     ../../components/efuse/esp32c3/esp_efuse_table.c
+    ../../components/efuse/esp32c3/esp_efuse_rtc_calib.c
     ../../components/efuse/esp32c3/esp_efuse_utility.c
     ../../components/efuse/esp32c3/esp_efuse_rtc_calib.c
     ../../components/efuse/src/esp_efuse_api.c

--- a/zephyr/esp32c3/src/esp_adc_cal/esp_adc_cal.c
+++ b/zephyr/esp32c3/src/esp_adc_cal/esp_adc_cal.c
@@ -1,0 +1,185 @@
+/*
+ * SPDX-FileCopyrightText: 2019-2021 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include "esp_types.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "driver/adc.h"
+#include "hal/adc_ll.h"
+#include "esp_efuse_rtc_calib.h"
+#include "esp_adc_cal.h"
+#include "esp_adc_cal_internal.h"
+
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(adc_cal, CONFIG_ADC_LOG_LEVEL);
+
+//const static char LOG_TAG[] = "ADC_CALI";
+
+
+/* ------------------------ Characterization Constants ---------------------- */
+
+// coeff_a is actually a float number
+// it is scaled to put them into uint32_t so that the headers do not have to be changed
+static const int coeff_a_scaling = 65536;
+
+/**
+ * @note Error Calculation
+ * Coefficients for calculating the reading voltage error.
+ * Four sets of coefficients for atten0 ~ atten3 respectively.
+ *
+ * For each item, first element is the Coefficient, second element is the Multiple. (Coefficient / Multiple) is the real coefficient.
+ *
+ * @note {0,0} stands for unused item
+ * @note In case of the overflow, these coeffcients are recorded as Absolute Value
+ * @note For atten0 ~ 2, error = (K0 * X^0) + (K1 * X^1) + (K2 * X^2); For atten3, error = (K0 * X^0) + (K1 * X^1)  + (K2 * X^2) + (K3 * X^3) + (K4 * X^4);
+ * @note Above formula is rewritten from the original documentation, please note that the coefficients are re-ordered.
+ * @note ADC1 and ADC2 use same coeffients
+ */
+const static uint64_t adc_error_coef_atten[4][5][2] = {
+     {{225966470500043, 1e15}, {7265418501948, 1e16}, {109410402681, 1e16}, {0, 0}, {0, 0}},                         //atten0
+     {{4229623392600516, 1e16}, {731527490903, 1e16}, {88166562521, 1e16}, {0, 0}, {0, 0}},                          //atten1
+     {{1017859239236435, 1e15}, {97159265299153, 1e16}, {149794028038, 1e16}, {0, 0}, {0, 0}},                       //atten2
+     {{14912262772850453, 1e16}, {228549975564099, 1e16}, {356391935717, 1e16}, {179964582, 1e16}, {42046, 1e16}}    //atten3
+    };
+/**
+ * Term sign
+ * @note ADC1 and ADC2 use same coeffients
+ */
+const static int32_t adc_error_sign[4][5] = {
+       {-1, -1, 1,  0,  0}, //atten0
+       { 1, -1, 1,  0,  0}, //atten1
+       {-1, -1, 1,  0,  0}, //atten2
+       {-1, -1, 1, -1,  1}  //atten3
+    };
+
+/* -------------------- Characterization Helper Data Types ------------------ */
+typedef struct {
+    uint32_t voltage;
+    uint32_t digi;
+} adc_calib_data_ver1;
+
+typedef struct {
+    char version_num;
+    adc_unit_t adc_num;
+    adc_atten_t atten_level;
+    union {
+        adc_calib_data_ver1 ver1;
+    } efuse_data;
+} adc_calib_parsed_info_t;
+
+static esp_err_t prepare_calib_data_for(int version_num, adc_unit_t adc_num, adc_atten_t atten, adc_calib_parsed_info_t *parsed_data_storage)
+{
+    assert(version_num == 1);
+    esp_err_t ret;
+
+    parsed_data_storage->version_num = version_num;
+    parsed_data_storage->adc_num = adc_num;
+    parsed_data_storage->atten_level = atten;
+    // V1 we don't have calibration data for ADC2, using the efuse data of ADC1
+    uint32_t voltage, digi;
+    ret = esp_efuse_rtc_calib_get_cal_voltage(version_num, atten, &digi, &voltage);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    parsed_data_storage->efuse_data.ver1.voltage = voltage;
+    parsed_data_storage->efuse_data.ver1.digi = digi;
+    return ret;
+}
+
+/* ----------------------- Characterization Functions ----------------------- */
+/*
+ * Estimate the (assumed) linear relationship btwn the measured raw value and the voltage
+ * with the previously done measurement when the chip was manufactured.
+ */
+static void calculate_characterization_coefficients(const adc_calib_parsed_info_t *parsed_data, esp_adc_cal_characteristics_t *chars)
+{
+    LOG_DBG("Calib V1, Cal Voltage = %d, Digi out = %d\n", parsed_data->efuse_data.ver1.voltage, parsed_data->efuse_data.ver1.digi);
+
+    chars->coeff_a = coeff_a_scaling * parsed_data->efuse_data.ver1.voltage / parsed_data->efuse_data.ver1.digi;
+    chars->coeff_b = 0;
+}
+
+/* ------------------------- Public API ------------------------------------- */
+esp_err_t esp_adc_cal_check_efuse(esp_adc_cal_value_t source)
+{
+    if (source != ESP_ADC_CAL_VAL_EFUSE_TP) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+    uint8_t adc_encoding_version = esp_efuse_rtc_calib_get_ver();
+    if (adc_encoding_version != 1) {
+        // current version only accepts encoding ver 1.
+        return ESP_ERR_INVALID_VERSION;
+    }
+
+    return ESP_OK;
+}
+
+esp_adc_cal_value_t esp_adc_cal_characterize(adc_unit_t adc_num,
+        adc_atten_t atten,
+        adc_bits_width_t bit_width,
+        uint32_t default_vref,
+        esp_adc_cal_characteristics_t *chars)
+{
+    esp_err_t ret;
+    adc_calib_parsed_info_t efuse_parsed_data = {0};
+    // Check parameters
+    if (adc_num != ADC_UNIT_1 && adc_num != ADC_UNIT_2) {
+        return ESP_ADC_CAL_VAL_NOT_SUPPORTED;
+	}
+    if (!chars) {
+        return ESP_ADC_CAL_VAL_NOT_SUPPORTED;
+	}
+    if (bit_width != ADC_WIDTH_BIT_12) {
+        return ESP_ADC_CAL_VAL_NOT_SUPPORTED;
+	}
+    if (atten >= ADC_ATTEN_MAX) {
+        return ESP_ADC_CAL_VAL_NOT_SUPPORTED;
+	}
+
+    int version_num = esp_efuse_rtc_calib_get_ver();
+    if (version_num != 1) {
+        return ESP_ADC_CAL_VAL_NOT_SUPPORTED;
+	}
+
+    memset(chars, 0, sizeof(esp_adc_cal_characteristics_t));
+
+    // make sure adc is calibrated.
+    ret = prepare_calib_data_for(version_num, adc_num, atten, &efuse_parsed_data);
+    if (ret != ESP_OK) {
+        abort();
+    }
+
+    calculate_characterization_coefficients(&efuse_parsed_data, chars);
+
+    // Initialize remaining fields
+    chars->adc_num = adc_num;
+    chars->atten = atten;
+    chars->bit_width = bit_width;
+
+    // in esp32c3 we only use the two point method to calibrate the adc.
+    return ESP_ADC_CAL_VAL_EFUSE_TP;
+}
+
+uint32_t esp_adc_cal_raw_to_voltage(uint32_t adc_reading, const esp_adc_cal_characteristics_t *chars)
+{
+    assert(chars != NULL);
+
+    int32_t error = 0;
+    uint64_t v_cali_1 = adc_reading * chars->coeff_a / coeff_a_scaling;
+    esp_adc_error_calc_param_t param = {
+        .v_cali_input = v_cali_1,
+        .term_num = (chars->atten == 3) ? 5 : 3,
+        .coeff = &adc_error_coef_atten,
+        .sign = &adc_error_sign,
+    };
+    error = esp_adc_cal_get_reading_error(&param, chars->atten);
+
+    return (int32_t)v_cali_1 - error;
+}

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CONFIG_SOC_ESP32S2)
     include/wifi
     ../esp_shared/include
     ../esp_shared/include/wifi
+    ../esp_shared/components/include
     ../../components/hal/include
     ../../components/hal/esp32s2/include
     ../../components/hal/platform_port/include
@@ -157,6 +158,15 @@ if(CONFIG_SOC_ESP32S2)
     )
 
   zephyr_sources_ifdef(
+    CONFIG_ADC_ESP32
+    ../../components/hal/adc_hal.c
+    ../esp_shared/components/driver/adc_common.c
+    ../esp_shared/components/driver/rtc_io_hal.c
+    ../esp_shared/components/driver/rtc_io.c
+    src/esp_adc_cal/esp_adc_cal.c
+    )
+
+  zephyr_sources_ifdef(
     CONFIG_PM
     ../esp_shared/components/driver/gpio.c
     ../esp_shared/components/driver/rtc_io.c
@@ -174,6 +184,7 @@ if(CONFIG_SOC_ESP32S2)
     )
 
   zephyr_sources(
+    ../../components/soc/esp32s2/adc_periph.c
     ../../components/soc/esp32s2/gpio_periph.c
     ../../components/soc/esp32s2/rtc_io_periph.c
     ../../components/esp_hw_support/regi2c_ctrl.c
@@ -197,6 +208,7 @@ if(CONFIG_SOC_ESP32S2)
     ../../components/log/log.c
     ../../components/efuse/esp32s2/esp_efuse_fields.c
     ../../components/efuse/esp32s2/esp_efuse_table.c
+    ../../components/efuse/esp32s2/esp_efuse_rtc_table.c
     ../../components/efuse/esp32s2/esp_efuse_utility.c
     ../../components/efuse/esp32s2/esp_efuse_rtc_table.c
     ../../components/efuse/src/esp_efuse_api.c

--- a/zephyr/esp32s2/src/esp_adc_cal/esp_adc_cal.c
+++ b/zephyr/esp32s2/src/esp_adc_cal/esp_adc_cal.c
@@ -1,0 +1,199 @@
+/*
+ * SPDX-FileCopyrightText: 2019-2021 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include "esp_types.h"
+#include "driver/adc.h"
+#include "soc/efuse_periph.h"
+#include "esp_err.h"
+#include "assert.h"
+#include "esp_adc_cal.h"
+#include "esp_efuse.h"
+#include "esp_efuse_table.h"
+#include "esp_efuse_rtc_table.h"
+#include "hal/adc_hal.h"
+
+const static char LOG_TAG[] = "adc_calib";
+
+/* ------------------------ Characterization Constants ---------------------- */
+
+// coeff_a and coeff_b are actually floats
+// they are scaled to put them into uint32_t so that the headers do not have to be changed
+static const int coeff_a_scaling = 65536;
+static const int coeff_b_scaling = 1024;
+/* -------------------- Characterization Helper Data Types ------------------ */
+typedef struct {
+    int adc_calib_high;
+    int adc_calib_low;
+} adc_calib_data_ver1;
+
+typedef struct {
+    int adc_calib_high;         // the reading of adc ...
+    int adc_calib_high_voltage; // ... at this voltage (mV)
+} adc_calib_data_ver2;
+
+typedef struct {
+    char version_num;
+    adc_unit_t adc_num;
+    adc_atten_t atten_level;
+    union {
+        adc_calib_data_ver1 ver1;
+        adc_calib_data_ver2 ver2;
+    } efuse_data;
+} adc_calib_parsed_info;
+
+static bool prepare_calib_data_for(adc_unit_t adc_num, adc_atten_t atten, adc_calib_parsed_info *parsed_data_storage)
+{
+    int version_num = esp_efuse_rtc_table_read_calib_version();
+    int tag;
+    parsed_data_storage->version_num = version_num;
+    parsed_data_storage->adc_num = adc_num;
+    parsed_data_storage->atten_level = atten;
+    switch (version_num) {
+    case 1:
+        // note: use the adc_num as in hal, which start from 0.
+        tag = esp_efuse_rtc_table_get_tag(version_num, adc_num, atten, RTCCALIB_V1_PARAM_VLOW);
+        parsed_data_storage->efuse_data.ver1.adc_calib_low = esp_efuse_rtc_table_get_parsed_efuse_value(tag, false);
+        tag = esp_efuse_rtc_table_get_tag(version_num, adc_num, atten, RTCCALIB_V1_PARAM_VHIGH);
+        parsed_data_storage->efuse_data.ver1.adc_calib_high = esp_efuse_rtc_table_get_parsed_efuse_value(tag, false);
+        break;
+    case 2:
+        tag = esp_efuse_rtc_table_get_tag(version_num, adc_num, atten, RTCCALIB_V2_PARAM_VHIGH);
+        parsed_data_storage->efuse_data.ver2.adc_calib_high = esp_efuse_rtc_table_get_parsed_efuse_value(tag, false);
+        switch (parsed_data_storage->atten_level) {
+        case ADC_ATTEN_DB_0:
+            parsed_data_storage->efuse_data.ver2.adc_calib_high_voltage = 600;
+            break;
+        case ADC_ATTEN_DB_2_5:
+            parsed_data_storage->efuse_data.ver2.adc_calib_high_voltage = 800;
+            break;
+        case ADC_ATTEN_DB_6:
+            parsed_data_storage->efuse_data.ver2.adc_calib_high_voltage = 1000;
+            break;
+        case ADC_ATTEN_DB_11:
+            parsed_data_storage->efuse_data.ver2.adc_calib_high_voltage = 2000;
+            break;
+        default:
+            break;
+        }
+        break;
+    default:
+        // fall back to case 1 with zeros as params.
+        parsed_data_storage->version_num = 1;
+        tag = esp_efuse_rtc_table_get_tag(version_num, adc_num, atten, RTCCALIB_V1_PARAM_VLOW);
+        parsed_data_storage->efuse_data.ver1.adc_calib_high = esp_efuse_rtc_table_get_parsed_efuse_value(tag, true);
+        tag = esp_efuse_rtc_table_get_tag(version_num, adc_num, atten, RTCCALIB_V1_PARAM_VHIGH);
+        parsed_data_storage->efuse_data.ver1.adc_calib_low = esp_efuse_rtc_table_get_parsed_efuse_value(tag, true);
+        break;
+    }
+    return true;
+}
+
+/* ----------------------- Characterization Functions ----------------------- */
+/**
+ *  (Used in V1 of calibration scheme)
+ *  The Two Point calibration measures the reading at two specific input voltages, and calculates the (assumed linear) relation
+ *  between input voltage and ADC response. (Response = A * Vinput + B)
+ *  A and B are scaled ints.
+ *  @param high The ADC response at the higher voltage of the corresponding attenuation (600mV, 800mV, 1000mV, 2000mV).
+ *  @param low The ADC response at the lower voltage of the corresponding attenuation (all 250mV).
+ *
+ */
+static void characterize_using_two_point(adc_unit_t adc_num,
+        adc_atten_t atten,
+        uint32_t high,
+        uint32_t low,
+        uint32_t *coeff_a,
+        uint32_t *coeff_b)
+{
+    // once we have recovered the reference high(Dhigh) and low(Dlow) readings, we can calculate a and b from
+    // the measured high and low readings
+    static const uint32_t v_high[] = {600, 800, 1000, 2000};
+    static const uint32_t v_low = 250;
+    *coeff_a = coeff_a_scaling * (v_high[atten] - v_low) / (high - low);
+    *coeff_b = coeff_b_scaling * (v_low * high - v_high[atten] * low) / (high - low);
+}
+
+/*
+ * Estimate the (assumed) linear relationship btwn the measured raw value and the voltage
+ * with the previously done measurement when the chip was manufactured.
+ * */
+static bool calculate_characterization_coefficients(const adc_calib_parsed_info *parsed_data, esp_adc_cal_characteristics_t *chars)
+{
+    switch (parsed_data->version_num) {
+    case 1:
+        ESP_LOGD(LOG_TAG, "Calib V1, low%dmV, high%dmV\n", parsed_data->efuse_data.ver1.adc_calib_low, parsed_data->efuse_data.ver1.adc_calib_high);
+
+        characterize_using_two_point(parsed_data->adc_num, parsed_data->atten_level,
+                                     parsed_data->efuse_data.ver1.adc_calib_high, parsed_data->efuse_data.ver1.adc_calib_low,
+                                     &(chars->coeff_a), &(chars->coeff_b));
+        break;
+    case 2:
+        ESP_LOGD(LOG_TAG, "Calib V2, volt%dmV\n", parsed_data->efuse_data.ver2.adc_calib_high);
+        chars->coeff_a = coeff_a_scaling * parsed_data->efuse_data.ver2.adc_calib_high_voltage /
+                         parsed_data->efuse_data.ver2.adc_calib_high;
+        chars->coeff_b = 0;
+        break;
+    default:
+        return false;
+        break;
+    }
+    return true;
+}
+
+/* ------------------------- Public API ------------------------------------- */
+esp_err_t esp_adc_cal_check_efuse(esp_adc_cal_value_t source)
+{
+    if (source != ESP_ADC_CAL_VAL_EFUSE_TP) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+    uint8_t adc_encoding_version = esp_efuse_rtc_table_read_calib_version();
+    if (adc_encoding_version != 1 && adc_encoding_version != 2) {
+        // current version only accepts encoding ver 1 and ver 2.
+        return ESP_ERR_INVALID_VERSION;
+    }
+    return ESP_OK;
+}
+
+esp_adc_cal_value_t esp_adc_cal_characterize(adc_unit_t adc_num,
+        adc_atten_t atten,
+        adc_bits_width_t bit_width,
+        uint32_t default_vref,
+        esp_adc_cal_characteristics_t *chars)
+{
+    bool res __attribute__((unused));
+    adc_calib_parsed_info efuse_parsed_data = {0};
+    // Check parameters
+    assert((adc_num == ADC_UNIT_1) || (adc_num == ADC_UNIT_2));
+    assert(chars != NULL);
+    assert(bit_width == ADC_WIDTH_BIT_13);
+
+    // make sure adc is calibrated.
+    res = prepare_calib_data_for(adc_num, atten, &efuse_parsed_data);
+    assert(res);
+    res = calculate_characterization_coefficients(&efuse_parsed_data, chars);
+    assert(res);
+    ESP_LOGD(LOG_TAG, "adc%d (atten leven %d) calibration done: A:%d B:%d\n", adc_num, atten, chars->coeff_a, chars->coeff_b);
+
+    // Initialize remaining fields
+    chars->adc_num = adc_num;
+    chars->atten = atten;
+    chars->bit_width = bit_width;
+
+    // these values are not used as the corresponding calibration themes are deprecated.
+    chars->vref = 0;
+    chars->low_curve = NULL;
+    chars->high_curve = NULL;
+
+    // in esp32s2 we only use the two point method to calibrate the adc.
+    return ESP_ADC_CAL_VAL_EFUSE_TP;
+}
+
+uint32_t esp_adc_cal_raw_to_voltage(uint32_t adc_reading, const esp_adc_cal_characteristics_t *chars)
+{
+    assert(chars != NULL);
+    return adc_reading * chars->coeff_a / coeff_a_scaling + chars->coeff_b / coeff_b_scaling;
+}

--- a/zephyr/esp_shared/components/driver/adc.c
+++ b/zephyr/esp_shared/components/driver/adc.c
@@ -1,0 +1,317 @@
+/*
+ * SPDX-FileCopyrightText: 2016-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <esp_types.h>
+#include "esp_err.h"
+#include <hal/adc_hal.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/ring_buffer.h>
+
+/* FIXME: */
+typedef uint32_t TickType_t;
+
+#include "driver/periph_ctrl.h"
+#include "esp_heap_caps.h"
+#include "hal/gpio_hal.h"
+#include "driver/adc.h"
+#include "hal/adc_hal.h"
+#include "hal/adc_hal_digi.h"
+
+//For calibration
+#if CONFIG_IDF_TARGET_ESP32S2
+#include "esp_efuse_rtc_table.h"
+#elif SOC_ADC_CALIBRATION_V1_SUPPORTED
+#include "esp_efuse_rtc_calib.h"
+#endif
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(adc_hal, CONFIG_ADC_LOG_LEVEL);
+
+struct adc_context {
+    unsigned int spinlock;
+};
+
+#define ADC_GET_IO_NUM(periph, channel) (adc_channel_io_map[periph][channel])
+
+#define ADC_ENTER_CRITICAL() do { adc_context.spinlock = irq_lock(); } while(0)
+#define ADC_EXIT_CRITICAL() do { irq_unlock(adc_context.spinlock); } while(0)
+
+extern struct adc_context adc_context;
+/* this mutex lock is to protect the SARADC1 module. */
+K_MUTEX_DEFINE(adc1_lock);
+/* this mutex lock is to protect the SARADC2 module. */
+K_MUTEX_DEFINE(adc2_lock);
+/* this spin lock is to protect the shared registers used by ADC1 / ADC2 single read mode. */
+K_MUTEX_DEFINE(reg_lock);
+
+#define SAR_ADC1_LOCK_ACQUIRE() do { k_mutex_lock(&adc1_lock, K_FOREVER); } while(0)
+#define SAR_ADC1_LOCK_RELEASE() do { k_mutex_unlock(&adc1_lock); } while(0)
+#define SAR_ADC2_LOCK_ACQUIRE() do { k_mutex_lock(&adc2_lock, K_FOREVER); } while(0)
+#define SAR_ADC2_LOCK_RELEASE() do { k_mutex_unlock(&adc2_lock); } while (0)
+#define ADC_REG_LOCK_ENTER() do { k_mutex_lock(&reg_lock, K_FOREVER); } while(0)
+#define ADC_REG_LOCK_EXIT() do { k_mutex_unlock(&reg_lock); } while(0)
+
+#if SOC_ADC_CALIBRATION_V1_SUPPORTED
+static uint32_t adc_get_calibration_offset(adc_ll_num_t adc_n, adc_channel_t chan, adc_atten_t atten);
+#endif
+
+static int8_t adc_digi_get_io_num(uint8_t adc_unit, uint8_t adc_channel)
+{
+    return adc_channel_io_map[adc_unit][adc_channel];
+}
+
+static esp_err_t adc_digi_gpio_init(adc_unit_t adc_unit, uint16_t channel_mask)
+{
+    esp_err_t ret = ESP_OK;
+    uint64_t gpio_mask = 0;
+    uint32_t n = 0;
+    int8_t io = 0;
+    struct gpio_dt_spec gpio;
+
+    gpio.port = DEVICE_DT_GET(DT_NODELABEL(gpio0));
+    gpio.dt_flags = 0;
+    if (!device_is_ready(gpio.port)) {
+        LOG_ERR("gpio0 port not ready");
+        return ESP_FAIL;
+    }
+
+    while (channel_mask) {
+        if (channel_mask & 0x1) {
+            io = adc_digi_get_io_num(adc_unit, n);
+            if (io < 0) {
+                return ESP_ERR_INVALID_ARG;
+            }
+            gpio_mask |= BIT64(io);
+            gpio.pin = io;
+            gpio_pin_configure_dt(&gpio, GPIO_DISCONNECTED);
+        }
+        channel_mask = channel_mask >> 1;
+        n++;
+    }
+
+    return ret;
+}
+
+esp_err_t adc_digi_initialize(const adc_digi_init_config_t *init_config)
+{
+    esp_err_t ret = ESP_OK;
+
+	/* TODO: ready for continuous mode operation */
+    return ret;
+}
+
+#if CONFIG_IDF_TARGET_ESP32C3
+/*---------------------------------------------------------------
+                    ADC Single Read Mode
+---------------------------------------------------------------*/
+static adc_atten_t s_atten1_single[ADC1_CHANNEL_MAX];
+static adc_atten_t s_atten2_single[ADC2_CHANNEL_MAX];
+
+esp_err_t adc_vref_to_gpio(adc_unit_t adc_unit, gpio_num_t gpio)
+{
+    esp_err_t ret;
+    uint32_t channel = ADC2_CHANNEL_MAX;
+    if (adc_unit == ADC_UNIT_2) {
+        for (int i = 0; i < ADC2_CHANNEL_MAX; i++) {
+            if (gpio == ADC_GET_IO_NUM(ADC_NUM_2, i)) {
+                channel = i;
+                break;
+            }
+        }
+        if (channel == ADC2_CHANNEL_MAX) {
+            return ESP_ERR_INVALID_ARG;
+        }
+    }
+
+    adc_power_acquire();
+    if (adc_unit & ADC_UNIT_1) {
+        ADC_ENTER_CRITICAL();
+        adc_hal_vref_output(ADC_NUM_1, channel, true);
+        ADC_EXIT_CRITICAL();
+    } else if (adc_unit & ADC_UNIT_2) {
+        ADC_ENTER_CRITICAL();
+        adc_hal_vref_output(ADC_NUM_2, channel, true);
+        ADC_EXIT_CRITICAL();
+    }
+
+    ret = adc_digi_gpio_init(ADC_NUM_2, BIT(channel));
+
+    return ret;
+}
+
+esp_err_t adc1_config_width(adc_bits_width_t width_bit)
+{
+    //On ESP32C3, the data width is always 12-bits.
+    if (width_bit != ADC_WIDTH_BIT_12) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t adc1_config_channel_atten(adc1_channel_t channel, adc_atten_t atten)
+{
+    if (channel >= SOC_ADC_CHANNEL_NUM(ADC_NUM_1)) {
+        return ESP_ERR_INVALID_ARG;
+	}
+    if (atten >= ADC_ATTEN_MAX) {
+        return ESP_ERR_INVALID_ARG;
+	}
+
+    esp_err_t ret = ESP_OK;
+    s_atten1_single[channel] = atten;
+    ret = adc_digi_gpio_init(ADC_NUM_1, BIT(channel));
+
+    adc_hal_calibration_init(ADC_NUM_1);
+
+    return ret;
+}
+
+int adc1_get_raw(adc1_channel_t channel)
+{
+    int raw_out = 0;
+
+    periph_module_enable(PERIPH_SARADC_MODULE);
+    adc_power_acquire();
+
+    SAR_ADC1_LOCK_ACQUIRE();
+
+    adc_atten_t atten = s_atten1_single[channel];
+    uint32_t cal_val = adc_get_calibration_offset(ADC_NUM_1, channel, atten);
+    adc_hal_set_calibration_param(ADC_NUM_1, cal_val);
+
+    ADC_REG_LOCK_ENTER();
+    adc_hal_set_atten(ADC_NUM_1, channel, atten);
+    adc_hal_convert(ADC_NUM_1, channel, &raw_out);
+    ADC_REG_LOCK_EXIT();
+
+    SAR_ADC1_LOCK_RELEASE();
+
+    adc_power_release();
+    periph_module_disable(PERIPH_SARADC_MODULE);
+
+    return raw_out;
+}
+
+esp_err_t adc2_config_channel_atten(adc2_channel_t channel, adc_atten_t atten)
+{
+    if (channel >= SOC_ADC_CHANNEL_NUM(ADC_NUM_2)) {
+        return ESP_ERR_INVALID_ARG;
+	}
+    if (atten >= ADC_ATTEN_MAX) {
+        return ESP_ERR_INVALID_ARG;
+	}
+
+    esp_err_t ret = ESP_OK;
+    s_atten2_single[channel] = atten;
+    ret = adc_digi_gpio_init(ADC_NUM_2, BIT(channel));
+
+    adc_hal_calibration_init(ADC_NUM_2);
+
+    return ret;
+}
+
+esp_err_t adc2_get_raw(adc2_channel_t channel, adc_bits_width_t width_bit, int *raw_out)
+{
+    //On ESP32C3, the data width is always 12-bits.
+    if (width_bit != ADC_WIDTH_BIT_12) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    esp_err_t ret = ESP_OK;
+
+    periph_module_enable(PERIPH_SARADC_MODULE);
+    adc_power_acquire();
+
+    SAR_ADC2_LOCK_ACQUIRE();
+
+    adc_arbiter_t config = ADC_ARBITER_CONFIG_DEFAULT();
+    adc_hal_arbiter_config(&config);
+
+    adc_atten_t atten = s_atten2_single[channel];
+    uint32_t cal_val = adc_get_calibration_offset(ADC_NUM_2, channel, atten);
+    adc_hal_set_calibration_param(ADC_NUM_2, cal_val);
+
+    ADC_REG_LOCK_ENTER();
+    adc_hal_set_atten(ADC_NUM_2, channel, atten);
+    ret = adc_hal_convert(ADC_NUM_2, channel, raw_out);
+    ADC_REG_LOCK_EXIT();
+
+    SAR_ADC2_LOCK_RELEASE();
+
+    adc_power_release();
+    periph_module_disable(PERIPH_SARADC_MODULE);
+
+    return ret;
+}
+
+#endif  //#if CONFIG_IDF_TARGET_ESP32C3
+
+
+#if SOC_ADC_CALIBRATION_V1_SUPPORTED
+/*---------------------------------------------------------------
+                    Hardware Calibration Setting
+---------------------------------------------------------------*/
+#if CONFIG_IDF_TARGET_ESP32S2
+#define esp_efuse_rtc_calib_get_ver()                               esp_efuse_rtc_table_read_calib_version()
+
+static inline uint32_t esp_efuse_rtc_calib_get_init_code(int version, uint32_t adc_unit, int atten)
+{
+    int tag = esp_efuse_rtc_table_get_tag(version, adc_unit + 1, atten, RTCCALIB_V2_PARAM_VINIT);
+    return esp_efuse_rtc_table_get_parsed_efuse_value(tag, false);
+}
+#endif	/* CONFIG_IDF_TARGET_ESP32S2 */
+
+static uint16_t s_adc_cali_param[SOC_ADC_PERIPH_NUM][ADC_ATTEN_MAX] = {};
+
+//NOTE: according to calibration version, different types of lock may be taken during the process:
+//  1. Semaphore when reading efuse
+//  2. Lock (Spinlock, or Mutex) if we actually do ADC calibration in the future
+//This function shoudn't be called inside critical section or ISR
+static uint32_t adc_get_calibration_offset(adc_ll_num_t adc_n, adc_channel_t channel, adc_atten_t atten)
+{
+    if (s_adc_cali_param[adc_n][atten]) {
+        //LOG_DBG("Use calibrated val ADC%d atten=%d: %04X", adc_n, atten, s_adc_cali_param[adc_n][atten]);
+        return (uint32_t)s_adc_cali_param[adc_n][atten];
+    }
+
+    // check if we can fetch the values from eFuse.
+    int version = esp_efuse_rtc_calib_get_ver();
+
+    uint32_t init_code = 0;
+
+    if (version == ESP_EFUSE_ADC_CALIB_VER) {
+        init_code = esp_efuse_rtc_calib_get_init_code(version, adc_n, atten);
+
+    } else {
+        //LOG_DBG("Calibration eFuse is not configured, use self-calibration for ICode");
+        adc_power_acquire();
+        ADC_ENTER_CRITICAL();
+        const bool internal_gnd = true;
+        init_code = adc_hal_self_calibration(adc_n, channel, atten, internal_gnd);
+        ADC_EXIT_CRITICAL();
+        adc_power_release();
+    }
+
+
+    s_adc_cali_param[adc_n][atten] = init_code;
+    //LOG_DBG("Calib(V%d) ADC%d atten=%d: %04X", version, adc_n, atten, init_code);
+
+    return init_code;
+}
+
+// Internal function to calibrate PWDET for WiFi
+esp_err_t adc_cal_offset(adc_ll_num_t adc_n, adc_channel_t channel, adc_atten_t atten)
+{
+    adc_hal_calibration_init(adc_n);
+    uint32_t cal_val = adc_get_calibration_offset(adc_n, channel, atten);
+    ADC_ENTER_CRITICAL();
+    adc_hal_set_calibration_param(adc_n, cal_val);
+    ADC_EXIT_CRITICAL();
+    return ESP_OK;
+}
+#endif //#if SOC_ADC_CALIBRATION_V1_SUPPORTED

--- a/zephyr/esp_shared/components/driver/adc_common.c
+++ b/zephyr/esp_shared/components/driver/adc_common.c
@@ -1,0 +1,757 @@
+/*
+ * SPDX-FileCopyrightText: 2019-2021 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <esp_types.h>
+#include <stdlib.h>
+#include "esp_err.h"
+#include "driver/rtc_io.h"
+#include "driver/adc.h"
+#include "hal/adc_types.h"
+#include "hal/adc_hal.h"
+#include "hal/adc_hal_conf.h"
+#include <zephyr/kernel.h>
+#include "esp_log.h"
+#include "soc/periph_defs.h"
+
+#if SOC_DAC_SUPPORTED
+#include "driver/dac.h"
+#include "hal/dac_hal.h"
+#endif
+
+#if CONFIG_IDF_TARGET_ESP32S3
+#include "esp_efuse_rtc_calib.h"
+#endif
+
+#if CONFIG_IDF_TARGET_ESP32C3
+#include "esp_efuse_rtc_calib.h"
+#endif
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(adc_common, CONFIG_ADC_LOG_LEVEL);
+
+#define ADC_CHECK_RET(fun_ret) ({                           \
+    if (fun_ret != ESP_OK) {                                \
+        LOG_ERR("%s:%d\n",__FUNCTION__,__LINE__);  \
+        return ESP_FAIL;                                    \
+    }                                                       \
+})
+
+static const char *ADC_TAG = "ADC";
+
+#define ADC_CHECK(a, str, ret_val) ({                                               \
+    if (!(a)) {                                                                     \
+        LOG_ERR("%s(%d): %s", __FUNCTION__, __LINE__, str);                \
+        return (ret_val);                                                           \
+    }                                                                               \
+})
+
+#define ADC_GET_IO_NUM(periph, channel) (adc_channel_io_map[periph][channel])
+
+#define ADC_CHANNEL_CHECK(periph, channel) ADC_CHECK(channel < SOC_ADC_CHANNEL_NUM(periph),	\
+		"ADC"#periph" channel error", ESP_ERR_INVALID_ARG)
+
+//////////////////////// Locks ///////////////////////////////////////////
+struct adc_context {
+    unsigned int spinlock;
+};
+struct adc_context adc_context = {
+	.spinlock = 0,
+};
+
+#define RTC_ENTER_CRITICAL() do { adc_context.spinlock = irq_lock(); } while(0)
+#define RTC_EXIT_CRITICAL() do { irq_unlock(adc_context.spinlock); } while(0)
+#define DIGI_ENTER_CRITICAL()
+#define DIGI_EXIT_CRITICAL()
+
+#define ADC_ENTER_CRITICAL()	RTC_ENTER_CRITICAL()
+#define ADC_EXIT_CRITICAL()	RTC_EXIT_CRITICAL()
+
+#define ADC_POWER_ENTER()       RTC_ENTER_CRITICAL()
+#define ADC_POWER_EXIT()        RTC_EXIT_CRITICAL()
+
+#define DIGI_CONTROLLER_ENTER() DIGI_ENTER_CRITICAL()
+#define DIGI_CONTROLLER_EXIT()  DIGI_EXIT_CRITICAL()
+
+#define SARADC1_ENTER()         RTC_ENTER_CRITICAL()
+#define SARADC1_EXIT()          RTC_EXIT_CRITICAL()
+
+#define SARADC2_ENTER()         RTC_ENTER_CRITICAL()
+#define SARADC2_EXIT()          RTC_EXIT_CRITICAL()
+
+//n stands for ADC unit: 1 for ADC1 and 2 for ADC2. Currently both unit touches the same registers
+#define VREF_ENTER(n)           RTC_ENTER_CRITICAL()
+#define VREF_EXIT(n)            RTC_EXIT_CRITICAL()
+
+#define FSM_ENTER()             RTC_ENTER_CRITICAL()
+#define FSM_EXIT()              RTC_EXIT_CRITICAL()
+
+//TODO: IDF-3610
+//#if 1 //CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+//prevent ADC1 being used by I2S dma and other tasks at the same time.
+K_MUTEX_DEFINE(adc1_dma_lock);
+#define SARADC1_ACQUIRE() do { k_mutex_lock(&adc1_dma_lock, K_FOREVER); } while(0)
+#define SARADC1_RELEASE() do { k_mutex_unlock(&adc1_dma_lock); } while(0)
+//#endif
+
+
+/*
+In ADC2, there're two locks used for different cases:
+1. lock shared with app and Wi-Fi:
+   ESP32:
+        When Wi-Fi using the ADC2, we assume it will never stop, so app checks the lock and returns immediately if failed.
+   ESP32S2:
+        The controller's control over the ADC is determined by the arbiter. There is no need to control by lock.
+
+2. lock shared between tasks:
+   when several tasks sharing the ADC2, we want to guarantee
+   all the requests will be handled.
+   Since conversions are short (about 31us), app returns the lock very soon,
+   we use a spinlock to stand there waiting to do conversions one by one.
+
+adc2_spinlock should be acquired first, then adc2_wifi_lock or rtc_spinlock.
+*/
+
+#ifdef CONFIG_IDF_TARGET_ESP32
+/* prevent ADC2 being used by wifi and other tasks at the same time. */
+K_MUTEX_DEFINE(adc2_wifi_lock);
+/** For ESP32S2 the ADC2 The right to use ADC2 is controlled by the arbiter, and there is no need to set a lock. */
+#define SARADC2_ACQUIRE()  do { k_mutex_lock(&adc2_wifi_lock, K_FOREVER); } while(0)
+#define SARADC2_RELEASE()  do { k_mutex_unlock(&adc2_wifi_lock); } while(0)
+#define SARADC2_TRY_ACQUIRE() k_mutex_lock(&adc2_wifi_lock, K_NO_WAIT)
+#define SARADC2_LOCK_CHECK()    (adc2_wifi_lock.lock_count != 0)
+
+#elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+#define SARADC2_ACQUIRE()
+#define SARADC2_RELEASE()
+#define SARADC2_TRY_ACQUIRE()   (0)     //WIFI controller and rtc controller have independent parameter configuration.
+#define SARADC2_LOCK_CHECK()    (true)
+
+#endif // CONFIG_IDF_TARGET_*
+
+#if CONFIG_IDF_TARGET_ESP32S2
+#ifdef CONFIG_PM_ENABLE
+static esp_pm_lock_handle_t s_adc2_arbiter_lock;
+#endif  //CONFIG_PM_ENABLE
+#endif  // !CONFIG_IDF_TARGET_ESP32
+
+/*---------------------------------------------------------------
+                    ADC Common
+---------------------------------------------------------------*/
+// ADC Power
+
+// This gets incremented when adc_power_acquire() is called, and decremented when
+// adc_power_release() is called. ADC is powered down when the value reaches zero.
+// Should be modified within critical section (ADC_ENTER/EXIT_CRITICAL).
+static int s_adc_power_on_cnt;
+
+static void adc_power_on_internal(void)
+{
+    /* Set the power always on to increase precision. */
+    adc_hal_set_power_manage(ADC_POWER_SW_ON);
+}
+
+void adc_power_acquire(void)
+{
+    ADC_POWER_ENTER();
+    s_adc_power_on_cnt++;
+    if (s_adc_power_on_cnt == 1) {
+        adc_power_on_internal();
+    }
+    ADC_POWER_EXIT();
+}
+
+void adc_power_on(void)
+{
+    ADC_POWER_ENTER();
+    adc_power_on_internal();
+    ADC_POWER_EXIT();
+}
+
+static void adc_power_off_internal(void)
+{
+#if CONFIG_IDF_TARGET_ESP32
+    adc_hal_set_power_manage(ADC_POWER_SW_OFF);
+#else
+    adc_hal_set_power_manage(ADC_POWER_BY_FSM);
+#endif
+}
+
+void adc_power_release(void)
+{
+    ADC_POWER_ENTER();
+    s_adc_power_on_cnt--;
+    /* Sanity check */
+    if (s_adc_power_on_cnt < 0) {
+        ADC_POWER_EXIT();
+        ESP_LOGE(ADC_TAG, "%s called, but s_adc_power_on_cnt == 0", __func__);
+        abort();
+    } else if (s_adc_power_on_cnt == 0) {
+        adc_power_off_internal();
+    }
+    ADC_POWER_EXIT();
+}
+
+void adc_power_off(void)
+{
+    ADC_POWER_ENTER();
+    adc_power_off_internal();
+    ADC_POWER_EXIT();
+}
+
+esp_err_t adc1_pad_get_io_num(adc1_channel_t channel, gpio_num_t *gpio_num)
+{
+    ADC_CHANNEL_CHECK(ADC_NUM_1, channel);
+
+    int io = ADC_GET_IO_NUM(ADC_NUM_1, channel);
+    if (io < 0) {
+        return ESP_ERR_INVALID_ARG;
+    } else {
+        *gpio_num = (gpio_num_t)io;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t adc2_pad_get_io_num(adc2_channel_t channel, gpio_num_t *gpio_num)
+{
+    ADC_CHANNEL_CHECK(ADC_NUM_2, channel);
+
+    int io = ADC_GET_IO_NUM(ADC_NUM_2, channel);
+    if (io < 0) {
+        return ESP_ERR_INVALID_ARG;
+    } else {
+        *gpio_num = (gpio_num_t)io;
+    }
+
+    return ESP_OK;
+}
+
+//------------------------------------------------------------RTC Single Read----------------------------------------------//
+#if SOC_ADC_RTC_CTRL_SUPPORTED
+#if SOC_ADC_CALIBRATION_V1_SUPPORTED
+static uint32_t get_calibration_offset(adc_ll_num_t adc_n, adc_channel_t chan)
+{
+    adc_atten_t atten = adc_ll_get_atten(adc_n, chan);
+    extern uint32_t adc_get_calibration_offset(adc_ll_num_t adc_n, adc_channel_t channel, adc_atten_t atten);
+
+    return adc_get_calibration_offset(adc_n, chan, atten);
+}
+#endif  //SOC_ADC_CALIBRATION_V1_SUPPORTED
+
+esp_err_t adc_set_clk_div(uint8_t clk_div)
+{
+    DIGI_CONTROLLER_ENTER();
+    adc_ll_digi_set_clk_div(clk_div);
+    DIGI_CONTROLLER_EXIT();
+    return ESP_OK;
+}
+
+static void adc_rtc_chan_init(adc_unit_t adc_unit)
+{
+    if (adc_unit & ADC_UNIT_1) {
+        /* Workaround: Disable the synchronization operation function of ADC1 and DAC.
+           If enabled(default), ADC RTC controller sampling will cause the DAC channel output voltage. */
+#if SOC_DAC_SUPPORTED
+        dac_hal_rtc_sync_by_adc(false);
+#endif
+        adc_hal_rtc_output_invert(ADC_NUM_1, SOC_ADC1_DATA_INVERT_DEFAULT);
+        adc_ll_set_sar_clk_div(ADC_NUM_1, SOC_ADC_SAR_CLK_DIV_DEFAULT(ADC_NUM_1));
+#ifdef CONFIG_IDF_TARGET_ESP32
+        adc_ll_hall_disable(); //Disable other peripherals.
+        adc_ll_amp_disable();  //Currently the LNA is not open, close it by default.
+#endif
+    }
+    if (adc_unit & ADC_UNIT_2) {
+        adc_hal_pwdet_set_cct(SOC_ADC_PWDET_CCT_DEFAULT);
+        adc_hal_rtc_output_invert(ADC_NUM_2, SOC_ADC2_DATA_INVERT_DEFAULT);
+        adc_ll_set_sar_clk_div(ADC_NUM_2, SOC_ADC_SAR_CLK_DIV_DEFAULT(ADC_NUM_2));
+    }
+}
+
+/**
+ * This function is NOT an API.
+ * Now some to-be-deprecated APIs are using this function, so don't make it static for now.
+ * Will make this static on v5.0
+ */
+esp_err_t adc_common_gpio_init(adc_unit_t adc_unit, adc_channel_t channel)
+{
+    gpio_num_t gpio_num = 0;
+    //If called with `ADC_UNIT_BOTH (ADC_UNIT_1 | ADC_UNIT_2)`, both if blocks will be run
+    if (adc_unit & ADC_UNIT_1) {
+        ADC_CHANNEL_CHECK(ADC_NUM_1, channel);
+        gpio_num = ADC_GET_IO_NUM(ADC_NUM_1, channel);
+        ADC_CHECK_RET(rtc_gpio_init(gpio_num));
+        ADC_CHECK_RET(rtc_gpio_set_direction(gpio_num, RTC_GPIO_MODE_DISABLED));
+        ADC_CHECK_RET(rtc_gpio_pulldown_dis(gpio_num));
+        ADC_CHECK_RET(rtc_gpio_pullup_dis(gpio_num));
+    }
+    if (adc_unit & ADC_UNIT_2) {
+        ADC_CHANNEL_CHECK(ADC_NUM_2, channel);
+        gpio_num = ADC_GET_IO_NUM(ADC_NUM_2, channel);
+        ADC_CHECK_RET(rtc_gpio_init(gpio_num));
+        ADC_CHECK_RET(rtc_gpio_set_direction(gpio_num, RTC_GPIO_MODE_DISABLED));
+        ADC_CHECK_RET(rtc_gpio_pulldown_dis(gpio_num));
+        ADC_CHECK_RET(rtc_gpio_pullup_dis(gpio_num));
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t adc_set_data_inv(adc_unit_t adc_unit, bool inv_en)
+{
+    if (adc_unit & ADC_UNIT_1) {
+        SARADC1_ENTER();
+        adc_hal_rtc_output_invert(ADC_NUM_1, inv_en);
+        SARADC1_EXIT();
+    }
+    if (adc_unit & ADC_UNIT_2) {
+        SARADC2_ENTER();
+        adc_hal_rtc_output_invert(ADC_NUM_2, inv_en);
+        SARADC2_EXIT();
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t adc_set_data_width(adc_unit_t adc_unit, adc_bits_width_t width_bit)
+{
+#if CONFIG_IDF_TARGET_ESP32
+    ADC_CHECK(width_bit < ADC_WIDTH_MAX, "WIDTH ERR: ESP32 support 9 ~ 12 bit width", ESP_ERR_INVALID_ARG);
+#else
+    ADC_CHECK(width_bit == ADC_WIDTH_MAX - 1, "WIDTH ERR: see `adc_bits_width_t` for supported bit width", ESP_ERR_INVALID_ARG);
+#endif
+
+    if (adc_unit & ADC_UNIT_1) {
+        SARADC1_ENTER();
+        adc_hal_rtc_set_output_format(ADC_NUM_1, width_bit);
+        SARADC1_EXIT();
+    }
+    if (adc_unit & ADC_UNIT_2) {
+        SARADC2_ENTER();
+        adc_hal_rtc_set_output_format(ADC_NUM_2, width_bit);
+        SARADC2_EXIT();
+    }
+
+    return ESP_OK;
+}
+
+/**
+ * @brief Reset RTC controller FSM.
+ *
+ * @return
+ *      - ESP_OK Success
+ */
+#if !CONFIG_IDF_TARGET_ESP32
+esp_err_t adc_rtc_reset(void)
+{
+    FSM_ENTER();
+    adc_ll_rtc_reset();
+    FSM_EXIT();
+    return ESP_OK;
+}
+#endif
+
+/*-------------------------------------------------------------------------------------
+ *                      ADC1
+ *------------------------------------------------------------------------------------*/
+esp_err_t adc1_config_channel_atten(adc1_channel_t channel, adc_atten_t atten)
+{
+    ADC_CHANNEL_CHECK(ADC_NUM_1, channel);
+    ADC_CHECK(atten < ADC_ATTEN_MAX, "ADC Atten Err", ESP_ERR_INVALID_ARG);
+
+    adc_common_gpio_init(ADC_UNIT_1, channel);
+    SARADC1_ENTER();
+    adc_rtc_chan_init(ADC_UNIT_1);
+    adc_hal_set_atten(ADC_NUM_1, channel, atten);
+    SARADC1_EXIT();
+
+#if SOC_ADC_CALIBRATION_V1_SUPPORTED
+    adc_hal_calibration_init(ADC_NUM_1);
+#endif
+
+    return ESP_OK;
+}
+
+esp_err_t adc1_config_width(adc_bits_width_t width_bit)
+{
+#if CONFIG_IDF_TARGET_ESP32
+    ADC_CHECK(width_bit < ADC_WIDTH_MAX, "WIDTH ERR: ESP32 support 9 ~ 12 bit width", ESP_ERR_INVALID_ARG);
+#else
+    ADC_CHECK(width_bit == ADC_WIDTH_MAX - 1, "WIDTH ERR: see `adc_bits_width_t` for supported bit width", ESP_ERR_INVALID_ARG);
+#endif
+
+    SARADC1_ENTER();
+    adc_hal_rtc_set_output_format(ADC_NUM_1, width_bit);
+    SARADC1_EXIT();
+
+    return ESP_OK;
+}
+
+esp_err_t adc1_dma_mode_acquire(void)
+{
+    /* Use locks to avoid digtal and RTC controller conflicts.
+       for adc1, block until acquire the lock. */
+    SARADC1_ACQUIRE();
+    ESP_LOGD( ADC_TAG, "dma mode takes adc1 lock." );
+
+    adc_power_acquire();
+
+    SARADC1_ENTER();
+    /* switch SARADC into DIG channel */
+    adc_ll_set_controller(ADC_NUM_1, ADC_LL_CTRL_DIG);
+    SARADC1_EXIT();
+
+    return ESP_OK;
+}
+
+esp_err_t adc1_rtc_mode_acquire(void)
+{
+    /* Use locks to avoid digtal and RTC controller conflicts.
+       for adc1, block until acquire the lock. */
+    SARADC1_ACQUIRE();
+    adc_power_acquire();
+
+    SARADC1_ENTER();
+    /* switch SARADC into RTC channel. */
+    adc_ll_set_controller(ADC_NUM_1, ADC_LL_CTRL_RTC);
+    SARADC1_EXIT();
+
+    return ESP_OK;
+}
+
+esp_err_t adc1_lock_release(void)
+{
+    ADC_CHECK(adc1_dma_lock.lock_count != 0, "adc1 lock release called before acquire", ESP_ERR_INVALID_STATE );
+    /* Use locks to avoid digtal and RTC controller conflicts. for adc1, block until acquire the lock. */
+
+    adc_power_release();
+    SARADC1_RELEASE();
+    return ESP_OK;
+}
+
+int adc1_get_raw(adc1_channel_t channel)
+{
+    int adc_value;
+    ADC_CHANNEL_CHECK(ADC_NUM_1, channel);
+    adc1_rtc_mode_acquire();
+
+#if SOC_ADC_CALIBRATION_V1_SUPPORTED
+    // Get calibration value before going into critical section
+    uint32_t cal_val = get_calibration_offset(ADC_NUM_1, channel);
+    adc_hal_set_calibration_param(ADC_NUM_1, cal_val);
+#endif  //SOC_ADC_CALIBRATION_V1_SUPPORTED
+
+    SARADC1_ENTER();
+#ifdef CONFIG_IDF_TARGET_ESP32
+    adc_ll_hall_disable(); //Disable other peripherals.
+    adc_ll_amp_disable();  //Currently the LNA is not open, close it by default.
+#endif
+    adc_ll_set_controller(ADC_NUM_1, ADC_LL_CTRL_RTC);    //Set controller
+    adc_hal_convert(ADC_NUM_1, channel, &adc_value);   //Start conversion, For ADC1, the data always valid.
+#if !CONFIG_IDF_TARGET_ESP32
+    adc_ll_rtc_reset();    //Reset FSM of rtc controller
+#endif
+    SARADC1_EXIT();
+
+    adc1_lock_release();
+    return adc_value;
+}
+
+int adc1_get_voltage(adc1_channel_t channel)    //Deprecated. Use adc1_get_raw() instead
+{
+    return adc1_get_raw(channel);
+}
+
+#if SOC_ULP_SUPPORTED
+void adc1_ulp_enable(void)
+{
+    adc_power_acquire();
+
+    SARADC1_ENTER();
+    adc_ll_set_controller(ADC_NUM_1, ADC_LL_CTRL_ULP);
+    /* since most users do not need LNA and HALL with uLP, we disable them here
+       open them in the uLP if needed. */
+#ifdef CONFIG_IDF_TARGET_ESP32
+    /* disable other peripherals. */
+    adc_ll_hall_disable();
+    adc_ll_amp_disable();
+#endif
+    SARADC1_EXIT();
+}
+#endif
+
+/*---------------------------------------------------------------
+                    ADC2
+---------------------------------------------------------------*/
+/** For ESP32S2 the ADC2 The right to use ADC2 is controlled by the arbiter, and there is no need to set a lock.*/
+esp_err_t adc2_wifi_acquire(void)
+{
+    /* Wi-Fi module will use adc2. Use locks to avoid conflicts. */
+    SARADC2_ACQUIRE();
+    ESP_LOGD( ADC_TAG, "Wi-Fi takes adc2 lock." );
+    return ESP_OK;
+}
+
+esp_err_t adc2_wifi_release(void)
+{
+    ADC_CHECK(SARADC2_LOCK_CHECK(), "wifi release called before acquire", ESP_ERR_INVALID_STATE );
+    SARADC2_RELEASE();
+    ESP_LOGD( ADC_TAG, "Wi-Fi returns adc2 lock." );
+
+    return ESP_OK;
+}
+
+esp_err_t adc2_config_channel_atten(adc2_channel_t channel, adc_atten_t atten)
+{
+    ADC_CHANNEL_CHECK(ADC_NUM_2, channel);
+    ADC_CHECK(atten <= ADC_ATTEN_11db, "ADC2 Atten Err", ESP_ERR_INVALID_ARG);
+
+    adc_common_gpio_init(ADC_UNIT_2, channel);
+
+    if ( SARADC2_TRY_ACQUIRE() == -1 ) {
+        //try the lock, return if failed (wifi using).
+        return ESP_ERR_TIMEOUT;
+    }
+
+    //avoid collision with other tasks
+    SARADC2_ENTER();
+    adc_rtc_chan_init(ADC_UNIT_2);
+    adc_hal_set_atten(ADC_NUM_2, channel, atten);
+    SARADC2_EXIT();
+
+    SARADC2_RELEASE();
+
+#if SOC_ADC_CALIBRATION_V1_SUPPORTED
+    adc_hal_calibration_init(ADC_NUM_2);
+#endif
+
+    return ESP_OK;
+}
+
+static inline void adc2_init(void)
+{
+#if CONFIG_IDF_TARGET_ESP32S2
+#ifdef CONFIG_PM_ENABLE
+    /* Lock APB clock. */
+    if (s_adc2_arbiter_lock == NULL) {
+        esp_pm_lock_create(ESP_PM_APB_FREQ_MAX, 0, "adc2", &s_adc2_arbiter_lock);
+    }
+#endif  //CONFIG_PM_ENABLE
+#endif  //CONFIG_IDF_TARGET_ESP32S2
+}
+
+static inline void adc2_dac_disable( adc2_channel_t channel)
+{
+#if SOC_DAC_SUPPORTED
+#ifdef CONFIG_IDF_TARGET_ESP32
+    if ( channel == ADC2_CHANNEL_8 ) { // the same as DAC channel 1
+        dac_output_disable(DAC_CHANNEL_1);
+    } else if ( channel == ADC2_CHANNEL_9 ) {
+        dac_output_disable(DAC_CHANNEL_2);
+    }
+#else
+    if ( channel == ADC2_CHANNEL_6 ) { // the same as DAC channel 1
+        dac_output_disable(DAC_CHANNEL_1);
+    } else if ( channel == ADC2_CHANNEL_7 ) {
+        dac_output_disable(DAC_CHANNEL_2);
+    }
+#endif
+#endif // SOC_DAC_SUPPORTED
+}
+
+/**
+ * @note For ESP32S2:
+ *       The arbiter's working clock is APB_CLK. When the APB_CLK clock drops below 8 MHz, the arbiter must be in shield mode.
+ *       Or, the RTC controller will fail when get raw data.
+ *       This issue does not occur on digital controllers (DMA mode), and the hardware guarantees that there will be no errors.
+ */
+esp_err_t adc2_get_raw(adc2_channel_t channel, adc_bits_width_t width_bit, int *raw_out)
+{
+    esp_err_t ret = ESP_OK;
+    int adc_value = 0;
+
+    ADC_CHECK(raw_out != NULL, "ADC out value err", ESP_ERR_INVALID_ARG);
+    ADC_CHECK(channel < ADC2_CHANNEL_MAX, "ADC Channel Err", ESP_ERR_INVALID_ARG);
+#if CONFIG_IDF_TARGET_ESP32
+    ADC_CHECK(width_bit < ADC_WIDTH_MAX, "WIDTH ERR: ESP32 support 9 ~ 12 bit width", ESP_ERR_INVALID_ARG);
+#else
+    ADC_CHECK(width_bit == ADC_WIDTH_MAX - 1, "WIDTH ERR: see `adc_bits_width_t` for supported bit width", ESP_ERR_INVALID_ARG);
+#endif
+
+#if SOC_ADC_CALIBRATION_V1_SUPPORTED
+    // Get calibration value before going into critical section
+    uint32_t cal_val = get_calibration_offset(ADC_NUM_2, channel);
+    adc_hal_set_calibration_param(ADC_NUM_2, cal_val);
+#endif  //SOC_ADC_CALIBRATION_V1_SUPPORTED
+
+    if ( SARADC2_TRY_ACQUIRE() == -1 ) {
+        //try the lock, return if failed (wifi using).
+        return ESP_ERR_TIMEOUT;
+    }
+    adc_power_acquire();         //in critical section with whole rtc module
+
+    //avoid collision with other tasks
+    adc2_init();   // in critical section with whole rtc module. because the PWDET use the same registers, place it here.
+    SARADC2_ENTER();
+
+#if SOC_ADC_ARBITER_SUPPORTED
+    adc_arbiter_t config = ADC_ARBITER_CONFIG_DEFAULT();
+    adc_hal_arbiter_config(&config);
+#endif
+
+#ifdef CONFIG_ADC_DISABLE_DAC
+    adc2_dac_disable(channel);      //disable other peripherals
+#endif
+    adc_hal_rtc_set_output_format(ADC_NUM_2, width_bit);
+
+#if CONFIG_IDF_TARGET_ESP32
+    adc_ll_set_controller(ADC_NUM_2, ADC_LL_CTRL_RTC);// set controller
+#else
+    adc_ll_set_controller(ADC_NUM_2, ADC_LL_CTRL_ARB);// set controller
+#endif
+
+#if CONFIG_IDF_TARGET_ESP32S2
+#ifdef CONFIG_PM_ENABLE
+    if (s_adc2_arbiter_lock) {
+        esp_pm_lock_acquire(s_adc2_arbiter_lock);
+    }
+#endif //CONFIG_PM_ENABLE
+#endif //CONFIG_IDF_TARGET_ESP32
+
+    ret = adc_hal_convert(ADC_NUM_2, channel, &adc_value);
+    if (ret != ESP_OK) {
+        adc_value = -1;
+    }
+
+#if CONFIG_IDF_TARGET_ESP32S2
+#ifdef CONFIG_PM_ENABLE
+    /* Release APB clock. */
+    if (s_adc2_arbiter_lock) {
+        esp_pm_lock_release(s_adc2_arbiter_lock);
+    }
+#endif //CONFIG_PM_ENABLE
+#endif //CONFIG_IDF_TARGET_ESP32
+    SARADC2_EXIT();
+
+    adc_power_release();
+    SARADC2_RELEASE();
+
+    *raw_out = adc_value;
+    return ret;
+}
+
+esp_err_t adc2_vref_to_gpio(gpio_num_t gpio)
+{
+    return adc_vref_to_gpio(ADC_UNIT_2, gpio);
+}
+
+esp_err_t adc_vref_to_gpio(adc_unit_t adc_unit, gpio_num_t gpio)
+{
+#ifdef CONFIG_IDF_TARGET_ESP32
+    if (adc_unit & ADC_UNIT_1) {
+        return ESP_ERR_INVALID_ARG;
+    }
+#endif
+    adc2_channel_t ch = ADC2_CHANNEL_MAX;
+    /* Check if the GPIO supported. */
+    for (int i = 0; i < ADC2_CHANNEL_MAX; i++) {
+        if (gpio == ADC_GET_IO_NUM(ADC_NUM_2, i)) {
+            ch = i;
+            break;
+        }
+    }
+    if (ch == ADC2_CHANNEL_MAX) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    adc_power_acquire();
+    if (adc_unit & ADC_UNIT_1) {
+        VREF_ENTER(1);
+        adc_hal_vref_output(ADC_NUM_1, ch, true);
+        VREF_EXIT(1);
+    } else if (adc_unit & ADC_UNIT_2) {
+        VREF_ENTER(2);
+        adc_hal_vref_output(ADC_NUM_2, ch, true);
+        VREF_EXIT(2);
+    }
+
+    //Configure RTC gpio, Only ADC2's channels IO are supported to output reference voltage.
+    adc_common_gpio_init(ADC_UNIT_2, ch);
+    return ESP_OK;
+}
+
+#endif //SOC_ADC_RTC_CTRL_SUPPORTED
+
+
+#if SOC_ADC_CALIBRATION_V1_SUPPORTED
+uint32_t adc_get_calibration_offset(adc_ll_num_t adc_n, adc_channel_t chan, adc_atten_t atten);
+#endif
+
+#if SOC_ADC_CALIBRATION_V1_SUPPORTED
+/*---------------------------------------------------------------
+                    Hardware Calibration Setting
+---------------------------------------------------------------*/
+#if CONFIG_IDF_TARGET_ESP32S2
+  #include "esp_efuse_rtc_table.h"
+  #define esp_efuse_rtc_calib_get_ver()                               esp_efuse_rtc_table_read_calib_version()
+
+static inline uint32_t esp_efuse_rtc_calib_get_init_code(int version, uint32_t adc_unit, int atten)
+{
+    int tag = esp_efuse_rtc_table_get_tag(version, adc_unit + 1, atten, RTCCALIB_V2_PARAM_VINIT);
+    return esp_efuse_rtc_table_get_parsed_efuse_value(tag, false);
+}
+#endif	/* CONFIG_IDF_TARGET_ESP32S2 */
+
+#if !CONFIG_IDF_TARGET_ESP32C3
+static uint16_t s_adc_cali_param[SOC_ADC_PERIPH_NUM][ADC_ATTEN_MAX] = {};
+
+//NOTE: according to calibration version, different types of lock may be taken during the process:
+//  1. Semaphore when reading efuse
+//  2. Lock (Spinlock, or Mutex) if we actually do ADC calibration in the future
+//This function shoudn't be called inside critical section or ISR
+uint32_t adc_get_calibration_offset(adc_ll_num_t adc_n, adc_channel_t channel, adc_atten_t atten)
+{
+    if (s_adc_cali_param[adc_n][atten]) {
+        //ESP_LOGV(ADC_TAG, "Use calibrated val ADC%d atten=%d: %04X", adc_n, atten, s_adc_cali_param[adc_n][atten]);
+        return (uint32_t)s_adc_cali_param[adc_n][atten];
+    }
+
+    // check if we can fetch the values from eFuse.
+    int version = esp_efuse_rtc_calib_get_ver();
+
+    uint32_t init_code = 0;
+
+    if (version == ESP_EFUSE_ADC_CALIB_VER) {
+        init_code = esp_efuse_rtc_calib_get_init_code(version, adc_n, atten);
+
+    } else {
+        ESP_LOGD(ADC_TAG, "Calibration eFuse is not configured, use self-calibration for ICode");
+        adc_power_acquire();
+        ADC_ENTER_CRITICAL();
+        const bool internal_gnd = true;
+        init_code = adc_hal_self_calibration(adc_n, channel, atten, internal_gnd);
+        ADC_EXIT_CRITICAL();
+        adc_power_release();
+    }
+
+    s_adc_cali_param[adc_n][atten] = init_code;
+    //ESP_LOGV(ADC_TAG, "Calib(V%d) ADC%d atten=%d: %04X", version, adc_n, atten, init_code);
+
+    return init_code;
+}
+
+// Internal function to calibrate PWDET for WiFi
+esp_err_t adc_cal_offset(adc_ll_num_t adc_n, adc_channel_t channel, adc_atten_t atten)
+{
+    adc_hal_calibration_init(adc_n);
+    uint32_t cal_val = adc_get_calibration_offset(adc_n, channel, atten);
+    ADC_ENTER_CRITICAL();
+    adc_hal_set_calibration_param(adc_n, cal_val);
+    ADC_EXIT_CRITICAL();
+    return ESP_OK;
+}
+#endif // CONFIG_IDF_TARGET_ESP32C3
+#endif // SOC_ADC_CALIBRATION_V1_SUPPORTED

--- a/zephyr/esp_shared/components/esp_adc_cal/esp_adc_cal_common.c
+++ b/zephyr/esp_shared/components/esp_adc_cal/esp_adc_cal_common.c
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2020-2021 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include "esp_types.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "driver/adc.h"
+#include "hal/adc_types.h"
+#include "esp_adc_cal.h"
+#include "esp_adc_cal_internal.h"
+
+esp_err_t esp_adc_cal_get_voltage(adc_channel_t channel,
+                                  const esp_adc_cal_characteristics_t *chars,
+                                  uint32_t *voltage)
+{
+    if (!chars || !voltage) {
+        return ESP_ERR_INVALID_ARG;
+	}
+
+    esp_err_t ret = ESP_OK;
+    int adc_reading;
+    if (chars->adc_num == ADC_UNIT_1) {
+        if (channel >= SOC_ADC_CHANNEL_NUM(0)) {
+            return ESP_ERR_INVALID_ARG;
+		}
+        adc_reading = adc1_get_raw(channel);
+    } else {
+        if (channel >= SOC_ADC_CHANNEL_NUM(1)) {
+            return ESP_ERR_INVALID_ARG;
+		}
+        ret = adc2_get_raw(channel, chars->bit_width, &adc_reading);
+    }
+    *voltage = esp_adc_cal_raw_to_voltage((uint32_t)adc_reading, chars);
+    return ret;
+}
+
+#if ESP_ADC_CAL_CURVE_FITTING_SUPPORTED
+/*------------------------------------------------------------------------------
+ * Private API
+ *----------------------------------------------------------------------------*/
+int32_t esp_adc_cal_get_reading_error(const esp_adc_error_calc_param_t *param, uint8_t atten)
+{
+    if (param->v_cali_input == 0) {
+        return 0;
+    }
+
+    uint64_t v_cali_1 = param->v_cali_input;
+    uint8_t term_num = param->term_num;
+    int32_t error = 0;
+    uint64_t coeff = 0;
+    uint64_t variable[term_num];
+    uint64_t term[term_num];
+    memset(variable, 0, term_num * sizeof(uint64_t));
+    memset(term, 0, term_num * sizeof(uint64_t));
+
+    /**
+     * For atten0 ~ 2:
+     * error = (K0 * X^0) + (K1 * X^1) + (K2 * X^2);
+     *
+     * For atten3:
+     * error = (K0 * X^0) + (K1 * X^1)  + (K2 * X^2) + (K3 * X^3) + (K4 * X^4);
+     */
+    variable[0] = 1;
+    coeff = (*param->coeff)[atten][0][0];
+    term[0] = variable[0] * coeff / (*param->coeff)[atten][0][1];
+    error = (int32_t)term[0] * (*param->sign)[atten][0];
+
+    for (int i = 1; i < term_num; i++) {
+        variable[i] = variable[i-1] * v_cali_1;
+        coeff = (*param->coeff)[atten][i][0];
+        term[i] = variable[i] * coeff;
+
+        term[i] = term[i] / (*param->coeff)[atten][i][1];
+        error += (int32_t)term[i] * (*param->sign)[atten][i];
+    }
+
+    return error;
+}
+#endif  //#if ESP_ADC_CAL_CURVE_FITTING_SUPPORTED

--- a/zephyr/esp_shared/components/include/esp_adc_cal.h
+++ b/zephyr/esp_shared/components/include/esp_adc_cal.h
@@ -1,0 +1,135 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __ESP_ADC_CAL_H__
+#define __ESP_ADC_CAL_H__
+
+#include <stdint.h>
+#include "esp_err.h"
+#include "driver/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Type of calibration value used in characterization
+ */
+typedef enum {
+    ESP_ADC_CAL_VAL_EFUSE_VREF = 0,         /**< Characterization based on reference voltage stored in eFuse*/
+    ESP_ADC_CAL_VAL_EFUSE_TP = 1,           /**< Characterization based on Two Point values stored in eFuse*/
+    ESP_ADC_CAL_VAL_DEFAULT_VREF = 2,       /**< Characterization based on default reference voltage*/
+    ESP_ADC_CAL_VAL_EFUSE_TP_FIT = 3,       /**< Characterization based on Two Point values and fitting curve coefficients stored in eFuse */
+    ESP_ADC_CAL_VAL_MAX,
+    ESP_ADC_CAL_VAL_NOT_SUPPORTED = ESP_ADC_CAL_VAL_MAX,
+} esp_adc_cal_value_t;
+
+/**
+ * @brief Structure storing characteristics of an ADC
+ *
+ * @note Call esp_adc_cal_characterize() to initialize the structure
+ */
+typedef struct {
+    adc_unit_t adc_num;                     /**< ADC number*/
+    adc_atten_t atten;                      /**< ADC attenuation*/
+    adc_bits_width_t bit_width;             /**< ADC bit width */
+    uint32_t coeff_a;                       /**< Gradient of ADC-Voltage curve*/
+    uint32_t coeff_b;                       /**< Offset of ADC-Voltage curve*/
+    uint32_t vref;                          /**< Vref used by lookup table*/
+    const uint32_t *low_curve;              /**< Pointer to low Vref curve of lookup table (NULL if unused)*/
+    const uint32_t *high_curve;             /**< Pointer to high Vref curve of lookup table (NULL if unused)*/
+    uint8_t version;                        /**< ADC Calibration */
+} esp_adc_cal_characteristics_t;
+
+/**
+ * @brief Checks if ADC calibration values are burned into eFuse
+ *
+ * This function checks if ADC reference voltage or Two Point values have been
+ * burned to the eFuse of the current ESP32
+ *
+ * @param   value_type  Type of calibration value (ESP_ADC_CAL_VAL_EFUSE_VREF or ESP_ADC_CAL_VAL_EFUSE_TP)
+ * @note in ESP32S2, only ESP_ADC_CAL_VAL_EFUSE_TP is supported. Some old ESP32S2s do not support this, either.
+ * In which case you have to calibrate it manually, possibly by performing your own two-point calibration on the chip.
+ *
+ * @return
+ *      - ESP_OK: The calibration mode is supported in eFuse
+ *      - ESP_ERR_NOT_SUPPORTED: Error, eFuse values are not burned
+ *      - ESP_ERR_INVALID_ARG: Error, invalid argument (ESP_ADC_CAL_VAL_DEFAULT_VREF)
+ */
+esp_err_t esp_adc_cal_check_efuse(esp_adc_cal_value_t value_type);
+
+/**
+ * @brief Characterize an ADC at a particular attenuation
+ *
+ * This function will characterize the ADC at a particular attenuation and generate
+ * the ADC-Voltage curve in the form of [y = coeff_a * x + coeff_b].
+ * Characterization can be based on Two Point values, eFuse Vref, or default Vref
+ * and the calibration values will be prioritized in that order.
+ *
+ * @note
+ * For ESP32, Two Point values and eFuse Vref calibration can be enabled/disabled using menuconfig.
+ * For ESP32s2, only Two Point values calibration and only ADC_WIDTH_BIT_13 is supported. The parameter default_vref is unused.
+ *
+ *
+ * @param[in]   adc_num         ADC to characterize (ADC_UNIT_1 or ADC_UNIT_2)
+ * @param[in]   atten           Attenuation to characterize
+ * @param[in]   bit_width       Bit width configuration of ADC
+ * @param[in]   default_vref    Default ADC reference voltage in mV (Only in ESP32, used if eFuse values is not available)
+ * @param[out]  chars           Pointer to empty structure used to store ADC characteristics
+ *
+ * @return
+ *      - ESP_ADC_CAL_VAL_EFUSE_VREF: eFuse Vref used for characterization
+ *      - ESP_ADC_CAL_VAL_EFUSE_TP: Two Point value used for characterization (only in Linear Mode)
+ *      - ESP_ADC_CAL_VAL_DEFAULT_VREF: Default Vref used for characterization
+ */
+esp_adc_cal_value_t esp_adc_cal_characterize(adc_unit_t adc_num,
+                                             adc_atten_t atten,
+                                             adc_bits_width_t bit_width,
+                                             uint32_t default_vref,
+                                             esp_adc_cal_characteristics_t *chars);
+
+/**
+ * @brief   Convert an ADC reading to voltage in mV
+ *
+ * This function converts an ADC reading to a voltage in mV based on the ADC's
+ * characteristics.
+ *
+ * @note    Characteristics structure must be initialized before this function
+ *          is called (call esp_adc_cal_characterize())
+ *
+ * @param[in]   adc_reading     ADC reading
+ * @param[in]   chars           Pointer to initialized structure containing ADC characteristics
+ *
+ * @return      Voltage in mV
+ */
+uint32_t esp_adc_cal_raw_to_voltage(uint32_t adc_reading, const esp_adc_cal_characteristics_t *chars);
+
+/**
+ * @brief   Reads an ADC and converts the reading to a voltage in mV
+ *
+ * This function reads an ADC then converts the raw reading to a voltage in mV
+ * based on the characteristics provided. The ADC that is read is also
+ * determined by the characteristics.
+ *
+ * @note    The Characteristics structure must be initialized before this
+ *          function is called (call esp_adc_cal_characterize())
+ *
+ * @param[in]   channel     ADC Channel to read
+ * @param[in]   chars       Pointer to initialized ADC characteristics structure
+ * @param[out]  voltage     Pointer to store converted voltage
+ *
+ * @return
+ *      - ESP_OK: ADC read and converted to mV
+ *      - ESP_ERR_INVALID_ARG: Error due to invalid arguments
+ *      - ESP_ERR_INVALID_STATE: Reading result is invalid. Try to read again.
+ */
+esp_err_t esp_adc_cal_get_voltage(adc_channel_t channel, const esp_adc_cal_characteristics_t *chars, uint32_t *voltage);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ESP_ADC_CAL_H__ */

--- a/zephyr/esp_shared/components/include/esp_adc_cal_internal.h
+++ b/zephyr/esp_shared/components/include/esp_adc_cal_internal.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2020-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <stdint.h>
+//#include "sdkconfig.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
+#define ESP_ADC_CAL_CURVE_FITTING_SUPPORTED    1
+
+#define COEFF_GROUP_NUM    4
+#define TERM_MAX           5
+#endif
+
+#if ESP_ADC_CAL_CURVE_FITTING_SUPPORTED
+/**
+ * Calculation parameters used for curve fitting calibration algorithm error
+ *
+ * @note For atten0 ~ 2, error = (K0 * X^0) + (K1 * X^1) + (K2 * X^2); For atten3, error = (K0 * X^0) + (K1 * X^1)  + (K2 * X^2) + (K3 * X^3) + (K4 * X^4);
+ *       Where X is the `v_cali_input`.
+ */
+typedef struct {
+    uint64_t v_cali_input;                                      //Input to calculate the error
+    uint8_t  term_num;                                          //Term number of the algorithm formula
+    const uint64_t (*coeff)[COEFF_GROUP_NUM][TERM_MAX][2];      //Coeff of each term. See `adc_error_coef_atten` for details (and the magic number 2)
+    const int32_t  (*sign)[COEFF_GROUP_NUM][TERM_MAX];          //Sign of each term
+} esp_adc_error_calc_param_t;
+
+/**
+ * Calculate the curve fitting error
+ *
+ * @param param   see `esp_adc_error_calc_param_t`
+ * @param atten   ADC attenuation
+ */
+int32_t esp_adc_cal_get_reading_error(const esp_adc_error_calc_param_t *param, uint8_t atten);
+
+#endif  //#if ESP_ADC_CAL_CURVE_FITTING_SUPPORTED
+
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This PR add ADC support for ESP32 (ESP32-S2 and ESP32-C3 will be supported as well).
The ADC is supported in single-shot mode, continuous mode DMA operation will be added soon.