### PR TITLE
utils: rename json enum to allow json-c integration

### DIFF
--- a/components/wpa_supplicant/src/utils/json.c
+++ b/components/wpa_supplicant/src/utils/json.c
@@ -528,7 +528,7 @@ struct wpabuf * json_get_member_base64url(struct json_token *json,
 }
 
 
-static const char * json_type_str(enum json_type type)
+static const char * json_type_str(enum esp_json_type type)
 {
 	switch (type) {
 	case JSON_VALUE:

--- a/components/wpa_supplicant/src/utils/json.h
+++ b/components/wpa_supplicant/src/utils/json.h
@@ -10,7 +10,7 @@
 #define JSON_H
 
 struct json_token {
-	enum json_type {
+	enum esp_json_type {
 		JSON_VALUE,
 		JSON_OBJECT,
 		JSON_ARRAY,


### PR DESCRIPTION
json-c integration in Zephyr uses the same enum label, which causes build error. It is not possible to use only json-c from Zephyr's as functions are not using same name structure.

That would be possible if all wpa-supplicant were re-worked to use jsonc providing in Zephyr upstream.