### PR TITLE
clock: esp32s3: fix build warnings and CPU name

### DIFF
--- a/components/esp_hw_support/port/esp32s3/rtc_clk_common.h
+++ b/components/esp_hw_support/port/esp32s3/rtc_clk_common.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#undef MHZ
 #define MHZ (1000000)
 
 #define DPORT_CPUPERIOD_SEL_80      0

--- a/zephyr/esp_shared/include/stubs.h
+++ b/zephyr/esp_shared/include/stubs.h
@@ -18,7 +18,7 @@
 
 #if defined(CONFIG_SOC_ESP32) || defined(CONFIG_SOC_ESP32_NET)
 #define DT_CPU_COMPAT cdns_tensilica_xtensa_lx6
-#elif defined(CONFIG_SOC_ESP32S2)
+#elif defined(CONFIG_SOC_ESP32S2) || defined(CONFIG_SOC_ESP32S3)
 #define DT_CPU_COMPAT cdns_tensilica_xtensa_lx7
 #elif CONFIG_IDF_TARGET_ESP32C3
 #define DT_CPU_COMPAT espressif_riscv


### PR DESCRIPTION
This fixes build warning due to MHZ definition and missing S3 CPU name convention.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>