### PR TITLE
pm: clock: check console status for proper flushing

### DIFF
--- a/components/esp_system/port/soc/esp32/clk.c
+++ b/components/esp_system/port/soc/esp32/clk.c
@@ -186,9 +186,9 @@ static void select_rtc_slow_clk(slow_clk_sel_t slow_clk)
 
     // Wait for UART TX to finish, otherwise some UART output will be lost
     // when switching APB frequency
-    if (CONFIG_ESP_CONSOLE_UART_NUM >= 0) {
-        esp_rom_uart_tx_wait_idle(CONFIG_ESP_CONSOLE_UART_NUM);
-    }
+#ifdef CONFIG_ESP_CONSOLE_UART
+    esp_rom_uart_tx_wait_idle(CONFIG_ESP_CONSOLE_UART_NUM);
+#endif
 
     if (res) {
         rtc_clk_cpu_freq_set_config(&new_config);

--- a/components/esp_system/port/soc/esp32c3/clk.c
+++ b/components/esp_system/port/soc/esp32c3/clk.c
@@ -128,7 +128,9 @@ static const char *TAG = "clk";
 
     // Wait for UART TX to finish, otherwise some UART output will be lost
     // when switching APB frequency
+#ifdef CONFIG_ESP_CONSOLE_UART
     esp_rom_uart_tx_wait_idle(CONFIG_ESP_CONSOLE_UART_NUM);
+#endif
 
     if (res)  {
         rtc_clk_cpu_freq_set_config(&new_config);

--- a/components/esp_system/port/soc/esp32s2/clk.c
+++ b/components/esp_system/port/soc/esp32s2/clk.c
@@ -131,9 +131,9 @@ static void select_rtc_slow_clk(slow_clk_sel_t slow_clk);
 
     // Wait for UART TX to finish, otherwise some UART output will be lost
     // when switching APB frequency
-    if (CONFIG_ESP_CONSOLE_UART_NUM >= 0) {
-        esp_rom_uart_tx_wait_idle(CONFIG_ESP_CONSOLE_UART_NUM);
-    }
+#ifdef CONFIG_ESP_CONSOLE_UART
+    esp_rom_uart_tx_wait_idle(CONFIG_ESP_CONSOLE_UART_NUM);
+#endif
 
     if (res) {
         rtc_clk_cpu_freq_set_config(&new_config);


### PR DESCRIPTION
Clock control needs to wait TX idle. However, it only needs to do that if console/uart is enabled.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>