### PR TITLE
system: soc: Add missing config

### DIFF
--- a/components/esp_system/port/soc/esp32/clk.c
+++ b/components/esp_system/port/soc/esp32/clk.c
@@ -27,7 +27,8 @@
 #include "sdkconfig.h"
 #else
 #include "stubs.h"
-#define CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ   ESP_SOC_DEFAULT_CPU_FREQ_MHZ
+#define CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ ESP_SOC_DEFAULT_CPU_FREQ_MHZ
+#define CONFIG_ESP32_RTC_CLK_CAL_CYCLES ESP_SOC_DEFAULT_RTC_CLK_CAL_CYCLES
 #endif /* !defined(__ZEPHYR__) */
 
 static const char* TAG = "clk";

--- a/components/esp_system/port/soc/esp32c3/clk.c
+++ b/components/esp_system/port/soc/esp32c3/clk.c
@@ -34,6 +34,7 @@
 #if defined(__ZEPHYR__)
 #include "stubs.h"
 #define CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ ESP_SOC_DEFAULT_CPU_FREQ_MHZ
+#define CONFIG_ESP32C3_RTC_CLK_CAL_CYCLES ESP_SOC_DEFAULT_RTC_CLK_CAL_CYCLES
 #endif /* defined(__ZEPHYR__) */
 
 /* Number of cycles to wait from the 32k XTAL oscillator to consider it running.

--- a/components/esp_system/port/soc/esp32s2/clk.c
+++ b/components/esp_system/port/soc/esp32s2/clk.c
@@ -37,6 +37,7 @@
 #if defined(__ZEPHYR__)
 #include "stubs.h"
 #define CONFIG_ESP32S2_DEFAULT_CPU_FREQ_MHZ ESP_SOC_DEFAULT_CPU_FREQ_MHZ
+#define CONFIG_ESP32S2_RTC_CLK_CAL_CYCLES ESP_SOC_DEFAULT_RTC_CLK_CAL_CYCLES
 #endif /* defined(__ZEPHYR__) */
 
 static const char *TAG = "clk";


### PR DESCRIPTION
When unifying stubs.h default config vanished. 