### PR TITLE
hal: esp32c3: soc_ll Software reset system

### DIFF
--- a/components/hal/esp32c3/include/hal/soc_ll.h
+++ b/components/hal/esp32c3/include/hal/soc_ll.h
@@ -44,7 +44,7 @@ static inline void soc_ll_unstall_core(int core)
 
 static inline void soc_ll_reset_core(int core)
 {
-    SET_PERI_REG_MASK(RTC_CNTL_OPTIONS0_REG, RTC_CNTL_SW_PROCPU_RST_M);
+    SET_PERI_REG_MASK(RTC_CNTL_OPTIONS0_REG, RTC_CNTL_SW_SYS_RST_M);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Resetting via Zephyr sys_reboot() on ESP32C3 I was seeing intermittent hangs on restart. Changing the reset mode in the HAL from a processor level to system level reset solved this.