### PR TITLE
bugfix: fix SPIRAM WP pin configuration

### DIFF
--- a/components/esp_hw_support/port/esp32/spiram_psram.c
+++ b/components/esp_hw_support/port/esp32/spiram_psram.c
@@ -891,7 +891,7 @@ esp_err_t IRAM_ATTR psram_enable(psram_cache_mode_t mode, psram_vaddr_mode_t vad
         psram_io.psram_spiq_sd0_io  = EFUSE_SPICONFIG_RET_SPIQ(spiconfig);
         psram_io.psram_spid_sd1_io  = EFUSE_SPICONFIG_RET_SPID(spiconfig);
         psram_io.psram_spihd_sd2_io = EFUSE_SPICONFIG_RET_SPIHD(spiconfig);
-        psram_io.psram_spiwp_sd3_io = CONFIG_SPIRAM_SPIWP_SD3_PIN;
+        psram_io.psram_spiwp_sd3_io = bootloader_flash_get_wp_pin();
     }
 
     assert(mode < PSRAM_CACHE_MAX && "we don't support any other mode for now.");

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -219,6 +219,8 @@ if(CONFIG_SOC_ESP32 OR CONFIG_SOC_ESP32_NET)
     ../../components/efuse/src/esp_efuse_api.c
     ../../components/efuse/src/esp_efuse_api_key_esp32.c
     ../../components/efuse/src/esp_efuse_utility.c
+    ../../components/bootloader_support/src/bootloader_flash_config_esp32.c
+    ../../components/bootloader_support/src/bootloader_efuse_esp32.c
     ../esp_shared/src/common/esp_system_api.c
     src/common/dport_access.c
     src/stubs.c


### PR DESCRIPTION
Update SPIRAM/flash WP SD3 pin configuration to be called
from bootloader source file. This will automatically check
whether WP_SD3 pin was customized or from efuse values.

Fixes [#54005](https://github.com/zephyrproject-rtos/zephyr/issues/54005)

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>