### PR TITLE
driver: uart_ll: fix wrong rs485 bit reference

### DIFF
--- a/components/hal/esp32s3/include/hal/uart_ll.h
+++ b/components/hal/esp32s3/include/hal/uart_ll.h
@@ -663,7 +663,7 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_rs485_half_duplex(uart_dev_t *hw)
  */
 FORCE_INLINE_ATTR bool uart_ll_is_mode_rs485_half_duplex(uart_dev_t *hw)
 {
-    return (!hw->rs485_conf.rx_busy_tx_en &&  hw->rs485_conf.en);
+    return (!hw->rs485_conf.rs485rxby_tx_en &&  hw->rs485_conf.rs485_en);
 }
 
 /**


### PR DESCRIPTION
RS485 support in ESP32-S3 uses different naming for some drivers struct entries. This fix it.