### PR TITLE
spiram: remove unused includes

### DIFF
--- a/components/esp_hw_support/port/esp32/spiram.c
+++ b/components/esp_hw_support/port/esp32/spiram.c
@@ -23,8 +23,6 @@ we add more types of external RAM memory, this can be made into a more intellige
 #include "esp32/spiram.h"
 #include "spiram_psram.h"
 #include "esp_log.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/xtensa_api.h"
 #include "soc/soc.h"
 #if !defined(__ZEPHYR__)
 #include "esp_heap_caps_init.h"

--- a/components/esp_hw_support/port/esp32s2/spiram.c
+++ b/components/esp_hw_support/port/esp32s2/spiram.c
@@ -22,8 +22,6 @@ we add more types of external RAM memory, this can be made into a more intellige
 #include "esp32s2/spiram.h"
 #include "spiram_psram.h"
 #include "esp_log.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/xtensa_api.h"
 #include "soc/soc.h"
 #if !defined(__ZEPHYR__)
 #include "esp_heap_caps_init.h"


### PR DESCRIPTION
This removes FreeRTOS entries that are not used and is currently blocking SPIRAM build.