### PR TITLE
components: Fix WIFI_SCAN_TYPE after Zephyr update

### DIFF
--- a/components/esp_wifi/include/esp_wifi_types.h
+++ b/components/esp_wifi/include/esp_wifi_types.h
@@ -105,8 +105,8 @@ typedef enum {
 } wifi_second_chan_t;
 
 typedef enum {
-    WIFI_SCAN_TYPE_ACTIVE = 0,  /**< active scan */
-    WIFI_SCAN_TYPE_PASSIVE,     /**< passive scan */
+    ESP_WIFI_SCAN_TYPE_ACTIVE = 0,  /**< active scan */
+    ESP_WIFI_SCAN_TYPE_PASSIVE,     /**< passive scan */
 } wifi_scan_type_t;
 
 /** @brief Range of active scan times per channel */

--- a/components/wifi_provisioning/src/manager.c
+++ b/components/wifi_provisioning/src/manager.c
@@ -920,13 +920,13 @@ esp_err_t wifi_prov_mgr_wifi_scan_start(bool blocking, bool passive,
     }
 
     if (passive) {
-        prov_ctx->scan_cfg.scan_type = WIFI_SCAN_TYPE_PASSIVE;
+        prov_ctx->scan_cfg.scan_type = ESP_WIFI_SCAN_TYPE_PASSIVE;
 /* We do not recommend scan configuration modification in Wi-Fi and BT coexistence mode */
 #if !CONFIG_BT_ENABLED
         prov_ctx->scan_cfg.scan_time.passive = period_ms;
 #endif
     } else {
-        prov_ctx->scan_cfg.scan_type = WIFI_SCAN_TYPE_ACTIVE;
+        prov_ctx->scan_cfg.scan_type = ESP_WIFI_SCAN_TYPE_ACTIVE;
 /* We do not recommend scan configuration modification in Wi-Fi and BT coexistence mode */
 #if !CONFIG_BT_ENABLED
         prov_ctx->scan_cfg.scan_time.active.min = period_ms;

--- a/components/wpa_supplicant/esp_supplicant/src/esp_scan.c
+++ b/components/wpa_supplicant/esp_supplicant/src/esp_scan.c
@@ -188,9 +188,9 @@ static int issue_scan(struct wpa_supplicant *wpa_s,
 		} else
 
 		if (scan_params->mode == BEACON_REPORT_MODE_PASSIVE) {
-			params->scan_type = WIFI_SCAN_TYPE_PASSIVE;
+			params->scan_type = ESP_WIFI_SCAN_TYPE_PASSIVE;
 		} else {
-			params->scan_type = WIFI_SCAN_TYPE_ACTIVE;
+			params->scan_type = ESP_WIFI_SCAN_TYPE_ACTIVE;
 		}
 
 		if (scan_params->bssid) {


### PR DESCRIPTION
Update the typedef name after Zephyr added the manager feature with the wifi scan type option colliding with the naming used in hal_espressif.