### PR TITLE
cmake: load all libc rom functions by default

### DIFF
--- a/components/esp_rom/esp32/ld/esp32.rom.newlib-funcs.ld
+++ b/components/esp_rom/esp32/ld/esp32.rom.newlib-funcs.ld
@@ -14,9 +14,9 @@
 
 abs = 0x40056340;
 __ascii_wctomb = 0x40058ef0;
-atoi = 0x400566c4;
+PROVIDE ( atoi = 0x400566c4 ); /* Zephyr: Keep as PROVIDE symbol */
 _atoi_r = 0x400566d4;
-atol = 0x400566ec;
+PROVIDE ( atol = 0x400566ec ); /* Zephyr: Keep as PROVIDE symbol */
 _atol_r = 0x400566fc;
 bzero = 0x4000c1f4;
 _cleanup = 0x40001df8;
@@ -109,9 +109,9 @@ strspn = 0x4000c648;
 strstr = 0x4000c674;
 __strtok_r = 0x4000c6a8;
 strtok_r = 0x4000c70c;
-strtol = 0x4005681c;
+PROVIDE ( strtol = 0x4005681c ); /* Zephyr: Keep as PROVIDE symbol */
 _strtol_r = 0x40056714;
-strtoul = 0x4005692c;
+PROVIDE ( strtoul = 0x4005692c ); /* Zephyr: Keep as PROVIDE symbol */
 _strtoul_r = 0x40056834;
 strupr = 0x4000174c;
 __submore = 0x40058f3c;

--- a/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld
+++ b/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld
@@ -75,10 +75,14 @@ rand = 0x4000043c;
 srand = 0x40000440;
 utoa = 0x40000444;
 itoa = 0x40000448;
-atoi = 0x4000044c;
-atol = 0x40000450;
-strtol = 0x40000454;
-strtoul = 0x40000458;
+
+/* ZEPHYR: Keep PROVIDE for these symbols: */
+PROVIDE( atoi = 0x4000044c );
+PROVIDE( atol = 0x40000450 );
+PROVIDE( strtol = 0x40000454 );
+PROVIDE( strtoul = 0x40000458 );
+/*******************************************/
+
 PROVIDE( fflush = 0x4000045c );
 PROVIDE( _fflush_r = 0x40000460 );
 PROVIDE( _fwalk = 0x40000464 );

--- a/components/esp_rom/esp32s2/ld/esp32s2.rom.newlib-funcs.ld
+++ b/components/esp_rom/esp32s2/ld/esp32s2.rom.newlib-funcs.ld
@@ -85,7 +85,9 @@ strlcat = 0x40007db8;
 strlcpy = 0x4001adf8;
 strlen = 0x40007e08;
 strlwr = 0x40007e68;
-strncasecmp = 0x40007e94;
+/* ZEPHYR: Keep PROVIDE for this symbol: */
+PROVIDE ( strncasecmp = 0x40007e94 );
+/*****************************************/
 strncat = 0x4001ae34;
 strncmp = 0x4001ae64;
 strncpy = 0x40007f20;

--- a/components/esp_rom/esp32s3/ld/esp32s3.rom.newlib.ld
+++ b/components/esp_rom/esp32s3/ld/esp32s3.rom.newlib.ld
@@ -75,10 +75,14 @@ rand = 0x400014a0;
 srand = 0x400014ac;
 utoa = 0x400014b8;
 itoa = 0x400014c4;
-atoi = 0x400014d0;
-atol = 0x400014dc;
-strtol = 0x400014e8;
-strtoul = 0x400014f4;
+
+/* ZEPHYR: Keep PROVIDE for these symbols: */
+PROVIDE( atoi = 0x400014d0 );
+PROVIDE( atol = 0x400014dc );
+PROVIDE( strtol = 0x400014e8 );
+PROVIDE( strtoul = 0x400014f4 );
+/*******************************************/
+
 PROVIDE( fflush = 0x40001500 );
 PROVIDE( _fflush_r = 0x4000150c );
 PROVIDE( _fwalk = 0x40001518 );

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -73,6 +73,8 @@ if(CONFIG_SOC_SERIES_ESP32 OR CONFIG_SOC_SERIES_ESP32_NET)
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32/ld/esp32.rom.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32/ld/esp32.rom.api.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32/ld/esp32.rom.libgcc.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32/ld/esp32.rom.newlib-data.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32/ld/esp32.rom.newlib-funcs.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/soc/esp32/ld/esp32.peripherals.ld
     )
 

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -75,6 +75,8 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32c3/ld/esp32c3.rom.eco3.ld
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32c3/ld/esp32c3.rom.api.ld
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32c3/ld/esp32c3.rom.libgcc.ld
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32c3/ld/esp32c3.rom.version.ld
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/soc/esp32c3/ld/esp32c3.peripherals.ld
     )
 

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -74,8 +74,10 @@ if(CONFIG_SOC_SERIES_ESP32S2)
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32s2/ld/esp32s2.rom.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32s2/ld/esp32s2.rom.api.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32s2/ld/esp32s2.rom.libgcc.ld
-        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/soc/esp32s2/ld/esp32s2.peripherals.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32s2/ld/esp32s2.rom.newlib-funcs.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32s2/ld/esp32s2.rom.newlib-data.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32s2/ld/esp32s2.rom.spiflash.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/soc/esp32s2/ld/esp32s2.peripherals.ld
       )
 
   zephyr_compile_definitions(ESP_PLATFORM)

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -75,6 +75,8 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32s3/ld/esp32s3.rom.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32s3/ld/esp32s3.rom.api.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32s3/ld/esp32s3.rom.libgcc.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32s3/ld/esp32s3.rom.newlib.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32s3/ld/esp32s3.rom.version.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/soc/esp32s3/ld/esp32s3.peripherals.ld
     )
 


### PR DESCRIPTION
RF libraries expects ROM functions as a form of
compatibility. Using different implementations can cause Wi-Fi/BLE errors/crashes. This PR adds a few libc functions to ESP32 environment.