### PR TITLE
heap: add SPIRAM heap offset and size

### DIFF
--- a/zephyr/esp_shared/src/common/heap_caps.c
+++ b/zephyr/esp_shared/src/common/heap_caps.c
@@ -29,15 +29,11 @@ STRUCT_SECTION_ITERABLE(k_heap, _internal_heap_1) = {
 #endif
 
 #if defined(CONFIG_ESP_SPIRAM)
-EXT_RAM_ATTR int _spiram_data_start;
+extern char _spiram_heap_start[];
 STRUCT_SECTION_ITERABLE(k_heap, _spiram_heap) = {
     .heap = {
-        .init_mem = &_spiram_data_start,
-#if (CONFIG_ESP_SPIRAM_SIZE <= 0x400000)
-        .init_bytes = CONFIG_ESP_SPIRAM_SIZE,
-#else
-        .init_bytes = 0x400000,
-#endif
+        .init_mem = _spiram_heap_start,
+        .init_bytes = CONFIG_SPIRAM_HEAP_SIZE,
     },
 };
 #endif


### PR DESCRIPTION
The existing heap starts at the beginning of SPIRAM which is also occupied by the WiFi stack if CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM is enabled.  This results in memory corruption.

Update the heap code to use a linker-description symbol _spiram_heap_start for setting the starting point of the SPIRAM heap.

Requires matching change to the .ld files in the Zephyr soc code:  https://github.com/zephyrproject-rtos/zephyr/pull/61365

Fixes: 61359