### PR TITLE
base64: remove from wpa source to avoid redefition

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -321,7 +321,6 @@ if(CONFIG_SOC_ESP32 OR CONFIG_SOC_ESP32_NET)
                        "../../components/wpa_supplicant/src/rsn_supp/pmksa_cache.c"
                        "../../components/wpa_supplicant/src/rsn_supp/wpa.c"
                        "../../components/wpa_supplicant/src/rsn_supp/wpa_ie.c"
-                       "../../components/wpa_supplicant/src/utils/base64.c"
                        "../../components/wpa_supplicant/src/utils/common.c"
                        "../../components/wpa_supplicant/src/utils/ext_password.c"
                        "../../components/wpa_supplicant/src/utils/uuid.c"

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -283,7 +283,6 @@ if(CONFIG_SOC_ESP32C3)
                        "../../components/wpa_supplicant/src/rsn_supp/pmksa_cache.c"
                        "../../components/wpa_supplicant/src/rsn_supp/wpa.c"
                        "../../components/wpa_supplicant/src/rsn_supp/wpa_ie.c"
-                       "../../components/wpa_supplicant/src/utils/base64.c"
                        "../../components/wpa_supplicant/src/utils/common.c"
                        "../../components/wpa_supplicant/src/utils/ext_password.c"
                        "../../components/wpa_supplicant/src/utils/uuid.c"

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -275,7 +275,6 @@ if(CONFIG_SOC_ESP32S2)
                        "../../components/wpa_supplicant/src/rsn_supp/pmksa_cache.c"
                        "../../components/wpa_supplicant/src/rsn_supp/wpa.c"
                        "../../components/wpa_supplicant/src/rsn_supp/wpa_ie.c"
-                       "../../components/wpa_supplicant/src/utils/base64.c"
                        "../../components/wpa_supplicant/src/utils/common.c"
                        "../../components/wpa_supplicant/src/utils/ext_password.c"
                        "../../components/wpa_supplicant/src/utils/uuid.c"


### PR DESCRIPTION
After Zephyr's SDK 0.15.2, base64 source is causing build redefinition.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>