### PR TITLE
cmake: esp32s3: make clk source code common

### DIFF
--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -201,10 +201,6 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       )
   endif()
 
-  zephyr_sources_ifdef(CONFIG_SOC_ESP32S3
-    ../../components/esp_system/port/soc/esp32s3/clk.c
-    )
-
   zephyr_sources(
     ../../components/esp_hw_support/regi2c_ctrl.c
     ../../components/soc/esp32s3/adc_periph.c
@@ -222,6 +218,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     ../../components/esp_hw_support/port/esp32s3/rtc_sleep.c
     ../../components/esp_hw_support/mac_addr.c
     ../../components/esp_rom/patches/esp_rom_uart.c
+    ../../components/esp_system/port/soc/esp32s3/clk.c
     ../../components/esp_system/port/soc/esp32s3/reset_reason.c
     ../../components/driver/periph_ctrl.c
     ../../components/hal/cpu_hal.c


### PR DESCRIPTION
Initially this was split between procpu and appcpu. Now it can be added as common source.