### PR TITLE
wifi: esp32s2: fix wrong struct definition

### DIFF
--- a/components/esp_wifi/include/esp_private/wifi_os_adapter.h
+++ b/components/esp_wifi/include/esp_private/wifi_os_adapter.h
@@ -77,7 +77,7 @@ typedef struct {
     void (* _wifi_apb80m_release)(void);
     void (* _phy_disable)(void);
     void (* _phy_enable)(void);
-#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+#if CONFIG_IDF_TARGET_ESP32
     void (* _phy_common_clock_enable)(void);
     void (* _phy_common_clock_disable)(void);
 #endif


### PR DESCRIPTION
Wi-Fi sample code is failing due to wrong configuration.