### PR TITLE
clock: use RTOS timer instead of esp_rom

### DIFF
--- a/components/esp_hw_support/port/esp32s3/rtc_time.c
+++ b/components/esp_hw_support/port/esp32s3/rtc_time.c
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef __ZEPHYR__
+#include <zephyr/kernel.h>
+#endif
+
 #include <stdint.h>
 #include "esp_rom_sys.h"
 #include "soc/rtc.h"
@@ -86,13 +90,17 @@ uint32_t rtc_clk_cal_internal(rtc_cal_sel_t cal_clk, uint32_t slowclk_cycles)
         REG_SET_FIELD(TIMG_RTCCALICFG2_REG(0), TIMG_RTC_CALI_TIMEOUT_THRES, RTC_SLOW_CLK_150K_CAL_TIMEOUT_THRES(slowclk_cycles));
         expected_freq = RTC_SLOW_CLK_FREQ_150K;
     }
-    uint32_t us_time_estimate = (uint32_t) (((uint64_t) slowclk_cycles) * MHZ / expected_freq);
+    uint32_t us_time_estimate = (uint32_t) (((uint64_t) slowclk_cycles) * 1000000 / expected_freq);
     /* Start calibration */
     CLEAR_PERI_REG_MASK(TIMG_RTCCALICFG_REG(0), TIMG_RTC_CALI_START);
     SET_PERI_REG_MASK(TIMG_RTCCALICFG_REG(0), TIMG_RTC_CALI_START);
 
     /* Wait for calibration to finish up to another us_time_estimate */
+#ifdef __ZEPHYR__
+    k_busy_wait(us_time_estimate);
+#else
     esp_rom_delay_us(us_time_estimate);
+#endif
     uint32_t cal_val;
     while (true) {
         if (GET_PERI_REG_MASK(TIMG_RTCCALICFG_REG(0), TIMG_RTC_CALI_RDY)) {


### PR DESCRIPTION
Clock calibration can get stuck due to usage of
esp_rom_delay_us greater than OS tick rate.
This PR updates this usage to kernel OS delay instead.

ESP32C3 needs to stick with default esp_rom_delay_us as it uses custom systimer, which is not ready yet during clock calibration.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>