### PR TITLE
Revert "macro: convert ESP macro to use Zephyr's logging"

### DIFF
--- a/components/esp_common/include/esp_check.h
+++ b/components/esp_common/include/esp_check.h
@@ -16,9 +16,6 @@
 #include "esp_err.h"
 #include "esp_log.h"
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(esp32, CONFIG_LOG_DEFAULT_LEVEL);
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -132,7 +129,7 @@ extern "C" {
 #define ESP_RETURN_ON_ERROR(x, log_tag, format, ...) do {                                                  \
         esp_err_t err_rc_ = (x);                                                                           \
         if (unlikely(err_rc_ != ESP_OK)) {                                                                 \
-            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
+            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
             return err_rc_;                                                                                \
         }                                                                                                  \
     } while(0)
@@ -143,6 +140,7 @@ extern "C" {
 #define ESP_RETURN_ON_ERROR_ISR(x, log_tag, format, ...) do {                                              \
         esp_err_t err_rc_ = (x);                                                                           \
         if (unlikely(err_rc_ != ESP_OK)) {                                                                 \
+            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);  \
             return err_rc_;                                                                                \
         }                                                                                                  \
     } while(0)
@@ -154,7 +152,7 @@ extern "C" {
 #define ESP_GOTO_ON_ERROR(x, goto_tag, log_tag, format, ...) do {                                          \
         esp_err_t err_rc_ = (x);                                                                           \
         if (unlikely(err_rc_ != ESP_OK)) {                                                                 \
-            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
+            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
             ret = err_rc_;                                                                                 \
             goto goto_tag;                                                                                 \
         }                                                                                                  \
@@ -166,6 +164,7 @@ extern "C" {
 #define ESP_GOTO_ON_ERROR_ISR(x, goto_tag, log_tag, format, ...) do {                                      \
         esp_err_t err_rc_ = (x);                                                                           \
         if (unlikely(err_rc_ != ESP_OK)) {                                                                 \
+            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);  \
             ret = err_rc_;                                                                                 \
             goto goto_tag;                                                                                 \
         }                                                                                                  \
@@ -177,7 +176,7 @@ extern "C" {
  */
 #define ESP_RETURN_ON_FALSE(a, err_code, log_tag, format, ...) do {                                        \
         if (unlikely(!(a))) {                                                                              \
-            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
+            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
             return err_code;                                                                               \
         }                                                                                                  \
     } while(0)
@@ -187,6 +186,7 @@ extern "C" {
  */
 #define ESP_RETURN_ON_FALSE_ISR(a, err_code, log_tag, format, ...) do {                                    \
         if (unlikely(!(a))) {                                                                              \
+            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);  \
             return err_code;                                                                               \
         }                                                                                                  \
     } while(0)
@@ -197,7 +197,7 @@ extern "C" {
  */
 #define ESP_GOTO_ON_FALSE(a, err_code, goto_tag, log_tag, format, ...) do {                                \
         if (unlikely(!(a))) {                                                                              \
-            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
+            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);        \
             ret = err_code;                                                                                \
             goto goto_tag;                                                                                 \
         }                                                                                                  \
@@ -208,6 +208,7 @@ extern "C" {
  */
 #define ESP_GOTO_ON_FALSE_ISR(a, err_code, goto_tag, log_tag, format, ...) do {                            \
         if (unlikely(!(a))) {                                                                              \
+            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__ __VA_OPT__(,) __VA_ARGS__);  \
             ret = err_code;                                                                                \
             goto goto_tag;                                                                                 \
         }                                                                                                  \
@@ -221,7 +222,7 @@ extern "C" {
 #define ESP_RETURN_ON_ERROR(x, log_tag, format, ...) do {                                       \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
-            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
+            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
             return err_rc_;                                                                     \
         }                                                                                       \
     } while(0)
@@ -232,6 +233,7 @@ extern "C" {
 #define ESP_RETURN_ON_ERROR_ISR(x, log_tag, format, ...) do {                                   \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
+            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);  \
             return err_rc_;                                                                     \
         }                                                                                       \
     } while(0)
@@ -243,7 +245,7 @@ extern "C" {
 #define ESP_GOTO_ON_ERROR(x, goto_tag, log_tag, format, ...) do {                               \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
-            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
+            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
             ret = err_rc_;                                                                      \
             goto goto_tag;                                                                      \
         }                                                                                       \
@@ -255,6 +257,7 @@ extern "C" {
 #define ESP_GOTO_ON_ERROR_ISR(x, goto_tag, log_tag, format, ...) do {                           \
         esp_err_t err_rc_ = (x);                                                                \
         if (unlikely(err_rc_ != ESP_OK)) {                                                      \
+            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);  \
             ret = err_rc_;                                                                      \
             goto goto_tag;                                                                      \
         }                                                                                       \
@@ -266,7 +269,7 @@ extern "C" {
  */
 #define ESP_RETURN_ON_FALSE(a, err_code, log_tag, format, ...) do {                             \
         if (unlikely(!(a))) {                                                                   \
-            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
+            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
             return err_code;                                                                    \
         }                                                                                       \
     } while(0)
@@ -276,6 +279,7 @@ extern "C" {
  */
 #define ESP_RETURN_ON_FALSE_ISR(a, err_code, log_tag, format, ...) do {                         \
         if (unlikely(!(a))) {                                                                   \
+            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);  \
             return err_code;                                                                    \
         }                                                                                       \
     } while(0)
@@ -286,7 +290,7 @@ extern "C" {
  */
 #define ESP_GOTO_ON_FALSE(a, err_code, goto_tag, log_tag, format, ...) do {                     \
         if (unlikely(!(a))) {                                                                   \
-            LOG_ERR("%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
+            ESP_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);        \
             ret = err_code;                                                                     \
             goto goto_tag;                                                                      \
         }                                                                                       \
@@ -297,6 +301,7 @@ extern "C" {
  */
 #define ESP_GOTO_ON_FALSE_ISR(a, err_code, goto_tag, log_tag, format, ...) do {                 \
         if (unlikely(!(a))) {                                                                   \
+            ESP_EARLY_LOGE(log_tag, "%s(%d): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__);  \
             ret = err_code;                                                                     \
             goto goto_tag;                                                                      \
         }                                                                                       \


### PR DESCRIPTION
This reverts commit cc411a9dcbb7c90cfe8ff9c2a93f0d966069890d, which adds Zephyr logging subsystem into esp-check internals. However, it won't work with multiple includes due to Zephyr Macro.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>