### PR TITLE
zephyr: esp32/c3/s2: compile power related files for poweroff

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -161,15 +161,17 @@ if(CONFIG_SOC_SERIES_ESP32 OR CONFIG_SOC_SERIES_ESP32_NET)
     ../esp_shared/components/driver/rtc_io.c
     )
 
-  zephyr_sources_ifdef(
-    CONFIG_PM
-    ../esp_shared/components/driver/gpio.c
-    ../esp_shared/components/driver/rtc_io.c
-    ../esp_shared/components/esp_hw_support/sleep_modes.c
-    ../esp_shared/components/esp_pm/pm_impl.c
-    ../../components/esp_hw_support/port/esp32/rtc_sleep.c
-    ../../components/hal/rtc_io_hal.c
+  # FIXME: depending on Zephyr Kconfig options here is wrong
+  if(CONFIG_PM OR CONFIG_POWEROFF)
+    zephyr_sources(
+      ../esp_shared/components/driver/gpio.c
+      ../esp_shared/components/driver/rtc_io.c
+      ../esp_shared/components/esp_hw_support/sleep_modes.c
+      ../esp_shared/components/esp_pm/pm_impl.c
+      ../../components/esp_hw_support/port/esp32/rtc_sleep.c
+      ../../components/hal/rtc_io_hal.c
     )
+  endif()
 
   zephyr_sources_ifdef(
     CONFIG_ADC_ESP32

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -124,15 +124,17 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     ../../components/hal/ledc_hal.c
     )
 
-  zephyr_sources_ifdef(
-    CONFIG_PM
-    ../esp_shared/components/driver/gpio.c
-    ../esp_shared/components/esp_hw_support/sleep_modes.c
-    ../esp_shared/components/esp_pm/pm_impl.c
-    ../../components/esp_hw_support/sleep_retention.c
-    ../../components/esp_system/esp_err.c
-    ../../components/hal/esp32c3/rtc_cntl_hal.c
+  # FIXME: depending on Zephyr Kconfig options here is wrong
+  if(CONFIG_PM OR CONFIG_POWEROFF)
+    zephyr_sources(
+      ../esp_shared/components/driver/gpio.c
+      ../esp_shared/components/esp_hw_support/sleep_modes.c
+      ../esp_shared/components/esp_pm/pm_impl.c
+      ../../components/esp_hw_support/sleep_retention.c
+      ../../components/esp_system/esp_err.c
+      ../../components/hal/esp32c3/rtc_cntl_hal.c
     )
+  endif()
 
   zephyr_sources_ifdef(
     CONFIG_ESP32_TEMP

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -162,16 +162,18 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     src/esp_adc_cal/esp_adc_cal.c
     )
 
-  zephyr_sources_ifdef(
-    CONFIG_PM
-    ../esp_shared/components/driver/gpio.c
-    ../esp_shared/components/driver/rtc_io.c
-    ../esp_shared/components/esp_hw_support/sleep_modes.c
-    ../esp_shared/components/esp_pm/pm_impl.c
-    ../../components/esp_system/port/brownout.c
-    ../../components/hal/esp32s2/brownout_hal.c
-    ../../components/hal/esp32s2/touch_sensor_hal.c
+  # FIXME: depending on Zephyr Kconfig options here is wrong
+  if(CONFIG_PM OR CONFIG_POWEROFF)
+    zephyr_sources(
+      ../esp_shared/components/driver/gpio.c
+      ../esp_shared/components/driver/rtc_io.c
+      ../esp_shared/components/esp_hw_support/sleep_modes.c
+      ../esp_shared/components/esp_pm/pm_impl.c
+      ../../components/esp_system/port/brownout.c
+      ../../components/hal/esp32s2/brownout_hal.c
+      ../../components/hal/esp32s2/touch_sensor_hal.c
     )
+  endif()
 
   zephyr_sources_ifdef(
     CONFIG_ESP32_TEMP


### PR DESCRIPTION
Some functionality guarded with CONFIG_PM is now needed by CONFIG_POWEROFF. While it is wrong to add such dependencies in a HAL, it allows us to move on for now. A fixme note has been added.