### PR TITLE
soc: esp32s3: add esp32s3_net series

### DIFF
--- a/components/esp_timer/src/esp_timer_impl_lac.c
+++ b/components/esp_timer/src/esp_timer_impl_lac.c
@@ -37,7 +37,7 @@
 #elif CONFIG_SOC_SERIES_ESP32S2
 #include "esp32s2/rom/rtc.h"
 #include "esp32s2/clk.h"
-#elif CONFIG_SOC_SERIES_ESP32S3
+#elif CONFIG_SOC_SERIES_ESP32S3 || CONFIG_SOC_SERIES_ESP32S3_NET
 #include "esp32s3/rom/rtc.h"
 #include "esp32s3/clk.h"
 #elif CONFIG_SOC_SERIES_ESP32C3

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -8,7 +8,7 @@ if(CONFIG_BT_ESP32 OR CONFIG_WIFI_ESP32)
     list(APPEND LIBRARIES "btdm_app" "rtc")
   endif()
 
-  if(CONFIG_SOC_SERIES_ESP32C3 OR CONFIG_SOC_SERIES_ESP32S3)
+  if(CONFIG_SOC_SERIES_ESP32C3 OR CONFIG_SOC_SERIES_ESP32S3 OR CONFIG_SOC_SERIES_ESP32S3_NET)
     list(APPEND LIBRARIES "btbb" "btdm_app")
   endif()
 
@@ -31,3 +31,4 @@ add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32_NET esp32)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32C3 esp32c3)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32S2 esp32s2)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32S3 esp32s3)
+add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32S3_NET esp32s3)

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_SOC_SERIES_ESP32S3)
+if(CONFIG_SOC_SERIES_ESP32S3 OR CONFIG_SOC_SERIES_ESP32S3_NET)
 
   zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
 
@@ -196,6 +196,12 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       )
   endif()
 
+  if (NOT CONFIG_SOC_SERIES_ESP32S3_NET)
+    zephyr_sources(
+      ../../components/esp_system/port/soc/esp32s3/clk.c
+    )
+  endif()
+
   zephyr_sources(
     ../../components/esp_hw_support/regi2c_ctrl.c
     ../../components/soc/esp32s3/adc_periph.c
@@ -213,7 +219,6 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     ../../components/esp_hw_support/port/esp32s3/rtc_sleep.c
     ../../components/esp_hw_support/mac_addr.c
     ../../components/esp_rom/patches/esp_rom_uart.c
-    ../../components/esp_system/port/soc/esp32s3/clk.c
     ../../components/esp_system/port/soc/esp32s3/reset_reason.c
     ../../components/driver/periph_ctrl.c
     ../../components/hal/cpu_hal.c
@@ -372,11 +377,6 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       mbedTLS
       )
 
-  endif()
-
-  ## Ethernet MAC/PHY definitions
-  if(CONFIG_ESP32_EMAC)
-    zephyr_sources(../../components/hal/emac_hal.c)
   endif()
 
   zephyr_link_libraries_ifdef(CONFIG_NEWLIB_LIBC c)

--- a/zephyr/esp_shared/include/stubs.h
+++ b/zephyr/esp_shared/include/stubs.h
@@ -18,7 +18,7 @@
 
 #if defined(CONFIG_SOC_SERIES_ESP32) || defined(CONFIG_SOC_SERIES_ESP32_NET)
 #define DT_CPU_COMPAT cdns_tensilica_xtensa_lx6
-#elif defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3)
+#elif defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3) || defined(CONFIG_SOC_SERIES_ESP32S3_NET)
 #define DT_CPU_COMPAT cdns_tensilica_xtensa_lx7
 #elif CONFIG_SOC_SERIES_ESP32C3
 #define DT_CPU_COMPAT espressif_riscv


### PR DESCRIPTION
Allows building ESP32-S3 AMP SoC.