### PR TITLE
driver: gdma: add source files to build

### DIFF
--- a/components/hal/esp32c3/include/hal/gdma_ll.h
+++ b/components/hal/esp32c3/include/hal/gdma_ll.h
@@ -165,8 +165,9 @@ static inline uint32_t gdma_ll_rx_get_fifo_bytes(gdma_dev_t *dev, uint32_t chann
  */
 static inline uint32_t gdma_ll_rx_pop_data(gdma_dev_t *dev, uint32_t channel)
 {
+	uint32_t pop_data = dev->channel[channel].in.in_pop.infifo_rdata;
     dev->channel[channel].in.in_pop.infifo_pop = 1;
-    return dev->channel[channel].in.in_pop.infifo_rdata;
+    return pop_data;
 }
 
 /**

--- a/components/soc/esp32c3/include/soc/soc.h
+++ b/components/soc/esp32c3/include/soc/soc.h
@@ -244,8 +244,8 @@
 #define SOC_DIRAM_DRAM_HIGH   0x3FCE0000
 
 // Region of memory accessible via DMA. See esp_ptr_dma_capable().
-#define SOC_DMA_LOW  0x3FC88000
-#define SOC_DMA_HIGH 0x3FD00000
+#define SOC_DMA_LOW  0x3FC80000
+#define SOC_DMA_HIGH 0x3FCDFFFF
 
 // Region of RAM that is byte-accessible. See esp_ptr_byte_accessible().
 #define SOC_BYTE_ACCESSIBLE_LOW     0x3FC88000

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -28,6 +28,7 @@ if(CONFIG_SOC_ESP32C3)
     ../../components/hal/esp32c3/include
     ../../components/hal/platform_port/include
     ../../components/soc/esp32c3/include
+    ../../components/soc/esp32c3/include/soc
     ../../components/soc/src/esp32c3/include
     ../../components/soc/include
     ../../components/driver/include
@@ -153,6 +154,12 @@ if(CONFIG_SOC_ESP32C3)
     ../esp_shared/components/driver/rtc_io.c
     ../esp_shared/components/esp_adc_cal/esp_adc_cal_common.c
     src/esp_adc_cal/esp_adc_cal.c
+  )
+
+  zephyr_sources_ifdef(
+    CONFIG_DMA_ESP32
+    ../../components/soc/lldesc.c
+    ../../components/hal/gdma_hal.c
     )
 
   zephyr_sources(


### PR DESCRIPTION
Add gdma driver source files to zephyr build for its own driver. 
Fix gdma_ll_rx_pop_data.
Fix region of memory accessible via DMA.

Signed-off-by: Lucas Tamborrino <lucas.tamborrino@espressif.com>