### PR TITLE
monitor: fix missing eol in console parser

### DIFF
--- a/tools/idf_monitor_base/console_parser.py
+++ b/tools/idf_monitor_base/console_parser.py
@@ -48,6 +48,7 @@ class ConsoleParser(object):
         self.menu_key = CTRL_T
         self.exit_key = CTRL_RBRACKET
         self._pressed_menu_key = False
+        self.eol = {'CRLF': b'\r\n', 'CR': b'\r', 'LF': b'\n'}[eol]
 
     def parse(self, key):  # type: (str) -> Optional[tuple]
         ret = None

--- a/tools/idf_monitor_base/serial_handler.py
+++ b/tools/idf_monitor_base/serial_handler.py
@@ -73,7 +73,7 @@ class SerialHandler:
             if pos != -1:
                 data = data[(pos + 1):]
 
-        sp = data.split(b'\n')
+        sp = data.split(console_parser.eol)
         if self._last_line_part != b'':
             # add unprocessed part from previous "data" to the first line
             sp[0] = self._last_line_part + sp[0]

--- a/west/tools.py
+++ b/west/tools.py
@@ -136,6 +136,7 @@ class Tools(WestCommand):
         group.add_argument('-b', '--baud', default="115200", help='Serial port baud rate')
         group.add_argument('-p', '--port', help='Serial port address')
         group.add_argument('-e', '--elf', help='ELF file')
+        group.add_argument('-n', '--eol', default='CRLF', help='EOL to use')
 
         return parser
 
@@ -173,7 +174,7 @@ class Tools(WestCommand):
         cmd_path = Path(os.getenv("ZEPHYR_BASE")).absolute()
         if platform.system() == 'Windows':
             cmd_exec(("python.exe", monitor_path, "-p", esp_port,
-                     "-b", args.baud, elf_path), cwd=cmd_path)
+                     "-b", args.baud, elf_path, "--eol", args.eol), cwd=cmd_path)
         else:
             cmd_exec((sys.executable, monitor_path, "-p", esp_port, "-b", args.baud,
-                      elf_path), cwd=cmd_path)
+                      elf_path, "--eol", args.eol), cwd=cmd_path)


### PR DESCRIPTION
Adds end-of-line argument parser in order to have
the console proper working without scrambling texts.

Fixes #162 

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>