### PR TITLE
phy: esp32s2: fix build issue

### DIFF
--- a/components/esp_phy/src/phy_init.c
+++ b/components/esp_phy/src/phy_init.c
@@ -296,7 +296,7 @@ void IRAM_ATTR esp_wifi_bt_power_domain_on(void)
     k_mutex_lock(&s_wifi_bt_pd_controller.lock, K_FOREVER);
     if (s_wifi_bt_pd_controller.count++ == 0) {
         CLEAR_PERI_REG_MASK(RTC_CNTL_DIG_PWC_REG, RTC_CNTL_WIFI_FORCE_PD);
-#if !CONFIG_IDF_TARGET_ESP32
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
         SET_PERI_REG_MASK(SYSCON_WIFI_RST_EN_REG, SYSTEM_BB_RST | SYSTEM_FE_RST);
         CLEAR_PERI_REG_MASK(SYSCON_WIFI_RST_EN_REG, SYSTEM_BB_RST | SYSTEM_FE_RST);
 #endif


### PR DESCRIPTION
ESP32-S2 is not able to build due to call to BB reset. This excludes this SOC from that condition.