### PR TITLE
driver: esp32: sensor: Add die temperature support

### DIFF
--- a/components/driver/esp32c3/rtc_tempsensor.c
+++ b/components/driver/esp32c3/rtc_tempsensor.c
@@ -22,6 +22,10 @@
 #include "esp32c3/rom/ets_sys.h"
 #include "esp_efuse_rtc_calib.h"
 
+#ifdef __ZEPHYR__
+#include <zephyr/kernel.h>
+#endif /* __ZEPHYR__ */
+
 static const char *TAG = "tsens";
 
 #define TSENS_XPD_WAIT_DEFAULT 0xFF   /* Set wait cycle time(8MHz) from power up to reset enable. */

--- a/components/efuse/esp32c3/esp_efuse_rtc_calib.c
+++ b/components/efuse/esp32c3/esp_efuse_rtc_calib.c
@@ -8,6 +8,10 @@
 #include "esp_efuse.h"
 #include "esp_efuse_table.h"
 
+#ifdef __ZEPHYR__
+#include <zephyr/kernel.h>
+#endif /* __ZEPHYR__ */
+
 int esp_efuse_rtc_calib_get_ver(void)
 {
     uint32_t result = 0;

--- a/components/esp_common/include/esp_compiler.h
+++ b/components/esp_common/include/esp_compiler.h
@@ -37,9 +37,9 @@
 #if !defined(unlikely)
 #define unlikely(x)    (x)
 #endif
-#endif
+#endif /* CONFIG_COMPILER_OPTIMIZATION_PERF */
 
-#endif
+#endif	/* __ZEPHYR__ */
 
 /*
  * Utility macros used for designated initializers, which work differently

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -30,6 +30,7 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/soc/src/esp32c3/include
     ../../components/soc/include
     ../../components/driver/include
+    ../../components/driver/esp32c3/include
     ../../components/efuse/include
     ../../components/efuse/private_include
     ../../components/efuse/esp32c3/include
@@ -136,6 +137,11 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/hal/wdt_hal_iram.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_ESP32_TEMP
+    ../../components/driver/esp32c3/rtc_tempsensor.c
+    )
+
   zephyr_sources(
     ../../components/soc/esp32c3/gpio_periph.c
     ../../components/esp_timer/src/esp_timer_impl_systimer.c
@@ -158,6 +164,7 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/efuse/esp32c3/esp_efuse_fields.c
     ../../components/efuse/esp32c3/esp_efuse_table.c
     ../../components/efuse/esp32c3/esp_efuse_utility.c
+    ../../components/efuse/esp32c3/esp_efuse_rtc_calib.c
     ../../components/efuse/src/esp_efuse_api.c
     ../../components/efuse/src/esp_efuse_api_key_esp32xx.c
     ../../components/efuse/src/esp_efuse_utility.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -28,7 +28,6 @@ if(CONFIG_SOC_ESP32S2)
     ../../components/xtensa/esp32s2/include
     ../../components/soc/include
     ../../components/soc/include/soc
-    ../../components/driver/include
     ../../components/driver/esp32s2/include
     ../../components/esp_system/include
     ../../components/esp_system/port/include
@@ -169,6 +168,11 @@ if(CONFIG_SOC_ESP32S2)
     ../../components/hal/wdt_hal_iram.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_ESP32_TEMP
+    ../../components/driver/esp32s2/rtc_tempsensor.c
+    )
+
   zephyr_sources(
     ../../components/soc/esp32s2/gpio_periph.c
     ../../components/soc/esp32s2/rtc_io_periph.c
@@ -194,6 +198,7 @@ if(CONFIG_SOC_ESP32S2)
     ../../components/efuse/esp32s2/esp_efuse_fields.c
     ../../components/efuse/esp32s2/esp_efuse_table.c
     ../../components/efuse/esp32s2/esp_efuse_utility.c
+    ../../components/efuse/esp32s2/esp_efuse_rtc_table.c
     ../../components/efuse/src/esp_efuse_api.c
     ../../components/efuse/src/esp_efuse_api_key_esp32xx.c
     ../../components/efuse/src/esp_efuse_utility.c


### PR DESCRIPTION
Add basic support for measuring die temperature on ESP32 targets S2 and C3.