### PR TITLE
west: espressif monitor path

### DIFF
--- a/west/tools.py
+++ b/west/tools.py
@@ -171,7 +171,7 @@ class Tools(WestCommand):
             esp_port = get_esp_serial_port(module_path)
 
         monitor_path = Path(module_path, "tools/idf_monitor.py")
-        cmd_path = Path(os.getenv("ZEPHYR_BASE")).absolute()
+        cmd_path = Path(os.getcwd())
         if platform.system() == 'Windows':
             cmd_exec(("python.exe", monitor_path, "-p", esp_port,
                      "-b", args.baud, elf_path, "--eol", args.eol), cwd=cmd_path)


### PR DESCRIPTION
Run the monitor using actual working directory, which is more likely to have build directory.  As we should be able to build anywhere in the west workspace.
Details in https://github.com/zephyrproject-rtos/zephyr/discussions/33521