### PR TITLE
esp32s3: update bootloader to enable all flash memory ranges

### DIFF
--- a/components/bootloader_support/include/esp_app_format.h
+++ b/components/bootloader_support/include/esp_app_format.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <inttypes.h>
+#include "esp_assert.h"
 
 /**
  * @brief ESP chip ID
@@ -21,7 +22,7 @@ typedef enum {
 } __attribute__((packed)) esp_chip_id_t;
 
 /** @cond */
-_Static_assert(sizeof(esp_chip_id_t) == 2, "esp_chip_id_t should be 16 bit");
+ESP_STATIC_ASSERT(sizeof(esp_chip_id_t) == 2, "esp_chip_id_t should be 16 bit");
 /** @endcond */
 
 /**
@@ -55,6 +56,9 @@ typedef enum {
     ESP_IMAGE_FLASH_SIZE_4MB,       /*!< SPI flash size 4 MB */
     ESP_IMAGE_FLASH_SIZE_8MB,       /*!< SPI flash size 8 MB */
     ESP_IMAGE_FLASH_SIZE_16MB,      /*!< SPI flash size 16 MB */
+    ESP_IMAGE_FLASH_SIZE_32MB,      /*!< SPI flash size 32 MB */
+    ESP_IMAGE_FLASH_SIZE_64MB,      /*!< SPI flash size 64 MB */
+    ESP_IMAGE_FLASH_SIZE_128MB,     /*!< SPI flash size 128 MB */
     ESP_IMAGE_FLASH_SIZE_MAX        /*!< SPI flash size MAX */
 } esp_image_flash_size_t;
 
@@ -75,8 +79,15 @@ typedef struct {
                                 * pin and sets this field to 0xEE=disabled) */
     uint8_t spi_pin_drv[3];     /*!< Drive settings for the SPI flash pins (read by ROM bootloader) */
     esp_chip_id_t chip_id;      /*!< Chip identification number */
-    uint8_t min_chip_rev;       /*!< Minimum chip revision supported by image */
-    uint8_t reserved[8];       /*!< Reserved bytes in additional header space, currently unused */
+    uint8_t min_chip_rev;       /*!< Minimal chip revision supported by image
+                                 * After the Major and Minor revision eFuses were introduced into the chips, this field is no longer used.
+                                 * But for compatibility reasons, we keep this field and the data in it.
+                                 * Use min_chip_rev_full instead.
+                                 * The software interprets this as a Major version for most of the chips and as a Minor version for the ESP32-C3.
+                                 */
+    uint16_t min_chip_rev_full; /*!< Minimal chip revision supported by image, in format: major * 100 + minor */
+    uint16_t max_chip_rev_full; /*!< Maximal chip revision supported by image, in format: major * 100 + minor */
+    uint8_t reserved[4];        /*!< Reserved bytes in additional header space, currently unused */
     uint8_t hash_appended;      /*!< If 1, a SHA256 digest "simple hash" (of the entire image) is appended after the checksum.
                                  * Included in image length. This digest
                                  * is separate to secure boot and only used for detecting corruption.
@@ -85,7 +96,7 @@ typedef struct {
 } __attribute__((packed))  esp_image_header_t;
 
 /** @cond */
-_Static_assert(sizeof(esp_image_header_t) == 24, "binary image header should be 24 bytes");
+ESP_STATIC_ASSERT(sizeof(esp_image_header_t) == 24, "binary image header should be 24 bytes");
 /** @endcond */
 
 

--- a/components/bootloader_support/src/esp32s3/bootloader_esp32s3.c
+++ b/components/bootloader_support/src/esp32s3/bootloader_esp32s3.c
@@ -103,6 +103,15 @@ static void update_flash_config(const esp_image_header_t *bootloader_hdr)
     case ESP_IMAGE_FLASH_SIZE_16MB:
         size = 16;
         break;
+    case ESP_IMAGE_FLASH_SIZE_32MB:
+        size = 32;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_64MB:
+        size = 64;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_128MB:
+        size = 128;
+        break;
     default:
         size = 2;
     }
@@ -176,6 +185,15 @@ static void print_flash_info(const esp_image_header_t *bootloader_hdr)
     case ESP_IMAGE_FLASH_SIZE_16MB:
         str = "16MB";
         break;
+    case ESP_IMAGE_FLASH_SIZE_32MB:
+        str = "32MB";
+        break;
+    case ESP_IMAGE_FLASH_SIZE_64MB:
+        str = "64MB";
+        break;
+    case ESP_IMAGE_FLASH_SIZE_128MB:
+        str = "128MB";
+        break;
     default:
         str = "2MB";
         break;
@@ -198,6 +216,11 @@ static esp_err_t bootloader_init_spi_flash(void)
         ESP_LOGE(TAG, "SPI flash pins are overridden. Enable CONFIG_SPI_FLASH_ROM_DRIVER_PATCH in menuconfig");
         return ESP_FAIL;
     }
+#endif
+
+#if CONFIG_SPI_FLASH_HPM_ENABLE
+    // Reset flash, clear volatile bits DC[0:1]. Make it work under default mode to boot.
+    bootloader_spi_flash_reset();
 #endif
 
     bootloader_flash_unlock();
@@ -299,7 +322,7 @@ static void bootloader_super_wdt_auto_feed(void)
 
 static inline void bootloader_ana_reset_config(void)
 {
-    //Enable WDT, BOR, and GLITCH reset
+    //Enable WDT, BOD, and GLITCH reset
     bootloader_ana_super_wdt_reset_config(true);
     bootloader_ana_bod_reset_config(true);
     bootloader_ana_clock_glitch_reset_config(true);

--- a/components/bootloader_support/src/esp32s3/bootloader_soc.c
+++ b/components/bootloader_support/src/esp32s3/bootloader_soc.c
@@ -12,15 +12,15 @@ void bootloader_ana_super_wdt_reset_config(bool enable)
     REG_CLR_BIT(RTC_CNTL_FIB_SEL_REG, RTC_CNTL_FIB_SUPER_WDT_RST);
 
     if (enable) {
-        REG_SET_BIT(RTC_CNTL_SWD_CONF_REG, RTC_CNTL_SWD_BYPASS_RST);
-    } else {
         REG_CLR_BIT(RTC_CNTL_SWD_CONF_REG, RTC_CNTL_SWD_BYPASS_RST);
+    } else {
+        REG_SET_BIT(RTC_CNTL_SWD_CONF_REG, RTC_CNTL_SWD_BYPASS_RST);
     }
 }
 
 void bootloader_ana_bod_reset_config(bool enable)
 {
-    REG_CLR_BIT(RTC_CNTL_FIB_SEL_REG, RTC_CNTL_FIB_BOR_RST);
+    REG_CLR_BIT(RTC_CNTL_FIB_SEL_REG, RTC_CNTL_FIB_BOD_RST);
 
     if (enable) {
         REG_SET_BIT(RTC_CNTL_BROWN_OUT_REG, RTC_CNTL_BROWN_OUT_ANA_RST_EN);

--- a/components/bootloader_support/src/esp32s3/flash_encryption_secure_features.c
+++ b/components/bootloader_support/src/esp32s3/flash_encryption_secure_features.c
@@ -39,7 +39,7 @@ esp_err_t esp_flash_encryption_enable_secure_features(void)
     ESP_LOGW(TAG, "Not disabling JTAG - SECURITY COMPROMISED");
 #endif
 
-    esp_efuse_write_field_bit(ESP_EFUSE_DIS_LEGACY_SPI_BOOT);
+    esp_efuse_write_field_bit(ESP_EFUSE_DIS_DIRECT_BOOT);
 
 #if defined(CONFIG_SECURE_BOOT_V2_ENABLED) && !defined(CONFIG_SECURE_BOOT_V2_ALLOW_EFUSE_RD_DIS)
     // This bit is set when enabling Secure Boot V2, but we can't enable it until this later point in the first boot

--- a/components/bootloader_support/src/esp32s3/secure_boot_secure_features.c
+++ b/components/bootloader_support/src/esp32s3/secure_boot_secure_features.c
@@ -16,7 +16,7 @@ static __attribute__((unused)) const char *TAG = "secure_boot";
 
 esp_err_t esp_secure_boot_enable_secure_features(void)
 {
-    esp_efuse_write_field_bit(ESP_EFUSE_DIS_LEGACY_SPI_BOOT);
+    esp_efuse_write_field_bit(ESP_EFUSE_DIS_DIRECT_BOOT);
 
 #ifdef CONFIG_SECURE_ENABLE_SECURE_ROM_DL_MODE
     ESP_LOGI(TAG, "Enabling Security download mode...");

--- a/components/efuse/esp32s3/esp_efuse_table.c
+++ b/components/efuse/esp32s3/esp_efuse_table.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2017-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2017-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,527 +9,919 @@
 #include <assert.h>
 #include "esp_efuse_table.h"
 
-// md5_digest_table 9444b887379d924049af42806ca71d45
+// md5_digest_table e0674ff40a1e124670c6eecf33410e76
 // This file was generated from the file esp_efuse_table.csv. DO NOT CHANGE THIS FILE MANUALLY.
 // If you want to change some fields, you need to change esp_efuse_table.csv file
 // then run `efuse_common_table` or `efuse_custom_table` command it will generate this file.
 // To show efuse_table run the command 'show_efuse_table'.
 
 static const esp_efuse_desc_t WR_DIS[] = {
-    {EFUSE_BLK0, 0, 32}, 	 // Write protection,
+    {EFUSE_BLK0, 0, 32}, 	 // [] Disable programming of individual eFuses,
 };
 
 static const esp_efuse_desc_t WR_DIS_RD_DIS[] = {
-    {EFUSE_BLK0, 0, 1}, 	 // Write protection for RD_DIS_KEY0 RD_DIS_KEY1 RD_DIS_KEY2 RD_DIS_KEY3 RD_DIS_KEY4 RD_DIS_KEY5 RD_DIS_SYS_DATA_PART2,
+    {EFUSE_BLK0, 0, 1}, 	 // [] wr_dis of RD_DIS,
 };
 
-static const esp_efuse_desc_t WR_DIS_GROUP_1[] = {
-    {EFUSE_BLK0, 2, 1}, 	 // Write protection for DIS_ICACHE DIS_DCACHE DIS_DOWNLOAD_ICACHE DIS_DOWNLOAD_DCACHE DIS_FORCE_DOWNLOAD DIS_USB DIS_CAN SOFT_DIS_JTAG HARD_DIS_JTAG DIS_DOWNLOAD_MANUAL_ENCRYPT,
+static const esp_efuse_desc_t WR_DIS_DIS_ICACHE[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [] wr_dis of DIS_ICACHE,
 };
 
-static const esp_efuse_desc_t WR_DIS_GROUP_2[] = {
-    {EFUSE_BLK0, 3, 1}, 	 // Write protection for VDD_SPI_XPD VDD_SPI_TIEH VDD_SPI_FORCE VDD_SPI_INIT VDD_SPI_DCAP WDT_DELAY_SEL,
+static const esp_efuse_desc_t WR_DIS_DIS_DCACHE[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [] wr_dis of DIS_DCACHE,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_DOWNLOAD_ICACHE[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [] wr_dis of DIS_DOWNLOAD_ICACHE,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_DOWNLOAD_DCACHE[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [] wr_dis of DIS_DOWNLOAD_DCACHE,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_FORCE_DOWNLOAD[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [] wr_dis of DIS_FORCE_DOWNLOAD,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_USB_OTG[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [WR_DIS.DIS_USB] wr_dis of DIS_USB_OTG,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_TWAI[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [WR_DIS.DIS_CAN] wr_dis of DIS_TWAI,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_APP_CPU[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [] wr_dis of DIS_APP_CPU,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_PAD_JTAG[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [WR_DIS.HARD_DIS_JTAG] wr_dis of DIS_PAD_JTAG,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_DOWNLOAD_MANUAL_ENCRYPT[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [] wr_dis of DIS_DOWNLOAD_MANUAL_ENCRYPT,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_USB_JTAG[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [] wr_dis of DIS_USB_JTAG,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_USB_SERIAL_JTAG[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [WR_DIS.DIS_USB_DEVICE] wr_dis of DIS_USB_SERIAL_JTAG,
+};
+
+static const esp_efuse_desc_t WR_DIS_STRAP_JTAG_SEL[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [] wr_dis of STRAP_JTAG_SEL,
+};
+
+static const esp_efuse_desc_t WR_DIS_USB_PHY_SEL[] = {
+    {EFUSE_BLK0, 2, 1}, 	 // [] wr_dis of USB_PHY_SEL,
+};
+
+static const esp_efuse_desc_t WR_DIS_VDD_SPI_XPD[] = {
+    {EFUSE_BLK0, 3, 1}, 	 // [] wr_dis of VDD_SPI_XPD,
+};
+
+static const esp_efuse_desc_t WR_DIS_VDD_SPI_TIEH[] = {
+    {EFUSE_BLK0, 3, 1}, 	 // [] wr_dis of VDD_SPI_TIEH,
+};
+
+static const esp_efuse_desc_t WR_DIS_VDD_SPI_FORCE[] = {
+    {EFUSE_BLK0, 3, 1}, 	 // [] wr_dis of VDD_SPI_FORCE,
+};
+
+static const esp_efuse_desc_t WR_DIS_WDT_DELAY_SEL[] = {
+    {EFUSE_BLK0, 3, 1}, 	 // [] wr_dis of WDT_DELAY_SEL,
 };
 
 static const esp_efuse_desc_t WR_DIS_SPI_BOOT_CRYPT_CNT[] = {
-    {EFUSE_BLK0, 4, 1}, 	 // Write protection for SPI_BOOT_CRYPT_CNT,
+    {EFUSE_BLK0, 4, 1}, 	 // [] wr_dis of SPI_BOOT_CRYPT_CNT,
 };
 
 static const esp_efuse_desc_t WR_DIS_SECURE_BOOT_KEY_REVOKE0[] = {
-    {EFUSE_BLK0, 5, 1}, 	 // Write protection for SECURE_BOOT_KEY_REVOKE0,
+    {EFUSE_BLK0, 5, 1}, 	 // [] wr_dis of SECURE_BOOT_KEY_REVOKE0,
 };
 
 static const esp_efuse_desc_t WR_DIS_SECURE_BOOT_KEY_REVOKE1[] = {
-    {EFUSE_BLK0, 6, 1}, 	 // Write protection for SECURE_BOOT_KEY_REVOKE1,
+    {EFUSE_BLK0, 6, 1}, 	 // [] wr_dis of SECURE_BOOT_KEY_REVOKE1,
 };
 
 static const esp_efuse_desc_t WR_DIS_SECURE_BOOT_KEY_REVOKE2[] = {
-    {EFUSE_BLK0, 7, 1}, 	 // Write protection for SECURE_BOOT_KEY_REVOKE2,
+    {EFUSE_BLK0, 7, 1}, 	 // [] wr_dis of SECURE_BOOT_KEY_REVOKE2,
 };
 
-static const esp_efuse_desc_t WR_DIS_KEY0_PURPOSE[] = {
-    {EFUSE_BLK0, 8, 1}, 	 // Write protection for key_purpose. KEY0,
+static const esp_efuse_desc_t WR_DIS_KEY_PURPOSE_0[] = {
+    {EFUSE_BLK0, 8, 1}, 	 // [WR_DIS.KEY0_PURPOSE] wr_dis of KEY_PURPOSE_0,
 };
 
-static const esp_efuse_desc_t WR_DIS_KEY1_PURPOSE[] = {
-    {EFUSE_BLK0, 9, 1}, 	 // Write protection for key_purpose. KEY1,
+static const esp_efuse_desc_t WR_DIS_KEY_PURPOSE_1[] = {
+    {EFUSE_BLK0, 9, 1}, 	 // [WR_DIS.KEY1_PURPOSE] wr_dis of KEY_PURPOSE_1,
 };
 
-static const esp_efuse_desc_t WR_DIS_KEY2_PURPOSE[] = {
-    {EFUSE_BLK0, 10, 1}, 	 // Write protection for key_purpose. KEY2,
+static const esp_efuse_desc_t WR_DIS_KEY_PURPOSE_2[] = {
+    {EFUSE_BLK0, 10, 1}, 	 // [WR_DIS.KEY2_PURPOSE] wr_dis of KEY_PURPOSE_2,
 };
 
-static const esp_efuse_desc_t WR_DIS_KEY3_PURPOSE[] = {
-    {EFUSE_BLK0, 11, 1}, 	 // Write protection for key_purpose. KEY3,
+static const esp_efuse_desc_t WR_DIS_KEY_PURPOSE_3[] = {
+    {EFUSE_BLK0, 11, 1}, 	 // [WR_DIS.KEY3_PURPOSE] wr_dis of KEY_PURPOSE_3,
 };
 
-static const esp_efuse_desc_t WR_DIS_KEY4_PURPOSE[] = {
-    {EFUSE_BLK0, 12, 1}, 	 // Write protection for key_purpose. KEY4,
+static const esp_efuse_desc_t WR_DIS_KEY_PURPOSE_4[] = {
+    {EFUSE_BLK0, 12, 1}, 	 // [WR_DIS.KEY4_PURPOSE] wr_dis of KEY_PURPOSE_4,
 };
 
-static const esp_efuse_desc_t WR_DIS_KEY5_PURPOSE[] = {
-    {EFUSE_BLK0, 13, 1}, 	 // Write protection for key_purpose. KEY5,
+static const esp_efuse_desc_t WR_DIS_KEY_PURPOSE_5[] = {
+    {EFUSE_BLK0, 13, 1}, 	 // [WR_DIS.KEY5_PURPOSE] wr_dis of KEY_PURPOSE_5,
 };
 
 static const esp_efuse_desc_t WR_DIS_SECURE_BOOT_EN[] = {
-    {EFUSE_BLK0, 15, 1}, 	 // Write protection for SECURE_BOOT_EN,
+    {EFUSE_BLK0, 15, 1}, 	 // [] wr_dis of SECURE_BOOT_EN,
 };
 
 static const esp_efuse_desc_t WR_DIS_SECURE_BOOT_AGGRESSIVE_REVOKE[] = {
-    {EFUSE_BLK0, 16, 1}, 	 // Write protection for SECURE_BOOT_AGGRESSIVE_REVOKE,
+    {EFUSE_BLK0, 16, 1}, 	 // [] wr_dis of SECURE_BOOT_AGGRESSIVE_REVOKE,
 };
 
-static const esp_efuse_desc_t WR_DIS_GROUP_3[] = {
-    {EFUSE_BLK0, 18, 1}, 	 // Write protection for FLASH_TPUW DIS_DOWNLOAD_MODE DIS_LEGACY_SPI_BOOT UART_PRINT_CHANNEL DIS_USB_DOWNLOAD_MODE ENABLE_SECURITY_DOWNLOAD UART_PRINT_CONTROL PIN_POWER_SELECTION FLASH_TYPE FORCE_SEND_RESUME SECURE_VERSION,
+static const esp_efuse_desc_t WR_DIS_FLASH_TPUW[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [] wr_dis of FLASH_TPUW,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_DOWNLOAD_MODE[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [] wr_dis of DIS_DOWNLOAD_MODE,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_DIRECT_BOOT[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [WR_DIS.DIS_LEGACY_SPI_BOOT] wr_dis of DIS_DIRECT_BOOT,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_USB_SERIAL_JTAG_ROM_PRINT[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [WR_DIS.UART_PRINT_CHANNEL] wr_dis of DIS_USB_SERIAL_JTAG_ROM_PRINT,
+};
+
+static const esp_efuse_desc_t WR_DIS_FLASH_ECC_MODE[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [] wr_dis of FLASH_ECC_MODE,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [WR_DIS.DIS_USB_DOWNLOAD_MODE] wr_dis of DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE,
+};
+
+static const esp_efuse_desc_t WR_DIS_ENABLE_SECURITY_DOWNLOAD[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [] wr_dis of ENABLE_SECURITY_DOWNLOAD,
+};
+
+static const esp_efuse_desc_t WR_DIS_UART_PRINT_CONTROL[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [] wr_dis of UART_PRINT_CONTROL,
+};
+
+static const esp_efuse_desc_t WR_DIS_PIN_POWER_SELECTION[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [] wr_dis of PIN_POWER_SELECTION,
+};
+
+static const esp_efuse_desc_t WR_DIS_FLASH_TYPE[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [] wr_dis of FLASH_TYPE,
+};
+
+static const esp_efuse_desc_t WR_DIS_FLASH_PAGE_SIZE[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [] wr_dis of FLASH_PAGE_SIZE,
+};
+
+static const esp_efuse_desc_t WR_DIS_FLASH_ECC_EN[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [] wr_dis of FLASH_ECC_EN,
+};
+
+static const esp_efuse_desc_t WR_DIS_FORCE_SEND_RESUME[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [] wr_dis of FORCE_SEND_RESUME,
+};
+
+static const esp_efuse_desc_t WR_DIS_SECURE_VERSION[] = {
+    {EFUSE_BLK0, 18, 1}, 	 // [] wr_dis of SECURE_VERSION,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIS_USB_OTG_DOWNLOAD_MODE[] = {
+    {EFUSE_BLK0, 19, 1}, 	 // [] wr_dis of DIS_USB_OTG_DOWNLOAD_MODE,
+};
+
+static const esp_efuse_desc_t WR_DIS_DISABLE_WAFER_VERSION_MAJOR[] = {
+    {EFUSE_BLK0, 19, 1}, 	 // [] wr_dis of DISABLE_WAFER_VERSION_MAJOR,
+};
+
+static const esp_efuse_desc_t WR_DIS_DISABLE_BLK_VERSION_MAJOR[] = {
+    {EFUSE_BLK0, 19, 1}, 	 // [] wr_dis of DISABLE_BLK_VERSION_MAJOR,
 };
 
 static const esp_efuse_desc_t WR_DIS_BLK1[] = {
-    {EFUSE_BLK0, 20, 1}, 	 // Write protection for EFUSE_BLK1.  MAC_SPI_8M_SYS,
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of BLOCK1,
+};
+
+static const esp_efuse_desc_t WR_DIS_MAC[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [WR_DIS.MAC_FACTORY] wr_dis of MAC,
+};
+
+static const esp_efuse_desc_t WR_DIS_SPI_PAD_CONFIG_CLK[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of SPI_PAD_CONFIG_CLK,
+};
+
+static const esp_efuse_desc_t WR_DIS_SPI_PAD_CONFIG_Q[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of SPI_PAD_CONFIG_Q,
+};
+
+static const esp_efuse_desc_t WR_DIS_SPI_PAD_CONFIG_D[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of SPI_PAD_CONFIG_D,
+};
+
+static const esp_efuse_desc_t WR_DIS_SPI_PAD_CONFIG_CS[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of SPI_PAD_CONFIG_CS,
+};
+
+static const esp_efuse_desc_t WR_DIS_SPI_PAD_CONFIG_HD[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of SPI_PAD_CONFIG_HD,
+};
+
+static const esp_efuse_desc_t WR_DIS_SPI_PAD_CONFIG_WP[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of SPI_PAD_CONFIG_WP,
+};
+
+static const esp_efuse_desc_t WR_DIS_SPI_PAD_CONFIG_DQS[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of SPI_PAD_CONFIG_DQS,
+};
+
+static const esp_efuse_desc_t WR_DIS_SPI_PAD_CONFIG_D4[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of SPI_PAD_CONFIG_D4,
+};
+
+static const esp_efuse_desc_t WR_DIS_SPI_PAD_CONFIG_D5[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of SPI_PAD_CONFIG_D5,
+};
+
+static const esp_efuse_desc_t WR_DIS_SPI_PAD_CONFIG_D6[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of SPI_PAD_CONFIG_D6,
+};
+
+static const esp_efuse_desc_t WR_DIS_SPI_PAD_CONFIG_D7[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of SPI_PAD_CONFIG_D7,
+};
+
+static const esp_efuse_desc_t WR_DIS_WAFER_VERSION_MINOR_LO[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of WAFER_VERSION_MINOR_LO,
+};
+
+static const esp_efuse_desc_t WR_DIS_PKG_VERSION[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of PKG_VERSION,
+};
+
+static const esp_efuse_desc_t WR_DIS_BLK_VERSION_MINOR[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of BLK_VERSION_MINOR,
+};
+
+static const esp_efuse_desc_t WR_DIS_FLASH_CAP[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of FLASH_CAP,
+};
+
+static const esp_efuse_desc_t WR_DIS_FLASH_TEMP[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of FLASH_TEMP,
+};
+
+static const esp_efuse_desc_t WR_DIS_FLASH_VENDOR[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of FLASH_VENDOR,
+};
+
+static const esp_efuse_desc_t WR_DIS_PSRAM_CAP[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of PSRAM_CAP,
+};
+
+static const esp_efuse_desc_t WR_DIS_PSRAM_TEMP[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of PSRAM_TEMP,
+};
+
+static const esp_efuse_desc_t WR_DIS_PSRAM_VENDOR[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of PSRAM_VENDOR,
+};
+
+static const esp_efuse_desc_t WR_DIS_K_RTC_LDO[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of K_RTC_LDO,
+};
+
+static const esp_efuse_desc_t WR_DIS_K_DIG_LDO[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of K_DIG_LDO,
+};
+
+static const esp_efuse_desc_t WR_DIS_V_RTC_DBIAS20[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of V_RTC_DBIAS20,
+};
+
+static const esp_efuse_desc_t WR_DIS_V_DIG_DBIAS20[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of V_DIG_DBIAS20,
+};
+
+static const esp_efuse_desc_t WR_DIS_DIG_DBIAS_HVT[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of DIG_DBIAS_HVT,
+};
+
+static const esp_efuse_desc_t WR_DIS_WAFER_VERSION_MINOR_HI[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of WAFER_VERSION_MINOR_HI,
+};
+
+static const esp_efuse_desc_t WR_DIS_WAFER_VERSION_MAJOR[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of WAFER_VERSION_MAJOR,
+};
+
+static const esp_efuse_desc_t WR_DIS_ADC2_CAL_VOL_ATTEN3[] = {
+    {EFUSE_BLK0, 20, 1}, 	 // [] wr_dis of ADC2_CAL_VOL_ATTEN3,
 };
 
 static const esp_efuse_desc_t WR_DIS_SYS_DATA_PART1[] = {
-    {EFUSE_BLK0, 21, 1}, 	 // Write protection for EFUSE_BLK2.  SYS_DATA_PART1,
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of BLOCK2,
 };
 
-static const esp_efuse_desc_t WR_DIS_USER_DATA[] = {
-    {EFUSE_BLK0, 22, 1}, 	 // Write protection for EFUSE_BLK3.  USER_DATA,
+static const esp_efuse_desc_t WR_DIS_OPTIONAL_UNIQUE_ID[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of OPTIONAL_UNIQUE_ID,
 };
 
-static const esp_efuse_desc_t WR_DIS_KEY0[] = {
-    {EFUSE_BLK0, 23, 1}, 	 // Write protection for EFUSE_BLK4.  KEY0,
+static const esp_efuse_desc_t WR_DIS_BLK_VERSION_MAJOR[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of BLK_VERSION_MAJOR,
 };
 
-static const esp_efuse_desc_t WR_DIS_KEY1[] = {
-    {EFUSE_BLK0, 24, 1}, 	 // Write protection for EFUSE_BLK5.  KEY1,
+static const esp_efuse_desc_t WR_DIS_TEMP_CALIB[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of TEMP_CALIB,
 };
 
-static const esp_efuse_desc_t WR_DIS_KEY2[] = {
-    {EFUSE_BLK0, 25, 1}, 	 // Write protection for EFUSE_BLK6.  KEY2,
+static const esp_efuse_desc_t WR_DIS_OCODE[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of OCODE,
 };
 
-static const esp_efuse_desc_t WR_DIS_KEY3[] = {
-    {EFUSE_BLK0, 26, 1}, 	 // Write protection for EFUSE_BLK7.  KEY3,
+static const esp_efuse_desc_t WR_DIS_ADC1_INIT_CODE_ATTEN0[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC1_INIT_CODE_ATTEN0,
 };
 
-static const esp_efuse_desc_t WR_DIS_KEY4[] = {
-    {EFUSE_BLK0, 27, 1}, 	 // Write protection for EFUSE_BLK8.  KEY4,
+static const esp_efuse_desc_t WR_DIS_ADC1_INIT_CODE_ATTEN1[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC1_INIT_CODE_ATTEN1,
 };
 
-static const esp_efuse_desc_t WR_DIS_KEY5[] = {
-    {EFUSE_BLK0, 28, 1}, 	 // Write protection for EFUSE_BLK9.  KEY5,
+static const esp_efuse_desc_t WR_DIS_ADC1_INIT_CODE_ATTEN2[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC1_INIT_CODE_ATTEN2,
 };
 
-static const esp_efuse_desc_t WR_DIS_SYS_DATA_PART2[] = {
-    {EFUSE_BLK0, 29, 1}, 	 // Write protection for EFUSE_BLK10. SYS_DATA_PART2,
+static const esp_efuse_desc_t WR_DIS_ADC1_INIT_CODE_ATTEN3[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC1_INIT_CODE_ATTEN3,
+};
+
+static const esp_efuse_desc_t WR_DIS_ADC2_INIT_CODE_ATTEN0[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC2_INIT_CODE_ATTEN0,
+};
+
+static const esp_efuse_desc_t WR_DIS_ADC2_INIT_CODE_ATTEN1[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC2_INIT_CODE_ATTEN1,
+};
+
+static const esp_efuse_desc_t WR_DIS_ADC2_INIT_CODE_ATTEN2[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC2_INIT_CODE_ATTEN2,
+};
+
+static const esp_efuse_desc_t WR_DIS_ADC2_INIT_CODE_ATTEN3[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC2_INIT_CODE_ATTEN3,
+};
+
+static const esp_efuse_desc_t WR_DIS_ADC1_CAL_VOL_ATTEN0[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC1_CAL_VOL_ATTEN0,
+};
+
+static const esp_efuse_desc_t WR_DIS_ADC1_CAL_VOL_ATTEN1[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC1_CAL_VOL_ATTEN1,
+};
+
+static const esp_efuse_desc_t WR_DIS_ADC1_CAL_VOL_ATTEN2[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC1_CAL_VOL_ATTEN2,
+};
+
+static const esp_efuse_desc_t WR_DIS_ADC1_CAL_VOL_ATTEN3[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC1_CAL_VOL_ATTEN3,
+};
+
+static const esp_efuse_desc_t WR_DIS_ADC2_CAL_VOL_ATTEN0[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC2_CAL_VOL_ATTEN0,
+};
+
+static const esp_efuse_desc_t WR_DIS_ADC2_CAL_VOL_ATTEN1[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC2_CAL_VOL_ATTEN1,
+};
+
+static const esp_efuse_desc_t WR_DIS_ADC2_CAL_VOL_ATTEN2[] = {
+    {EFUSE_BLK0, 21, 1}, 	 // [] wr_dis of ADC2_CAL_VOL_ATTEN2,
+};
+
+static const esp_efuse_desc_t WR_DIS_BLOCK_USR_DATA[] = {
+    {EFUSE_BLK0, 22, 1}, 	 // [WR_DIS.USER_DATA] wr_dis of BLOCK_USR_DATA,
+};
+
+static const esp_efuse_desc_t WR_DIS_CUSTOM_MAC[] = {
+    {EFUSE_BLK0, 22, 1}, 	 // [WR_DIS.MAC_CUSTOM WR_DIS.USER_DATA_MAC_CUSTOM] wr_dis of CUSTOM_MAC,
+};
+
+static const esp_efuse_desc_t WR_DIS_BLOCK_KEY0[] = {
+    {EFUSE_BLK0, 23, 1}, 	 // [WR_DIS.KEY0] wr_dis of BLOCK_KEY0,
+};
+
+static const esp_efuse_desc_t WR_DIS_BLOCK_KEY1[] = {
+    {EFUSE_BLK0, 24, 1}, 	 // [WR_DIS.KEY1] wr_dis of BLOCK_KEY1,
+};
+
+static const esp_efuse_desc_t WR_DIS_BLOCK_KEY2[] = {
+    {EFUSE_BLK0, 25, 1}, 	 // [WR_DIS.KEY2] wr_dis of BLOCK_KEY2,
+};
+
+static const esp_efuse_desc_t WR_DIS_BLOCK_KEY3[] = {
+    {EFUSE_BLK0, 26, 1}, 	 // [WR_DIS.KEY3] wr_dis of BLOCK_KEY3,
+};
+
+static const esp_efuse_desc_t WR_DIS_BLOCK_KEY4[] = {
+    {EFUSE_BLK0, 27, 1}, 	 // [WR_DIS.KEY4] wr_dis of BLOCK_KEY4,
+};
+
+static const esp_efuse_desc_t WR_DIS_BLOCK_KEY5[] = {
+    {EFUSE_BLK0, 28, 1}, 	 // [WR_DIS.KEY5] wr_dis of BLOCK_KEY5,
+};
+
+static const esp_efuse_desc_t WR_DIS_BLOCK_SYS_DATA2[] = {
+    {EFUSE_BLK0, 29, 1}, 	 // [WR_DIS.SYS_DATA_PART2] wr_dis of BLOCK_SYS_DATA2,
 };
 
 static const esp_efuse_desc_t WR_DIS_USB_EXCHG_PINS[] = {
-    {EFUSE_BLK0, 30, 1}, 	 // Write protection for USB_EXCHG_PINS,
+    {EFUSE_BLK0, 30, 1}, 	 // [] wr_dis of USB_EXCHG_PINS,
+};
+
+static const esp_efuse_desc_t WR_DIS_USB_EXT_PHY_ENABLE[] = {
+    {EFUSE_BLK0, 30, 1}, 	 // [WR_DIS.EXT_PHY_ENABLE] wr_dis of USB_EXT_PHY_ENABLE,
+};
+
+static const esp_efuse_desc_t WR_DIS_SOFT_DIS_JTAG[] = {
+    {EFUSE_BLK0, 31, 1}, 	 // [] wr_dis of SOFT_DIS_JTAG,
 };
 
 static const esp_efuse_desc_t RD_DIS[] = {
-    {EFUSE_BLK0, 32, 7}, 	 // Read protection,
+    {EFUSE_BLK0, 32, 7}, 	 // [] Disable reading from BlOCK4-10,
 };
 
-static const esp_efuse_desc_t RD_DIS_KEY0[] = {
-    {EFUSE_BLK0, 32, 1}, 	 // Read protection for EFUSE_BLK4.  KEY0,
+static const esp_efuse_desc_t RD_DIS_BLOCK_KEY0[] = {
+    {EFUSE_BLK0, 32, 1}, 	 // [RD_DIS.KEY0] rd_dis of BLOCK_KEY0,
 };
 
-static const esp_efuse_desc_t RD_DIS_KEY1[] = {
-    {EFUSE_BLK0, 33, 1}, 	 // Read protection for EFUSE_BLK5.  KEY1,
+static const esp_efuse_desc_t RD_DIS_BLOCK_KEY1[] = {
+    {EFUSE_BLK0, 33, 1}, 	 // [RD_DIS.KEY1] rd_dis of BLOCK_KEY1,
 };
 
-static const esp_efuse_desc_t RD_DIS_KEY2[] = {
-    {EFUSE_BLK0, 34, 1}, 	 // Read protection for EFUSE_BLK6.  KEY2,
+static const esp_efuse_desc_t RD_DIS_BLOCK_KEY2[] = {
+    {EFUSE_BLK0, 34, 1}, 	 // [RD_DIS.KEY2] rd_dis of BLOCK_KEY2,
 };
 
-static const esp_efuse_desc_t RD_DIS_KEY3[] = {
-    {EFUSE_BLK0, 35, 1}, 	 // Read protection for EFUSE_BLK7.  KEY3,
+static const esp_efuse_desc_t RD_DIS_BLOCK_KEY3[] = {
+    {EFUSE_BLK0, 35, 1}, 	 // [RD_DIS.KEY3] rd_dis of BLOCK_KEY3,
 };
 
-static const esp_efuse_desc_t RD_DIS_KEY4[] = {
-    {EFUSE_BLK0, 36, 1}, 	 // Read protection for EFUSE_BLK8.  KEY4,
+static const esp_efuse_desc_t RD_DIS_BLOCK_KEY4[] = {
+    {EFUSE_BLK0, 36, 1}, 	 // [RD_DIS.KEY4] rd_dis of BLOCK_KEY4,
 };
 
-static const esp_efuse_desc_t RD_DIS_KEY5[] = {
-    {EFUSE_BLK0, 37, 1}, 	 // Read protection for EFUSE_BLK9.  KEY5,
+static const esp_efuse_desc_t RD_DIS_BLOCK_KEY5[] = {
+    {EFUSE_BLK0, 37, 1}, 	 // [RD_DIS.KEY5] rd_dis of BLOCK_KEY5,
 };
 
-static const esp_efuse_desc_t RD_DIS_SYS_DATA_PART2[] = {
-    {EFUSE_BLK0, 38, 1}, 	 // Read protection for EFUSE_BLK10. SYS_DATA_PART2,
+static const esp_efuse_desc_t RD_DIS_BLOCK_SYS_DATA2[] = {
+    {EFUSE_BLK0, 38, 1}, 	 // [RD_DIS.SYS_DATA_PART2] rd_dis of BLOCK_SYS_DATA2,
 };
 
 static const esp_efuse_desc_t DIS_ICACHE[] = {
-    {EFUSE_BLK0, 40, 1}, 	 // Disable Icache,
+    {EFUSE_BLK0, 40, 1}, 	 // [] Set this bit to disable Icache,
 };
 
 static const esp_efuse_desc_t DIS_DCACHE[] = {
-    {EFUSE_BLK0, 41, 1}, 	 // Disable Dcace,
+    {EFUSE_BLK0, 41, 1}, 	 // [] Set this bit to disable Dcache,
 };
 
 static const esp_efuse_desc_t DIS_DOWNLOAD_ICACHE[] = {
-    {EFUSE_BLK0, 42, 1}, 	 // Disable Icache in download mode include boot_mode 0 1 2 3 6 7,
+    {EFUSE_BLK0, 42, 1}, 	 // [] Set this bit to disable Icache in download mode (boot_mode[3:0] is 0; 1; 2; 3; 6; 7),
 };
 
 static const esp_efuse_desc_t DIS_DOWNLOAD_DCACHE[] = {
-    {EFUSE_BLK0, 43, 1}, 	 // Disable Dcache in download mode include boot_mode 0 1 2 3 6 7,
+    {EFUSE_BLK0, 43, 1}, 	 // [] Set this bit to disable Dcache in download mode ( boot_mode[3:0] is 0; 1; 2; 3; 6; 7),
 };
 
 static const esp_efuse_desc_t DIS_FORCE_DOWNLOAD[] = {
-    {EFUSE_BLK0, 44, 1}, 	 // Disable force chip go to download mode function,
+    {EFUSE_BLK0, 44, 1}, 	 // [] Set this bit to disable the function that forces chip into download mode,
 };
 
-static const esp_efuse_desc_t DIS_USB[] = {
-    {EFUSE_BLK0, 45, 1}, 	 // Disable USB function,
+static const esp_efuse_desc_t DIS_USB_OTG[] = {
+    {EFUSE_BLK0, 45, 1}, 	 // [DIS_USB] Set this bit to disable USB function,
 };
 
-static const esp_efuse_desc_t DIS_CAN[] = {
-    {EFUSE_BLK0, 46, 1}, 	 // Disable CAN function,
+static const esp_efuse_desc_t DIS_TWAI[] = {
+    {EFUSE_BLK0, 46, 1}, 	 // [DIS_CAN] Set this bit to disable CAN function,
 };
 
 static const esp_efuse_desc_t DIS_APP_CPU[] = {
-    {EFUSE_BLK0, 47, 1}, 	 // Disables APP CPU,
+    {EFUSE_BLK0, 47, 1}, 	 // [] Disable app cpu,
 };
 
 static const esp_efuse_desc_t SOFT_DIS_JTAG[] = {
-    {EFUSE_BLK0, 48, 3}, 	 // Software disables JTAG by programming odd number of 1 bit(s). JTAG can be re-enabled via HMAC peripheral,
+    {EFUSE_BLK0, 48, 3}, 	 // [] Set these bits to disable JTAG in the soft way (odd number 1 means disable ). JTAG can be enabled in HMAC module,
 };
 
-static const esp_efuse_desc_t HARD_DIS_JTAG[] = {
-    {EFUSE_BLK0, 51, 1}, 	 // Hardware disable jtag permanently disable jtag function,
+static const esp_efuse_desc_t DIS_PAD_JTAG[] = {
+    {EFUSE_BLK0, 51, 1}, 	 // [HARD_DIS_JTAG] Set this bit to disable JTAG in the hard way. JTAG is disabled permanently,
 };
 
 static const esp_efuse_desc_t DIS_DOWNLOAD_MANUAL_ENCRYPT[] = {
-    {EFUSE_BLK0, 52, 1}, 	 // Disable flash encrypt function,
+    {EFUSE_BLK0, 52, 1}, 	 // [] Set this bit to disable flash encryption when in download boot modes,
 };
 
 static const esp_efuse_desc_t USB_EXCHG_PINS[] = {
-    {EFUSE_BLK0, 57, 1}, 	 // Exchange D+ D- pins,
+    {EFUSE_BLK0, 57, 1}, 	 // [] Set this bit to exchange USB D+ and D- pins,
 };
 
 static const esp_efuse_desc_t USB_EXT_PHY_ENABLE[] = {
-    {EFUSE_BLK0, 58, 1}, 	 // Enable external PHY,
-};
-
-static const esp_efuse_desc_t BTLC_GPIO_ENABLE[] = {
-    {EFUSE_BLK0, 59, 2}, 	 // Enables BTLC GPIO,
+    {EFUSE_BLK0, 58, 1}, 	 // [EXT_PHY_ENABLE] Set this bit to enable external PHY,
 };
 
 static const esp_efuse_desc_t VDD_SPI_XPD[] = {
-    {EFUSE_BLK0, 68, 1}, 	 // VDD_SPI regulator power up,
+    {EFUSE_BLK0, 68, 1}, 	 // [] SPI regulator power up signal,
 };
 
 static const esp_efuse_desc_t VDD_SPI_TIEH[] = {
-    {EFUSE_BLK0, 69, 1}, 	 // VDD_SPI regulator tie high to vdda,
+    {EFUSE_BLK0, 69, 1}, 	 // [] If VDD_SPI_FORCE is 1; determines VDD_SPI voltage {0: "VDD_SPI connects to 1.8 V LDO"; 1: "VDD_SPI connects to VDD3P3_RTC_IO"},
 };
 
 static const esp_efuse_desc_t VDD_SPI_FORCE[] = {
-    {EFUSE_BLK0, 70, 1}, 	 // Force using eFuse configuration of VDD_SPI,
+    {EFUSE_BLK0, 70, 1}, 	 // [] Set this bit and force to use the configuration of eFuse to configure VDD_SPI,
 };
 
 static const esp_efuse_desc_t WDT_DELAY_SEL[] = {
-    {EFUSE_BLK0, 80, 2}, 	 // Select RTC WDT time out threshold,
+    {EFUSE_BLK0, 80, 2}, 	 // [] RTC watchdog timeout threshold; in unit of slow clock cycle {0: "40000"; 1: "80000"; 2: "160000"; 3: "320000"},
 };
 
 static const esp_efuse_desc_t SPI_BOOT_CRYPT_CNT[] = {
-    {EFUSE_BLK0, 82, 3}, 	 // SPI boot encrypt decrypt enable. odd number 1 enable. even number 1 disable,
+    {EFUSE_BLK0, 82, 3}, 	 // [] Enables flash encryption when 1 or 3 bits are set and disabled otherwise {0: "Disable"; 1: "Enable"; 3: "Disable"; 7: "Enable"},
 };
 
 static const esp_efuse_desc_t SECURE_BOOT_KEY_REVOKE0[] = {
-    {EFUSE_BLK0, 85, 1}, 	 // Enable revoke first secure boot key,
+    {EFUSE_BLK0, 85, 1}, 	 // [] Revoke 1st secure boot key,
 };
 
 static const esp_efuse_desc_t SECURE_BOOT_KEY_REVOKE1[] = {
-    {EFUSE_BLK0, 86, 1}, 	 // Enable revoke second secure boot key,
+    {EFUSE_BLK0, 86, 1}, 	 // [] Revoke 2nd secure boot key,
 };
 
 static const esp_efuse_desc_t SECURE_BOOT_KEY_REVOKE2[] = {
-    {EFUSE_BLK0, 87, 1}, 	 // Enable revoke third secure boot key,
+    {EFUSE_BLK0, 87, 1}, 	 // [] Revoke 3rd secure boot key,
 };
 
 static const esp_efuse_desc_t KEY_PURPOSE_0[] = {
-    {EFUSE_BLK0, 88, 4}, 	 // Key0 purpose,
+    {EFUSE_BLK0, 88, 4}, 	 // [KEY0_PURPOSE] Purpose of Key0,
 };
 
 static const esp_efuse_desc_t KEY_PURPOSE_1[] = {
-    {EFUSE_BLK0, 92, 4}, 	 // Key1 purpose,
+    {EFUSE_BLK0, 92, 4}, 	 // [KEY1_PURPOSE] Purpose of Key1,
 };
 
 static const esp_efuse_desc_t KEY_PURPOSE_2[] = {
-    {EFUSE_BLK0, 96, 4}, 	 // Key2 purpose,
+    {EFUSE_BLK0, 96, 4}, 	 // [KEY2_PURPOSE] Purpose of Key2,
 };
 
 static const esp_efuse_desc_t KEY_PURPOSE_3[] = {
-    {EFUSE_BLK0, 100, 4}, 	 // Key3 purpose,
+    {EFUSE_BLK0, 100, 4}, 	 // [KEY3_PURPOSE] Purpose of Key3,
 };
 
 static const esp_efuse_desc_t KEY_PURPOSE_4[] = {
-    {EFUSE_BLK0, 104, 4}, 	 // Key4 purpose,
+    {EFUSE_BLK0, 104, 4}, 	 // [KEY4_PURPOSE] Purpose of Key4,
 };
 
 static const esp_efuse_desc_t KEY_PURPOSE_5[] = {
-    {EFUSE_BLK0, 108, 4}, 	 // Key5 purpose,
+    {EFUSE_BLK0, 108, 4}, 	 // [KEY5_PURPOSE] Purpose of Key5,
 };
 
 static const esp_efuse_desc_t SECURE_BOOT_EN[] = {
-    {EFUSE_BLK0, 116, 1}, 	 // Secure boot enable,
+    {EFUSE_BLK0, 116, 1}, 	 // [] Set this bit to enable secure boot,
 };
 
 static const esp_efuse_desc_t SECURE_BOOT_AGGRESSIVE_REVOKE[] = {
-    {EFUSE_BLK0, 117, 1}, 	 // Enable aggressive secure boot revoke,
+    {EFUSE_BLK0, 117, 1}, 	 // [] Set this bit to enable revoking aggressive secure boot,
 };
 
 static const esp_efuse_desc_t DIS_USB_JTAG[] = {
-    {EFUSE_BLK0, 118, 1}, 	 // Set to disable usb_serial_jtag-to-jtag function,
+    {EFUSE_BLK0, 118, 1}, 	 // [] Set this bit to disable function of usb switch to jtag in module of usb device,
 };
 
 static const esp_efuse_desc_t DIS_USB_SERIAL_JTAG[] = {
-    {EFUSE_BLK0, 119, 1}, 	 // Set to disable usb_serial_jtag module,
+    {EFUSE_BLK0, 119, 1}, 	 // [DIS_USB_DEVICE] Set this bit to disable usb device,
 };
 
 static const esp_efuse_desc_t STRAP_JTAG_SEL[] = {
-    {EFUSE_BLK0, 120, 1}, 	 // Enable selection between usb_to_jtag or pad_to_jtag through gpio10,
+    {EFUSE_BLK0, 120, 1}, 	 // [] Set this bit to enable selection between usb_to_jtag and pad_to_jtag through strapping gpio10 when both reg_dis_usb_jtag and reg_dis_pad_jtag are equal to 0,
 };
 
 static const esp_efuse_desc_t USB_PHY_SEL[] = {
-    {EFUSE_BLK0, 121, 1}, 	 // Select internal/external PHY for USB OTG and usb_serial_jtag,
+    {EFUSE_BLK0, 121, 1}, 	 // [] This bit is used to switch internal PHY and external PHY for USB OTG and USB Device {0: "internal PHY is assigned to USB Device while external PHY is assigned to USB OTG"; 1: "internal PHY is assigned to USB OTG while external PHY is assigned to USB Device"},
 };
 
 static const esp_efuse_desc_t FLASH_TPUW[] = {
-    {EFUSE_BLK0, 124, 4}, 	 // Flash wait time after power up. (unit is ms). When value is 15. the time is 30 ms,
+    {EFUSE_BLK0, 124, 4}, 	 // [] Configures flash waiting time after power-up; in unit of ms. If the value is less than 15; the waiting time is the configurable value.  Otherwise; the waiting time is twice the configurable value,
 };
 
 static const esp_efuse_desc_t DIS_DOWNLOAD_MODE[] = {
-    {EFUSE_BLK0, 128, 1}, 	 // Disble download mode include boot_mode[3:0] is 0 1 2 3 6 7,
+    {EFUSE_BLK0, 128, 1}, 	 // [] Set this bit to disable download mode (boot_mode[3:0] = 0; 1; 2; 3; 6; 7),
 };
 
-static const esp_efuse_desc_t DIS_LEGACY_SPI_BOOT[] = {
-    {EFUSE_BLK0, 129, 1}, 	 // Disable_Legcy_SPI_boot mode include boot_mode[3:0] is 4,
+static const esp_efuse_desc_t DIS_DIRECT_BOOT[] = {
+    {EFUSE_BLK0, 129, 1}, 	 // [DIS_LEGACY_SPI_BOOT] Disable direct boot mode,
 };
 
-static const esp_efuse_desc_t UART_PRINT_CHANNEL[] = {
-    {EFUSE_BLK0, 130, 1}, 	 // 0: UART0. 1: UART1,
+static const esp_efuse_desc_t DIS_USB_SERIAL_JTAG_ROM_PRINT[] = {
+    {EFUSE_BLK0, 130, 1}, 	 // [UART_PRINT_CHANNEL] USB printing {0: "Enable"; 1: "Disable"},
 };
 
 static const esp_efuse_desc_t FLASH_ECC_MODE[] = {
-    {EFUSE_BLK0, 131, 1}, 	 // Configures the ECC mode for SPI flash. 0:16-byte to 18-byte mode. 1:16-byte to 17-byte mode,
+    {EFUSE_BLK0, 131, 1}, 	 // [] Flash ECC mode in ROM {0: "16to18 byte"; 1: "16to17 byte"},
 };
 
-static const esp_efuse_desc_t DIS_USB_DOWNLOAD_MODE[] = {
-    {EFUSE_BLK0, 132, 1}, 	 // Disable download through USB,
+static const esp_efuse_desc_t DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE[] = {
+    {EFUSE_BLK0, 132, 1}, 	 // [DIS_USB_DOWNLOAD_MODE] Set this bit to disable UART download mode through USB,
 };
 
 static const esp_efuse_desc_t ENABLE_SECURITY_DOWNLOAD[] = {
-    {EFUSE_BLK0, 133, 1}, 	 // Enable security download mode,
+    {EFUSE_BLK0, 133, 1}, 	 // [] Set this bit to enable secure UART download mode,
 };
 
 static const esp_efuse_desc_t UART_PRINT_CONTROL[] = {
-    {EFUSE_BLK0, 134, 2}, 	 // b00:force print. b01:control by GPIO46 - low level print. b10:control by GPIO46 - high level print. b11:force disable print.,
+    {EFUSE_BLK0, 134, 2}, 	 // [] Set the default UART boot message output mode {0: "Enable"; 1: "Enable when GPIO46 is low at reset"; 2: "Enable when GPIO46 is high at reset"; 3: "Disable"},
 };
 
 static const esp_efuse_desc_t PIN_POWER_SELECTION[] = {
-    {EFUSE_BLK0, 136, 1}, 	 // GPIO33-GPIO37 power supply selection in ROM code. 0:VDD3P3_CPU. 1:VDD_SPI.,
+    {EFUSE_BLK0, 136, 1}, 	 // [] Set default power supply for GPIO33-GPIO37; set when SPI flash is initialized {0: "VDD3P3_CPU"; 1: "VDD_SPI"},
 };
 
 static const esp_efuse_desc_t FLASH_TYPE[] = {
-    {EFUSE_BLK0, 137, 1}, 	 // Connected Flash interface type. 0: 4 data line. 1: 8 data line,
+    {EFUSE_BLK0, 137, 1}, 	 // [] SPI flash type {0: "4 data lines"; 1: "8 data lines"},
 };
 
 static const esp_efuse_desc_t FLASH_PAGE_SIZE[] = {
-    {EFUSE_BLK0, 138, 2}, 	 // Sets the size of flash page,
+    {EFUSE_BLK0, 138, 2}, 	 // [] Set Flash page size,
 };
 
 static const esp_efuse_desc_t FLASH_ECC_EN[] = {
-    {EFUSE_BLK0, 140, 1}, 	 // Enables ECC in Flash boot mode,
+    {EFUSE_BLK0, 140, 1}, 	 // [] Set 1 to enable ECC for flash boot,
 };
 
 static const esp_efuse_desc_t FORCE_SEND_RESUME[] = {
-    {EFUSE_BLK0, 141, 1}, 	 // Force ROM code to send a resume command during SPI boot,
+    {EFUSE_BLK0, 141, 1}, 	 // [] Set this bit to force ROM code to send a resume command during SPI boot,
 };
 
 static const esp_efuse_desc_t SECURE_VERSION[] = {
-    {EFUSE_BLK0, 142, 16}, 	 // Secure version for anti-rollback,
+    {EFUSE_BLK0, 142, 16}, 	 // [] Secure version (used by ESP-IDF anti-rollback feature),
 };
 
-static const esp_efuse_desc_t MAC_FACTORY[] = {
-    {EFUSE_BLK1, 40, 8}, 	 // Factory MAC addr [0],
-    {EFUSE_BLK1, 32, 8}, 	 // Factory MAC addr [1],
-    {EFUSE_BLK1, 24, 8}, 	 // Factory MAC addr [2],
-    {EFUSE_BLK1, 16, 8}, 	 // Factory MAC addr [3],
-    {EFUSE_BLK1, 8, 8}, 	 // Factory MAC addr [4],
-    {EFUSE_BLK1, 0, 8}, 	 // Factory MAC addr [5],
+static const esp_efuse_desc_t DIS_USB_OTG_DOWNLOAD_MODE[] = {
+    {EFUSE_BLK0, 159, 1}, 	 // [] Set this bit to disable download through USB-OTG,
+};
+
+static const esp_efuse_desc_t DISABLE_WAFER_VERSION_MAJOR[] = {
+    {EFUSE_BLK0, 160, 1}, 	 // [] Disables check of wafer version major,
+};
+
+static const esp_efuse_desc_t DISABLE_BLK_VERSION_MAJOR[] = {
+    {EFUSE_BLK0, 161, 1}, 	 // [] Disables check of blk version major,
+};
+
+static const esp_efuse_desc_t MAC[] = {
+    {EFUSE_BLK1, 40, 8}, 	 // [MAC_FACTORY] MAC address,
+    {EFUSE_BLK1, 32, 8}, 	 // [MAC_FACTORY] MAC address,
+    {EFUSE_BLK1, 24, 8}, 	 // [MAC_FACTORY] MAC address,
+    {EFUSE_BLK1, 16, 8}, 	 // [MAC_FACTORY] MAC address,
+    {EFUSE_BLK1, 8, 8}, 	 // [MAC_FACTORY] MAC address,
+    {EFUSE_BLK1, 0, 8}, 	 // [MAC_FACTORY] MAC address,
 };
 
 static const esp_efuse_desc_t SPI_PAD_CONFIG_CLK[] = {
-    {EFUSE_BLK1, 48, 6}, 	 // SPI_PAD_configure CLK,
+    {EFUSE_BLK1, 48, 6}, 	 // [] SPI_PAD_configure CLK,
 };
 
-static const esp_efuse_desc_t SPI_PAD_CONFIG_Q_D1[] = {
-    {EFUSE_BLK1, 54, 6}, 	 // SPI_PAD_configure Q(D1),
+static const esp_efuse_desc_t SPI_PAD_CONFIG_Q[] = {
+    {EFUSE_BLK1, 54, 6}, 	 // [] SPI_PAD_configure Q(D1),
 };
 
-static const esp_efuse_desc_t SPI_PAD_CONFIG_D_D0[] = {
-    {EFUSE_BLK1, 60, 6}, 	 // SPI_PAD_configure D(D0),
+static const esp_efuse_desc_t SPI_PAD_CONFIG_D[] = {
+    {EFUSE_BLK1, 60, 6}, 	 // [] SPI_PAD_configure D(D0),
 };
 
 static const esp_efuse_desc_t SPI_PAD_CONFIG_CS[] = {
-    {EFUSE_BLK1, 66, 6}, 	 // SPI_PAD_configure CS,
+    {EFUSE_BLK1, 66, 6}, 	 // [] SPI_PAD_configure CS,
 };
 
-static const esp_efuse_desc_t SPI_PAD_CONFIG_HD_D3[] = {
-    {EFUSE_BLK1, 72, 6}, 	 // SPI_PAD_configure HD(D3),
+static const esp_efuse_desc_t SPI_PAD_CONFIG_HD[] = {
+    {EFUSE_BLK1, 72, 6}, 	 // [] SPI_PAD_configure HD(D3),
 };
 
-static const esp_efuse_desc_t SPI_PAD_CONFIG_WP_D2[] = {
-    {EFUSE_BLK1, 78, 6}, 	 // SPI_PAD_configure WP(D2),
+static const esp_efuse_desc_t SPI_PAD_CONFIG_WP[] = {
+    {EFUSE_BLK1, 78, 6}, 	 // [] SPI_PAD_configure WP(D2),
 };
 
 static const esp_efuse_desc_t SPI_PAD_CONFIG_DQS[] = {
-    {EFUSE_BLK1, 84, 6}, 	 // SPI_PAD_configure DQS,
+    {EFUSE_BLK1, 84, 6}, 	 // [] SPI_PAD_configure DQS,
 };
 
 static const esp_efuse_desc_t SPI_PAD_CONFIG_D4[] = {
-    {EFUSE_BLK1, 90, 6}, 	 // SPI_PAD_configure D4,
+    {EFUSE_BLK1, 90, 6}, 	 // [] SPI_PAD_configure D4,
 };
 
 static const esp_efuse_desc_t SPI_PAD_CONFIG_D5[] = {
-    {EFUSE_BLK1, 96, 6}, 	 // SPI_PAD_configure D5,
+    {EFUSE_BLK1, 96, 6}, 	 // [] SPI_PAD_configure D5,
 };
 
 static const esp_efuse_desc_t SPI_PAD_CONFIG_D6[] = {
-    {EFUSE_BLK1, 102, 6}, 	 // SPI_PAD_configure D6,
+    {EFUSE_BLK1, 102, 6}, 	 // [] SPI_PAD_configure D6,
 };
 
 static const esp_efuse_desc_t SPI_PAD_CONFIG_D7[] = {
-    {EFUSE_BLK1, 108, 6}, 	 // SPI_PAD_configure D7,
+    {EFUSE_BLK1, 108, 6}, 	 // [] SPI_PAD_configure D7,
 };
 
-static const esp_efuse_desc_t WAFER_VERSION[] = {
-    {EFUSE_BLK1, 114, 3}, 	 // WAFER version 0:A,
+static const esp_efuse_desc_t WAFER_VERSION_MINOR_LO[] = {
+    {EFUSE_BLK1, 114, 3}, 	 // [] WAFER_VERSION_MINOR least significant bits,
 };
 
 static const esp_efuse_desc_t PKG_VERSION[] = {
-    {EFUSE_BLK1, 117, 3}, 	 // Package version,
+    {EFUSE_BLK1, 117, 3}, 	 // [] Package version,
 };
 
-static const esp_efuse_desc_t BLK_VER_MINOR[] = {
-    {EFUSE_BLK1, 120, 3}, 	 // BLK_VERSION_MINOR,
+static const esp_efuse_desc_t BLK_VERSION_MINOR[] = {
+    {EFUSE_BLK1, 120, 3}, 	 // [] BLK_VERSION_MINOR,
+};
+
+static const esp_efuse_desc_t FLASH_CAP[] = {
+    {EFUSE_BLK1, 123, 3}, 	 // [] Flash capacity {0: "None"; 1: "8M"; 2: "4M"},
+};
+
+static const esp_efuse_desc_t FLASH_TEMP[] = {
+    {EFUSE_BLK1, 126, 2}, 	 // [] Flash temperature {0: "None"; 1: "105C"; 2: "85C"},
+};
+
+static const esp_efuse_desc_t FLASH_VENDOR[] = {
+    {EFUSE_BLK1, 128, 3}, 	 // [] Flash vendor {0: "None"; 1: "XMC"; 2: "GD"; 3: "FM"; 4: "TT"; 5: "BY"},
+};
+
+static const esp_efuse_desc_t PSRAM_CAP[] = {
+    {EFUSE_BLK1, 131, 2}, 	 // [] PSRAM capacity {0: "None"; 1: "8M"; 2: "2M"},
+};
+
+static const esp_efuse_desc_t PSRAM_TEMP[] = {
+    {EFUSE_BLK1, 133, 2}, 	 // [] PSRAM temperature {0: "None"; 1: "105C"; 2: "85C"},
+};
+
+static const esp_efuse_desc_t PSRAM_VENDOR[] = {
+    {EFUSE_BLK1, 135, 2}, 	 // [] PSRAM vendor {0: "None"; 1: "AP_3v3"; 2: "AP_1v8"},
+};
+
+static const esp_efuse_desc_t K_RTC_LDO[] = {
+    {EFUSE_BLK1, 141, 7}, 	 // [] BLOCK1 K_RTC_LDO,
+};
+
+static const esp_efuse_desc_t K_DIG_LDO[] = {
+    {EFUSE_BLK1, 148, 7}, 	 // [] BLOCK1 K_DIG_LDO,
+};
+
+static const esp_efuse_desc_t V_RTC_DBIAS20[] = {
+    {EFUSE_BLK1, 155, 8}, 	 // [] BLOCK1 voltage of rtc dbias20,
+};
+
+static const esp_efuse_desc_t V_DIG_DBIAS20[] = {
+    {EFUSE_BLK1, 163, 8}, 	 // [] BLOCK1 voltage of digital dbias20,
+};
+
+static const esp_efuse_desc_t DIG_DBIAS_HVT[] = {
+    {EFUSE_BLK1, 171, 5}, 	 // [] BLOCK1 digital dbias when hvt,
+};
+
+static const esp_efuse_desc_t WAFER_VERSION_MINOR_HI[] = {
+    {EFUSE_BLK1, 183, 1}, 	 // [] WAFER_VERSION_MINOR most significant bit,
+};
+
+static const esp_efuse_desc_t WAFER_VERSION_MAJOR[] = {
+    {EFUSE_BLK1, 184, 2}, 	 // [] WAFER_VERSION_MAJOR,
 };
 
 static const esp_efuse_desc_t ADC2_CAL_VOL_ATTEN3[] = {
-    {EFUSE_BLK1, 186, 6}, 	 // ADC2 calibration voltage at atten3,
+    {EFUSE_BLK1, 186, 6}, 	 // [] ADC2 calibration voltage at atten3,
 };
 
 static const esp_efuse_desc_t OPTIONAL_UNIQUE_ID[] = {
-    {EFUSE_BLK2, 0, 128}, 	 // Optional unique 128-bit ID,
+    {EFUSE_BLK2, 0, 128}, 	 // [] Optional unique 128-bit ID,
 };
 
-static const esp_efuse_desc_t BLK_VER_MAJOR[] = {
-    {EFUSE_BLK2, 128, 2}, 	 // BLK_VERSION_MAJOR,
+static const esp_efuse_desc_t BLK_VERSION_MAJOR[] = {
+    {EFUSE_BLK2, 128, 2}, 	 // [] BLK_VERSION_MAJOR of BLOCK2 {0: "No calib"; 1: "ADC calib V1"},
 };
 
 static const esp_efuse_desc_t TEMP_CALIB[] = {
-    {EFUSE_BLK2, 132, 9}, 	 // Temperature calibration data,
+    {EFUSE_BLK2, 132, 9}, 	 // [] Temperature calibration data,
 };
 
 static const esp_efuse_desc_t OCODE[] = {
-    {EFUSE_BLK2, 141, 8}, 	 // ADC OCode,
+    {EFUSE_BLK2, 141, 8}, 	 // [] ADC OCode,
 };
 
 static const esp_efuse_desc_t ADC1_INIT_CODE_ATTEN0[] = {
-    {EFUSE_BLK2, 149, 8}, 	 // ADC1 init code at atten0,
+    {EFUSE_BLK2, 149, 8}, 	 // [] ADC1 init code at atten0,
 };
 
 static const esp_efuse_desc_t ADC1_INIT_CODE_ATTEN1[] = {
-    {EFUSE_BLK2, 157, 6}, 	 // ADC1 init code at atten1,
+    {EFUSE_BLK2, 157, 6}, 	 // [] ADC1 init code at atten1,
 };
 
 static const esp_efuse_desc_t ADC1_INIT_CODE_ATTEN2[] = {
-    {EFUSE_BLK2, 163, 6}, 	 // ADC1 init code at atten2,
+    {EFUSE_BLK2, 163, 6}, 	 // [] ADC1 init code at atten2,
 };
 
 static const esp_efuse_desc_t ADC1_INIT_CODE_ATTEN3[] = {
-    {EFUSE_BLK2, 169, 6}, 	 // ADC1 init code at atten3,
+    {EFUSE_BLK2, 169, 6}, 	 // [] ADC1 init code at atten3,
 };
 
 static const esp_efuse_desc_t ADC2_INIT_CODE_ATTEN0[] = {
-    {EFUSE_BLK2, 175, 8}, 	 // ADC2 init code at atten0,
+    {EFUSE_BLK2, 175, 8}, 	 // [] ADC2 init code at atten0,
 };
 
 static const esp_efuse_desc_t ADC2_INIT_CODE_ATTEN1[] = {
-    {EFUSE_BLK2, 183, 6}, 	 // ADC2 init code at atten1,
+    {EFUSE_BLK2, 183, 6}, 	 // [] ADC2 init code at atten1,
 };
 
 static const esp_efuse_desc_t ADC2_INIT_CODE_ATTEN2[] = {
-    {EFUSE_BLK2, 189, 6}, 	 // ADC2 init code at atten2,
+    {EFUSE_BLK2, 189, 6}, 	 // [] ADC2 init code at atten2,
 };
 
 static const esp_efuse_desc_t ADC2_INIT_CODE_ATTEN3[] = {
-    {EFUSE_BLK2, 195, 6}, 	 // ADC2 init code at atten3,
+    {EFUSE_BLK2, 195, 6}, 	 // [] ADC2 init code at atten3,
 };
 
 static const esp_efuse_desc_t ADC1_CAL_VOL_ATTEN0[] = {
-    {EFUSE_BLK2, 201, 8}, 	 // ADC1 calibration voltage at atten0,
+    {EFUSE_BLK2, 201, 8}, 	 // [] ADC1 calibration voltage at atten0,
 };
 
 static const esp_efuse_desc_t ADC1_CAL_VOL_ATTEN1[] = {
-    {EFUSE_BLK2, 209, 8}, 	 // ADC1 calibration voltage at atten1,
+    {EFUSE_BLK2, 209, 8}, 	 // [] ADC1 calibration voltage at atten1,
 };
 
 static const esp_efuse_desc_t ADC1_CAL_VOL_ATTEN2[] = {
-    {EFUSE_BLK2, 217, 8}, 	 // ADC1 calibration voltage at atten2,
+    {EFUSE_BLK2, 217, 8}, 	 // [] ADC1 calibration voltage at atten2,
 };
 
 static const esp_efuse_desc_t ADC1_CAL_VOL_ATTEN3[] = {
-    {EFUSE_BLK2, 225, 8}, 	 // ADC1 calibration voltage at atten3,
+    {EFUSE_BLK2, 225, 8}, 	 // [] ADC1 calibration voltage at atten3,
 };
 
 static const esp_efuse_desc_t ADC2_CAL_VOL_ATTEN0[] = {
-    {EFUSE_BLK2, 233, 8}, 	 // ADC2 calibration voltage at atten0,
+    {EFUSE_BLK2, 233, 8}, 	 // [] ADC2 calibration voltage at atten0,
 };
 
 static const esp_efuse_desc_t ADC2_CAL_VOL_ATTEN1[] = {
-    {EFUSE_BLK2, 241, 7}, 	 // ADC2 calibration voltage at atten1,
+    {EFUSE_BLK2, 241, 7}, 	 // [] ADC2 calibration voltage at atten1,
 };
 
 static const esp_efuse_desc_t ADC2_CAL_VOL_ATTEN2[] = {
-    {EFUSE_BLK2, 248, 7}, 	 // ADC2 calibration voltage at atten2,
+    {EFUSE_BLK2, 248, 7}, 	 // [] ADC2 calibration voltage at atten2,
 };
 
 static const esp_efuse_desc_t USER_DATA[] = {
-    {EFUSE_BLK3, 0, 256}, 	 // User data,
+    {EFUSE_BLK3, 0, 256}, 	 // [BLOCK_USR_DATA] User data,
 };
 
 static const esp_efuse_desc_t USER_DATA_MAC_CUSTOM[] = {
-    {EFUSE_BLK3, 200, 48}, 	 // Custom MAC,
+    {EFUSE_BLK3, 200, 48}, 	 // [MAC_CUSTOM CUSTOM_MAC] Custom MAC,
 };
 
 static const esp_efuse_desc_t KEY0[] = {
-    {EFUSE_BLK4, 0, 256}, 	 // Key0 or user data,
+    {EFUSE_BLK4, 0, 256}, 	 // [BLOCK_KEY0] Key0 or user data,
 };
 
 static const esp_efuse_desc_t KEY1[] = {
-    {EFUSE_BLK5, 0, 256}, 	 // Key1 or user data,
+    {EFUSE_BLK5, 0, 256}, 	 // [BLOCK_KEY1] Key1 or user data,
 };
 
 static const esp_efuse_desc_t KEY2[] = {
-    {EFUSE_BLK6, 0, 256}, 	 // Key2 or user data,
+    {EFUSE_BLK6, 0, 256}, 	 // [BLOCK_KEY2] Key2 or user data,
 };
 
 static const esp_efuse_desc_t KEY3[] = {
-    {EFUSE_BLK7, 0, 256}, 	 // Key3 or user data,
+    {EFUSE_BLK7, 0, 256}, 	 // [BLOCK_KEY3] Key3 or user data,
 };
 
 static const esp_efuse_desc_t KEY4[] = {
-    {EFUSE_BLK8, 0, 256}, 	 // Key4 or user data,
+    {EFUSE_BLK8, 0, 256}, 	 // [BLOCK_KEY4] Key4 or user data,
 };
 
 static const esp_efuse_desc_t KEY5[] = {
-    {EFUSE_BLK9, 0, 256}, 	 // Key5 or user data,
+    {EFUSE_BLK9, 0, 256}, 	 // [BLOCK_KEY5] Key5 or user data,
 };
 
 static const esp_efuse_desc_t SYS_DATA_PART2[] = {
-    {EFUSE_BLK10, 0, 256}, 	 // System configuration,
+    {EFUSE_BLK10, 0, 256}, 	 // [BLOCK_SYS_DATA2] System data part 2 (reserved),
 };
 
 
@@ -537,646 +929,1136 @@ static const esp_efuse_desc_t SYS_DATA_PART2[] = {
 
 
 const esp_efuse_desc_t* ESP_EFUSE_WR_DIS[] = {
-    &WR_DIS[0],    		// Write protection
+    &WR_DIS[0],    		// [] Disable programming of individual eFuses
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_RD_DIS[] = {
-    &WR_DIS_RD_DIS[0],    		// Write protection for RD_DIS_KEY0 RD_DIS_KEY1 RD_DIS_KEY2 RD_DIS_KEY3 RD_DIS_KEY4 RD_DIS_KEY5 RD_DIS_SYS_DATA_PART2
+    &WR_DIS_RD_DIS[0],    		// [] wr_dis of RD_DIS
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_GROUP_1[] = {
-    &WR_DIS_GROUP_1[0],    		// Write protection for DIS_ICACHE DIS_DCACHE DIS_DOWNLOAD_ICACHE DIS_DOWNLOAD_DCACHE DIS_FORCE_DOWNLOAD DIS_USB DIS_CAN SOFT_DIS_JTAG HARD_DIS_JTAG DIS_DOWNLOAD_MANUAL_ENCRYPT
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_ICACHE[] = {
+    &WR_DIS_DIS_ICACHE[0],    		// [] wr_dis of DIS_ICACHE
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_GROUP_2[] = {
-    &WR_DIS_GROUP_2[0],    		// Write protection for VDD_SPI_XPD VDD_SPI_TIEH VDD_SPI_FORCE VDD_SPI_INIT VDD_SPI_DCAP WDT_DELAY_SEL
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_DCACHE[] = {
+    &WR_DIS_DIS_DCACHE[0],    		// [] wr_dis of DIS_DCACHE
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_DOWNLOAD_ICACHE[] = {
+    &WR_DIS_DIS_DOWNLOAD_ICACHE[0],    		// [] wr_dis of DIS_DOWNLOAD_ICACHE
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_DOWNLOAD_DCACHE[] = {
+    &WR_DIS_DIS_DOWNLOAD_DCACHE[0],    		// [] wr_dis of DIS_DOWNLOAD_DCACHE
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_FORCE_DOWNLOAD[] = {
+    &WR_DIS_DIS_FORCE_DOWNLOAD[0],    		// [] wr_dis of DIS_FORCE_DOWNLOAD
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_USB_OTG[] = {
+    &WR_DIS_DIS_USB_OTG[0],    		// [WR_DIS.DIS_USB] wr_dis of DIS_USB_OTG
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_TWAI[] = {
+    &WR_DIS_DIS_TWAI[0],    		// [WR_DIS.DIS_CAN] wr_dis of DIS_TWAI
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_APP_CPU[] = {
+    &WR_DIS_DIS_APP_CPU[0],    		// [] wr_dis of DIS_APP_CPU
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_PAD_JTAG[] = {
+    &WR_DIS_DIS_PAD_JTAG[0],    		// [WR_DIS.HARD_DIS_JTAG] wr_dis of DIS_PAD_JTAG
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_DOWNLOAD_MANUAL_ENCRYPT[] = {
+    &WR_DIS_DIS_DOWNLOAD_MANUAL_ENCRYPT[0],    		// [] wr_dis of DIS_DOWNLOAD_MANUAL_ENCRYPT
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_USB_JTAG[] = {
+    &WR_DIS_DIS_USB_JTAG[0],    		// [] wr_dis of DIS_USB_JTAG
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_USB_SERIAL_JTAG[] = {
+    &WR_DIS_DIS_USB_SERIAL_JTAG[0],    		// [WR_DIS.DIS_USB_DEVICE] wr_dis of DIS_USB_SERIAL_JTAG
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_STRAP_JTAG_SEL[] = {
+    &WR_DIS_STRAP_JTAG_SEL[0],    		// [] wr_dis of STRAP_JTAG_SEL
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_USB_PHY_SEL[] = {
+    &WR_DIS_USB_PHY_SEL[0],    		// [] wr_dis of USB_PHY_SEL
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_VDD_SPI_XPD[] = {
+    &WR_DIS_VDD_SPI_XPD[0],    		// [] wr_dis of VDD_SPI_XPD
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_VDD_SPI_TIEH[] = {
+    &WR_DIS_VDD_SPI_TIEH[0],    		// [] wr_dis of VDD_SPI_TIEH
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_VDD_SPI_FORCE[] = {
+    &WR_DIS_VDD_SPI_FORCE[0],    		// [] wr_dis of VDD_SPI_FORCE
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_WDT_DELAY_SEL[] = {
+    &WR_DIS_WDT_DELAY_SEL[0],    		// [] wr_dis of WDT_DELAY_SEL
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_BOOT_CRYPT_CNT[] = {
-    &WR_DIS_SPI_BOOT_CRYPT_CNT[0],    		// Write protection for SPI_BOOT_CRYPT_CNT
+    &WR_DIS_SPI_BOOT_CRYPT_CNT[0],    		// [] wr_dis of SPI_BOOT_CRYPT_CNT
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SECURE_BOOT_KEY_REVOKE0[] = {
-    &WR_DIS_SECURE_BOOT_KEY_REVOKE0[0],    		// Write protection for SECURE_BOOT_KEY_REVOKE0
+    &WR_DIS_SECURE_BOOT_KEY_REVOKE0[0],    		// [] wr_dis of SECURE_BOOT_KEY_REVOKE0
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SECURE_BOOT_KEY_REVOKE1[] = {
-    &WR_DIS_SECURE_BOOT_KEY_REVOKE1[0],    		// Write protection for SECURE_BOOT_KEY_REVOKE1
+    &WR_DIS_SECURE_BOOT_KEY_REVOKE1[0],    		// [] wr_dis of SECURE_BOOT_KEY_REVOKE1
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SECURE_BOOT_KEY_REVOKE2[] = {
-    &WR_DIS_SECURE_BOOT_KEY_REVOKE2[0],    		// Write protection for SECURE_BOOT_KEY_REVOKE2
+    &WR_DIS_SECURE_BOOT_KEY_REVOKE2[0],    		// [] wr_dis of SECURE_BOOT_KEY_REVOKE2
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY0_PURPOSE[] = {
-    &WR_DIS_KEY0_PURPOSE[0],    		// Write protection for key_purpose. KEY0
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY_PURPOSE_0[] = {
+    &WR_DIS_KEY_PURPOSE_0[0],    		// [WR_DIS.KEY0_PURPOSE] wr_dis of KEY_PURPOSE_0
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY1_PURPOSE[] = {
-    &WR_DIS_KEY1_PURPOSE[0],    		// Write protection for key_purpose. KEY1
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY_PURPOSE_1[] = {
+    &WR_DIS_KEY_PURPOSE_1[0],    		// [WR_DIS.KEY1_PURPOSE] wr_dis of KEY_PURPOSE_1
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY2_PURPOSE[] = {
-    &WR_DIS_KEY2_PURPOSE[0],    		// Write protection for key_purpose. KEY2
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY_PURPOSE_2[] = {
+    &WR_DIS_KEY_PURPOSE_2[0],    		// [WR_DIS.KEY2_PURPOSE] wr_dis of KEY_PURPOSE_2
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY3_PURPOSE[] = {
-    &WR_DIS_KEY3_PURPOSE[0],    		// Write protection for key_purpose. KEY3
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY_PURPOSE_3[] = {
+    &WR_DIS_KEY_PURPOSE_3[0],    		// [WR_DIS.KEY3_PURPOSE] wr_dis of KEY_PURPOSE_3
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY4_PURPOSE[] = {
-    &WR_DIS_KEY4_PURPOSE[0],    		// Write protection for key_purpose. KEY4
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY_PURPOSE_4[] = {
+    &WR_DIS_KEY_PURPOSE_4[0],    		// [WR_DIS.KEY4_PURPOSE] wr_dis of KEY_PURPOSE_4
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY5_PURPOSE[] = {
-    &WR_DIS_KEY5_PURPOSE[0],    		// Write protection for key_purpose. KEY5
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY_PURPOSE_5[] = {
+    &WR_DIS_KEY_PURPOSE_5[0],    		// [WR_DIS.KEY5_PURPOSE] wr_dis of KEY_PURPOSE_5
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SECURE_BOOT_EN[] = {
-    &WR_DIS_SECURE_BOOT_EN[0],    		// Write protection for SECURE_BOOT_EN
+    &WR_DIS_SECURE_BOOT_EN[0],    		// [] wr_dis of SECURE_BOOT_EN
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SECURE_BOOT_AGGRESSIVE_REVOKE[] = {
-    &WR_DIS_SECURE_BOOT_AGGRESSIVE_REVOKE[0],    		// Write protection for SECURE_BOOT_AGGRESSIVE_REVOKE
+    &WR_DIS_SECURE_BOOT_AGGRESSIVE_REVOKE[0],    		// [] wr_dis of SECURE_BOOT_AGGRESSIVE_REVOKE
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_GROUP_3[] = {
-    &WR_DIS_GROUP_3[0],    		// Write protection for FLASH_TPUW DIS_DOWNLOAD_MODE DIS_LEGACY_SPI_BOOT UART_PRINT_CHANNEL DIS_USB_DOWNLOAD_MODE ENABLE_SECURITY_DOWNLOAD UART_PRINT_CONTROL PIN_POWER_SELECTION FLASH_TYPE FORCE_SEND_RESUME SECURE_VERSION
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_TPUW[] = {
+    &WR_DIS_FLASH_TPUW[0],    		// [] wr_dis of FLASH_TPUW
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_DOWNLOAD_MODE[] = {
+    &WR_DIS_DIS_DOWNLOAD_MODE[0],    		// [] wr_dis of DIS_DOWNLOAD_MODE
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_DIRECT_BOOT[] = {
+    &WR_DIS_DIS_DIRECT_BOOT[0],    		// [WR_DIS.DIS_LEGACY_SPI_BOOT] wr_dis of DIS_DIRECT_BOOT
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_USB_SERIAL_JTAG_ROM_PRINT[] = {
+    &WR_DIS_DIS_USB_SERIAL_JTAG_ROM_PRINT[0],    		// [WR_DIS.UART_PRINT_CHANNEL] wr_dis of DIS_USB_SERIAL_JTAG_ROM_PRINT
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_ECC_MODE[] = {
+    &WR_DIS_FLASH_ECC_MODE[0],    		// [] wr_dis of FLASH_ECC_MODE
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE[] = {
+    &WR_DIS_DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE[0],    		// [WR_DIS.DIS_USB_DOWNLOAD_MODE] wr_dis of DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ENABLE_SECURITY_DOWNLOAD[] = {
+    &WR_DIS_ENABLE_SECURITY_DOWNLOAD[0],    		// [] wr_dis of ENABLE_SECURITY_DOWNLOAD
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_UART_PRINT_CONTROL[] = {
+    &WR_DIS_UART_PRINT_CONTROL[0],    		// [] wr_dis of UART_PRINT_CONTROL
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_PIN_POWER_SELECTION[] = {
+    &WR_DIS_PIN_POWER_SELECTION[0],    		// [] wr_dis of PIN_POWER_SELECTION
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_TYPE[] = {
+    &WR_DIS_FLASH_TYPE[0],    		// [] wr_dis of FLASH_TYPE
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_PAGE_SIZE[] = {
+    &WR_DIS_FLASH_PAGE_SIZE[0],    		// [] wr_dis of FLASH_PAGE_SIZE
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_ECC_EN[] = {
+    &WR_DIS_FLASH_ECC_EN[0],    		// [] wr_dis of FLASH_ECC_EN
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FORCE_SEND_RESUME[] = {
+    &WR_DIS_FORCE_SEND_RESUME[0],    		// [] wr_dis of FORCE_SEND_RESUME
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SECURE_VERSION[] = {
+    &WR_DIS_SECURE_VERSION[0],    		// [] wr_dis of SECURE_VERSION
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_USB_OTG_DOWNLOAD_MODE[] = {
+    &WR_DIS_DIS_USB_OTG_DOWNLOAD_MODE[0],    		// [] wr_dis of DIS_USB_OTG_DOWNLOAD_MODE
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DISABLE_WAFER_VERSION_MAJOR[] = {
+    &WR_DIS_DISABLE_WAFER_VERSION_MAJOR[0],    		// [] wr_dis of DISABLE_WAFER_VERSION_MAJOR
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DISABLE_BLK_VERSION_MAJOR[] = {
+    &WR_DIS_DISABLE_BLK_VERSION_MAJOR[0],    		// [] wr_dis of DISABLE_BLK_VERSION_MAJOR
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLK1[] = {
-    &WR_DIS_BLK1[0],    		// Write protection for EFUSE_BLK1.  MAC_SPI_8M_SYS
+    &WR_DIS_BLK1[0],    		// [] wr_dis of BLOCK1
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_MAC[] = {
+    &WR_DIS_MAC[0],    		// [WR_DIS.MAC_FACTORY] wr_dis of MAC
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_CLK[] = {
+    &WR_DIS_SPI_PAD_CONFIG_CLK[0],    		// [] wr_dis of SPI_PAD_CONFIG_CLK
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_Q[] = {
+    &WR_DIS_SPI_PAD_CONFIG_Q[0],    		// [] wr_dis of SPI_PAD_CONFIG_Q
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_D[] = {
+    &WR_DIS_SPI_PAD_CONFIG_D[0],    		// [] wr_dis of SPI_PAD_CONFIG_D
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_CS[] = {
+    &WR_DIS_SPI_PAD_CONFIG_CS[0],    		// [] wr_dis of SPI_PAD_CONFIG_CS
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_HD[] = {
+    &WR_DIS_SPI_PAD_CONFIG_HD[0],    		// [] wr_dis of SPI_PAD_CONFIG_HD
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_WP[] = {
+    &WR_DIS_SPI_PAD_CONFIG_WP[0],    		// [] wr_dis of SPI_PAD_CONFIG_WP
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_DQS[] = {
+    &WR_DIS_SPI_PAD_CONFIG_DQS[0],    		// [] wr_dis of SPI_PAD_CONFIG_DQS
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_D4[] = {
+    &WR_DIS_SPI_PAD_CONFIG_D4[0],    		// [] wr_dis of SPI_PAD_CONFIG_D4
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_D5[] = {
+    &WR_DIS_SPI_PAD_CONFIG_D5[0],    		// [] wr_dis of SPI_PAD_CONFIG_D5
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_D6[] = {
+    &WR_DIS_SPI_PAD_CONFIG_D6[0],    		// [] wr_dis of SPI_PAD_CONFIG_D6
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_D7[] = {
+    &WR_DIS_SPI_PAD_CONFIG_D7[0],    		// [] wr_dis of SPI_PAD_CONFIG_D7
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_WAFER_VERSION_MINOR_LO[] = {
+    &WR_DIS_WAFER_VERSION_MINOR_LO[0],    		// [] wr_dis of WAFER_VERSION_MINOR_LO
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_PKG_VERSION[] = {
+    &WR_DIS_PKG_VERSION[0],    		// [] wr_dis of PKG_VERSION
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLK_VERSION_MINOR[] = {
+    &WR_DIS_BLK_VERSION_MINOR[0],    		// [] wr_dis of BLK_VERSION_MINOR
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_CAP[] = {
+    &WR_DIS_FLASH_CAP[0],    		// [] wr_dis of FLASH_CAP
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_TEMP[] = {
+    &WR_DIS_FLASH_TEMP[0],    		// [] wr_dis of FLASH_TEMP
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_VENDOR[] = {
+    &WR_DIS_FLASH_VENDOR[0],    		// [] wr_dis of FLASH_VENDOR
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_PSRAM_CAP[] = {
+    &WR_DIS_PSRAM_CAP[0],    		// [] wr_dis of PSRAM_CAP
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_PSRAM_TEMP[] = {
+    &WR_DIS_PSRAM_TEMP[0],    		// [] wr_dis of PSRAM_TEMP
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_PSRAM_VENDOR[] = {
+    &WR_DIS_PSRAM_VENDOR[0],    		// [] wr_dis of PSRAM_VENDOR
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_K_RTC_LDO[] = {
+    &WR_DIS_K_RTC_LDO[0],    		// [] wr_dis of K_RTC_LDO
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_K_DIG_LDO[] = {
+    &WR_DIS_K_DIG_LDO[0],    		// [] wr_dis of K_DIG_LDO
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_V_RTC_DBIAS20[] = {
+    &WR_DIS_V_RTC_DBIAS20[0],    		// [] wr_dis of V_RTC_DBIAS20
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_V_DIG_DBIAS20[] = {
+    &WR_DIS_V_DIG_DBIAS20[0],    		// [] wr_dis of V_DIG_DBIAS20
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIG_DBIAS_HVT[] = {
+    &WR_DIS_DIG_DBIAS_HVT[0],    		// [] wr_dis of DIG_DBIAS_HVT
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_WAFER_VERSION_MINOR_HI[] = {
+    &WR_DIS_WAFER_VERSION_MINOR_HI[0],    		// [] wr_dis of WAFER_VERSION_MINOR_HI
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_WAFER_VERSION_MAJOR[] = {
+    &WR_DIS_WAFER_VERSION_MAJOR[0],    		// [] wr_dis of WAFER_VERSION_MAJOR
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_CAL_VOL_ATTEN3[] = {
+    &WR_DIS_ADC2_CAL_VOL_ATTEN3[0],    		// [] wr_dis of ADC2_CAL_VOL_ATTEN3
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SYS_DATA_PART1[] = {
-    &WR_DIS_SYS_DATA_PART1[0],    		// Write protection for EFUSE_BLK2.  SYS_DATA_PART1
+    &WR_DIS_SYS_DATA_PART1[0],    		// [] wr_dis of BLOCK2
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_USER_DATA[] = {
-    &WR_DIS_USER_DATA[0],    		// Write protection for EFUSE_BLK3.  USER_DATA
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_OPTIONAL_UNIQUE_ID[] = {
+    &WR_DIS_OPTIONAL_UNIQUE_ID[0],    		// [] wr_dis of OPTIONAL_UNIQUE_ID
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY0[] = {
-    &WR_DIS_KEY0[0],    		// Write protection for EFUSE_BLK4.  KEY0
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLK_VERSION_MAJOR[] = {
+    &WR_DIS_BLK_VERSION_MAJOR[0],    		// [] wr_dis of BLK_VERSION_MAJOR
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY1[] = {
-    &WR_DIS_KEY1[0],    		// Write protection for EFUSE_BLK5.  KEY1
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_TEMP_CALIB[] = {
+    &WR_DIS_TEMP_CALIB[0],    		// [] wr_dis of TEMP_CALIB
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY2[] = {
-    &WR_DIS_KEY2[0],    		// Write protection for EFUSE_BLK6.  KEY2
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_OCODE[] = {
+    &WR_DIS_OCODE[0],    		// [] wr_dis of OCODE
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY3[] = {
-    &WR_DIS_KEY3[0],    		// Write protection for EFUSE_BLK7.  KEY3
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_INIT_CODE_ATTEN0[] = {
+    &WR_DIS_ADC1_INIT_CODE_ATTEN0[0],    		// [] wr_dis of ADC1_INIT_CODE_ATTEN0
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY4[] = {
-    &WR_DIS_KEY4[0],    		// Write protection for EFUSE_BLK8.  KEY4
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_INIT_CODE_ATTEN1[] = {
+    &WR_DIS_ADC1_INIT_CODE_ATTEN1[0],    		// [] wr_dis of ADC1_INIT_CODE_ATTEN1
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY5[] = {
-    &WR_DIS_KEY5[0],    		// Write protection for EFUSE_BLK9.  KEY5
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_INIT_CODE_ATTEN2[] = {
+    &WR_DIS_ADC1_INIT_CODE_ATTEN2[0],    		// [] wr_dis of ADC1_INIT_CODE_ATTEN2
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SYS_DATA_PART2[] = {
-    &WR_DIS_SYS_DATA_PART2[0],    		// Write protection for EFUSE_BLK10. SYS_DATA_PART2
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_INIT_CODE_ATTEN3[] = {
+    &WR_DIS_ADC1_INIT_CODE_ATTEN3[0],    		// [] wr_dis of ADC1_INIT_CODE_ATTEN3
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_INIT_CODE_ATTEN0[] = {
+    &WR_DIS_ADC2_INIT_CODE_ATTEN0[0],    		// [] wr_dis of ADC2_INIT_CODE_ATTEN0
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_INIT_CODE_ATTEN1[] = {
+    &WR_DIS_ADC2_INIT_CODE_ATTEN1[0],    		// [] wr_dis of ADC2_INIT_CODE_ATTEN1
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_INIT_CODE_ATTEN2[] = {
+    &WR_DIS_ADC2_INIT_CODE_ATTEN2[0],    		// [] wr_dis of ADC2_INIT_CODE_ATTEN2
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_INIT_CODE_ATTEN3[] = {
+    &WR_DIS_ADC2_INIT_CODE_ATTEN3[0],    		// [] wr_dis of ADC2_INIT_CODE_ATTEN3
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_CAL_VOL_ATTEN0[] = {
+    &WR_DIS_ADC1_CAL_VOL_ATTEN0[0],    		// [] wr_dis of ADC1_CAL_VOL_ATTEN0
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_CAL_VOL_ATTEN1[] = {
+    &WR_DIS_ADC1_CAL_VOL_ATTEN1[0],    		// [] wr_dis of ADC1_CAL_VOL_ATTEN1
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_CAL_VOL_ATTEN2[] = {
+    &WR_DIS_ADC1_CAL_VOL_ATTEN2[0],    		// [] wr_dis of ADC1_CAL_VOL_ATTEN2
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_CAL_VOL_ATTEN3[] = {
+    &WR_DIS_ADC1_CAL_VOL_ATTEN3[0],    		// [] wr_dis of ADC1_CAL_VOL_ATTEN3
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_CAL_VOL_ATTEN0[] = {
+    &WR_DIS_ADC2_CAL_VOL_ATTEN0[0],    		// [] wr_dis of ADC2_CAL_VOL_ATTEN0
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_CAL_VOL_ATTEN1[] = {
+    &WR_DIS_ADC2_CAL_VOL_ATTEN1[0],    		// [] wr_dis of ADC2_CAL_VOL_ATTEN1
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_CAL_VOL_ATTEN2[] = {
+    &WR_DIS_ADC2_CAL_VOL_ATTEN2[0],    		// [] wr_dis of ADC2_CAL_VOL_ATTEN2
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_USR_DATA[] = {
+    &WR_DIS_BLOCK_USR_DATA[0],    		// [WR_DIS.USER_DATA] wr_dis of BLOCK_USR_DATA
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_CUSTOM_MAC[] = {
+    &WR_DIS_CUSTOM_MAC[0],    		// [WR_DIS.MAC_CUSTOM WR_DIS.USER_DATA_MAC_CUSTOM] wr_dis of CUSTOM_MAC
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_KEY0[] = {
+    &WR_DIS_BLOCK_KEY0[0],    		// [WR_DIS.KEY0] wr_dis of BLOCK_KEY0
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_KEY1[] = {
+    &WR_DIS_BLOCK_KEY1[0],    		// [WR_DIS.KEY1] wr_dis of BLOCK_KEY1
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_KEY2[] = {
+    &WR_DIS_BLOCK_KEY2[0],    		// [WR_DIS.KEY2] wr_dis of BLOCK_KEY2
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_KEY3[] = {
+    &WR_DIS_BLOCK_KEY3[0],    		// [WR_DIS.KEY3] wr_dis of BLOCK_KEY3
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_KEY4[] = {
+    &WR_DIS_BLOCK_KEY4[0],    		// [WR_DIS.KEY4] wr_dis of BLOCK_KEY4
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_KEY5[] = {
+    &WR_DIS_BLOCK_KEY5[0],    		// [WR_DIS.KEY5] wr_dis of BLOCK_KEY5
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_SYS_DATA2[] = {
+    &WR_DIS_BLOCK_SYS_DATA2[0],    		// [WR_DIS.SYS_DATA_PART2] wr_dis of BLOCK_SYS_DATA2
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_USB_EXCHG_PINS[] = {
-    &WR_DIS_USB_EXCHG_PINS[0],    		// Write protection for USB_EXCHG_PINS
+    &WR_DIS_USB_EXCHG_PINS[0],    		// [] wr_dis of USB_EXCHG_PINS
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_USB_EXT_PHY_ENABLE[] = {
+    &WR_DIS_USB_EXT_PHY_ENABLE[0],    		// [WR_DIS.EXT_PHY_ENABLE] wr_dis of USB_EXT_PHY_ENABLE
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SOFT_DIS_JTAG[] = {
+    &WR_DIS_SOFT_DIS_JTAG[0],    		// [] wr_dis of SOFT_DIS_JTAG
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_RD_DIS[] = {
-    &RD_DIS[0],    		// Read protection
+    &RD_DIS[0],    		// [] Disable reading from BlOCK4-10
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_KEY0[] = {
-    &RD_DIS_KEY0[0],    		// Read protection for EFUSE_BLK4.  KEY0
+const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_KEY0[] = {
+    &RD_DIS_BLOCK_KEY0[0],    		// [RD_DIS.KEY0] rd_dis of BLOCK_KEY0
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_KEY1[] = {
-    &RD_DIS_KEY1[0],    		// Read protection for EFUSE_BLK5.  KEY1
+const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_KEY1[] = {
+    &RD_DIS_BLOCK_KEY1[0],    		// [RD_DIS.KEY1] rd_dis of BLOCK_KEY1
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_KEY2[] = {
-    &RD_DIS_KEY2[0],    		// Read protection for EFUSE_BLK6.  KEY2
+const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_KEY2[] = {
+    &RD_DIS_BLOCK_KEY2[0],    		// [RD_DIS.KEY2] rd_dis of BLOCK_KEY2
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_KEY3[] = {
-    &RD_DIS_KEY3[0],    		// Read protection for EFUSE_BLK7.  KEY3
+const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_KEY3[] = {
+    &RD_DIS_BLOCK_KEY3[0],    		// [RD_DIS.KEY3] rd_dis of BLOCK_KEY3
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_KEY4[] = {
-    &RD_DIS_KEY4[0],    		// Read protection for EFUSE_BLK8.  KEY4
+const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_KEY4[] = {
+    &RD_DIS_BLOCK_KEY4[0],    		// [RD_DIS.KEY4] rd_dis of BLOCK_KEY4
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_KEY5[] = {
-    &RD_DIS_KEY5[0],    		// Read protection for EFUSE_BLK9.  KEY5
+const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_KEY5[] = {
+    &RD_DIS_BLOCK_KEY5[0],    		// [RD_DIS.KEY5] rd_dis of BLOCK_KEY5
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_SYS_DATA_PART2[] = {
-    &RD_DIS_SYS_DATA_PART2[0],    		// Read protection for EFUSE_BLK10. SYS_DATA_PART2
+const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_SYS_DATA2[] = {
+    &RD_DIS_BLOCK_SYS_DATA2[0],    		// [RD_DIS.SYS_DATA_PART2] rd_dis of BLOCK_SYS_DATA2
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_DIS_ICACHE[] = {
-    &DIS_ICACHE[0],    		// Disable Icache
+    &DIS_ICACHE[0],    		// [] Set this bit to disable Icache
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_DIS_DCACHE[] = {
-    &DIS_DCACHE[0],    		// Disable Dcace
+    &DIS_DCACHE[0],    		// [] Set this bit to disable Dcache
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_DIS_DOWNLOAD_ICACHE[] = {
-    &DIS_DOWNLOAD_ICACHE[0],    		// Disable Icache in download mode include boot_mode 0 1 2 3 6 7
+    &DIS_DOWNLOAD_ICACHE[0],    		// [] Set this bit to disable Icache in download mode (boot_mode[3:0] is 0; 1; 2; 3; 6; 7)
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_DIS_DOWNLOAD_DCACHE[] = {
-    &DIS_DOWNLOAD_DCACHE[0],    		// Disable Dcache in download mode include boot_mode 0 1 2 3 6 7
+    &DIS_DOWNLOAD_DCACHE[0],    		// [] Set this bit to disable Dcache in download mode ( boot_mode[3:0] is 0; 1; 2; 3; 6; 7)
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_DIS_FORCE_DOWNLOAD[] = {
-    &DIS_FORCE_DOWNLOAD[0],    		// Disable force chip go to download mode function
+    &DIS_FORCE_DOWNLOAD[0],    		// [] Set this bit to disable the function that forces chip into download mode
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_DIS_USB[] = {
-    &DIS_USB[0],    		// Disable USB function
+const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_OTG[] = {
+    &DIS_USB_OTG[0],    		// [DIS_USB] Set this bit to disable USB function
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_DIS_CAN[] = {
-    &DIS_CAN[0],    		// Disable CAN function
+const esp_efuse_desc_t* ESP_EFUSE_DIS_TWAI[] = {
+    &DIS_TWAI[0],    		// [DIS_CAN] Set this bit to disable CAN function
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_DIS_APP_CPU[] = {
-    &DIS_APP_CPU[0],    		// Disables APP CPU
+    &DIS_APP_CPU[0],    		// [] Disable app cpu
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SOFT_DIS_JTAG[] = {
-    &SOFT_DIS_JTAG[0],    		// Software disables JTAG by programming odd number of 1 bit(s). JTAG can be re-enabled via HMAC peripheral
+    &SOFT_DIS_JTAG[0],    		// [] Set these bits to disable JTAG in the soft way (odd number 1 means disable ). JTAG can be enabled in HMAC module
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_HARD_DIS_JTAG[] = {
-    &HARD_DIS_JTAG[0],    		// Hardware disable jtag permanently disable jtag function
+const esp_efuse_desc_t* ESP_EFUSE_DIS_PAD_JTAG[] = {
+    &DIS_PAD_JTAG[0],    		// [HARD_DIS_JTAG] Set this bit to disable JTAG in the hard way. JTAG is disabled permanently
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_DIS_DOWNLOAD_MANUAL_ENCRYPT[] = {
-    &DIS_DOWNLOAD_MANUAL_ENCRYPT[0],    		// Disable flash encrypt function
+    &DIS_DOWNLOAD_MANUAL_ENCRYPT[0],    		// [] Set this bit to disable flash encryption when in download boot modes
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_USB_EXCHG_PINS[] = {
-    &USB_EXCHG_PINS[0],    		// Exchange D+ D- pins
+    &USB_EXCHG_PINS[0],    		// [] Set this bit to exchange USB D+ and D- pins
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_USB_EXT_PHY_ENABLE[] = {
-    &USB_EXT_PHY_ENABLE[0],    		// Enable external PHY
-    NULL
-};
-
-const esp_efuse_desc_t* ESP_EFUSE_BTLC_GPIO_ENABLE[] = {
-    &BTLC_GPIO_ENABLE[0],    		// Enables BTLC GPIO
+    &USB_EXT_PHY_ENABLE[0],    		// [EXT_PHY_ENABLE] Set this bit to enable external PHY
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_VDD_SPI_XPD[] = {
-    &VDD_SPI_XPD[0],    		// VDD_SPI regulator power up
+    &VDD_SPI_XPD[0],    		// [] SPI regulator power up signal
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_VDD_SPI_TIEH[] = {
-    &VDD_SPI_TIEH[0],    		// VDD_SPI regulator tie high to vdda
+    &VDD_SPI_TIEH[0],    		// [] If VDD_SPI_FORCE is 1; determines VDD_SPI voltage {0: "VDD_SPI connects to 1.8 V LDO"; 1: "VDD_SPI connects to VDD3P3_RTC_IO"}
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_VDD_SPI_FORCE[] = {
-    &VDD_SPI_FORCE[0],    		// Force using eFuse configuration of VDD_SPI
+    &VDD_SPI_FORCE[0],    		// [] Set this bit and force to use the configuration of eFuse to configure VDD_SPI
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_WDT_DELAY_SEL[] = {
-    &WDT_DELAY_SEL[0],    		// Select RTC WDT time out threshold
+    &WDT_DELAY_SEL[0],    		// [] RTC watchdog timeout threshold; in unit of slow clock cycle {0: "40000"; 1: "80000"; 2: "160000"; 3: "320000"}
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SPI_BOOT_CRYPT_CNT[] = {
-    &SPI_BOOT_CRYPT_CNT[0],    		// SPI boot encrypt decrypt enable. odd number 1 enable. even number 1 disable
+    &SPI_BOOT_CRYPT_CNT[0],    		// [] Enables flash encryption when 1 or 3 bits are set and disabled otherwise {0: "Disable"; 1: "Enable"; 3: "Disable"; 7: "Enable"}
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SECURE_BOOT_KEY_REVOKE0[] = {
-    &SECURE_BOOT_KEY_REVOKE0[0],    		// Enable revoke first secure boot key
+    &SECURE_BOOT_KEY_REVOKE0[0],    		// [] Revoke 1st secure boot key
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SECURE_BOOT_KEY_REVOKE1[] = {
-    &SECURE_BOOT_KEY_REVOKE1[0],    		// Enable revoke second secure boot key
+    &SECURE_BOOT_KEY_REVOKE1[0],    		// [] Revoke 2nd secure boot key
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SECURE_BOOT_KEY_REVOKE2[] = {
-    &SECURE_BOOT_KEY_REVOKE2[0],    		// Enable revoke third secure boot key
+    &SECURE_BOOT_KEY_REVOKE2[0],    		// [] Revoke 3rd secure boot key
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_KEY_PURPOSE_0[] = {
-    &KEY_PURPOSE_0[0],    		// Key0 purpose
+    &KEY_PURPOSE_0[0],    		// [KEY0_PURPOSE] Purpose of Key0
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_KEY_PURPOSE_1[] = {
-    &KEY_PURPOSE_1[0],    		// Key1 purpose
+    &KEY_PURPOSE_1[0],    		// [KEY1_PURPOSE] Purpose of Key1
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_KEY_PURPOSE_2[] = {
-    &KEY_PURPOSE_2[0],    		// Key2 purpose
+    &KEY_PURPOSE_2[0],    		// [KEY2_PURPOSE] Purpose of Key2
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_KEY_PURPOSE_3[] = {
-    &KEY_PURPOSE_3[0],    		// Key3 purpose
+    &KEY_PURPOSE_3[0],    		// [KEY3_PURPOSE] Purpose of Key3
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_KEY_PURPOSE_4[] = {
-    &KEY_PURPOSE_4[0],    		// Key4 purpose
+    &KEY_PURPOSE_4[0],    		// [KEY4_PURPOSE] Purpose of Key4
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_KEY_PURPOSE_5[] = {
-    &KEY_PURPOSE_5[0],    		// Key5 purpose
+    &KEY_PURPOSE_5[0],    		// [KEY5_PURPOSE] Purpose of Key5
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SECURE_BOOT_EN[] = {
-    &SECURE_BOOT_EN[0],    		// Secure boot enable
+    &SECURE_BOOT_EN[0],    		// [] Set this bit to enable secure boot
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SECURE_BOOT_AGGRESSIVE_REVOKE[] = {
-    &SECURE_BOOT_AGGRESSIVE_REVOKE[0],    		// Enable aggressive secure boot revoke
+    &SECURE_BOOT_AGGRESSIVE_REVOKE[0],    		// [] Set this bit to enable revoking aggressive secure boot
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_JTAG[] = {
-    &DIS_USB_JTAG[0],    		// Set to disable usb_serial_jtag-to-jtag function
+    &DIS_USB_JTAG[0],    		// [] Set this bit to disable function of usb switch to jtag in module of usb device
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_SERIAL_JTAG[] = {
-    &DIS_USB_SERIAL_JTAG[0],    		// Set to disable usb_serial_jtag module
+    &DIS_USB_SERIAL_JTAG[0],    		// [DIS_USB_DEVICE] Set this bit to disable usb device
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_STRAP_JTAG_SEL[] = {
-    &STRAP_JTAG_SEL[0],    		// Enable selection between usb_to_jtag or pad_to_jtag through gpio10
+    &STRAP_JTAG_SEL[0],    		// [] Set this bit to enable selection between usb_to_jtag and pad_to_jtag through strapping gpio10 when both reg_dis_usb_jtag and reg_dis_pad_jtag are equal to 0
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_USB_PHY_SEL[] = {
-    &USB_PHY_SEL[0],    		// Select internal/external PHY for USB OTG and usb_serial_jtag
+    &USB_PHY_SEL[0],    		// [] This bit is used to switch internal PHY and external PHY for USB OTG and USB Device {0: "internal PHY is assigned to USB Device while external PHY is assigned to USB OTG"; 1: "internal PHY is assigned to USB OTG while external PHY is assigned to USB Device"}
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_FLASH_TPUW[] = {
-    &FLASH_TPUW[0],    		// Flash wait time after power up. (unit is ms). When value is 15. the time is 30 ms
+    &FLASH_TPUW[0],    		// [] Configures flash waiting time after power-up; in unit of ms. If the value is less than 15; the waiting time is the configurable value.  Otherwise; the waiting time is twice the configurable value
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_DIS_DOWNLOAD_MODE[] = {
-    &DIS_DOWNLOAD_MODE[0],    		// Disble download mode include boot_mode[3:0] is 0 1 2 3 6 7
+    &DIS_DOWNLOAD_MODE[0],    		// [] Set this bit to disable download mode (boot_mode[3:0] = 0; 1; 2; 3; 6; 7)
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_DIS_LEGACY_SPI_BOOT[] = {
-    &DIS_LEGACY_SPI_BOOT[0],    		// Disable_Legcy_SPI_boot mode include boot_mode[3:0] is 4
+const esp_efuse_desc_t* ESP_EFUSE_DIS_DIRECT_BOOT[] = {
+    &DIS_DIRECT_BOOT[0],    		// [DIS_LEGACY_SPI_BOOT] Disable direct boot mode
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_UART_PRINT_CHANNEL[] = {
-    &UART_PRINT_CHANNEL[0],    		// 0: UART0. 1: UART1
+const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_SERIAL_JTAG_ROM_PRINT[] = {
+    &DIS_USB_SERIAL_JTAG_ROM_PRINT[0],    		// [UART_PRINT_CHANNEL] USB printing {0: "Enable"; 1: "Disable"}
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_FLASH_ECC_MODE[] = {
-    &FLASH_ECC_MODE[0],    		// Configures the ECC mode for SPI flash. 0:16-byte to 18-byte mode. 1:16-byte to 17-byte mode
+    &FLASH_ECC_MODE[0],    		// [] Flash ECC mode in ROM {0: "16to18 byte"; 1: "16to17 byte"}
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_DOWNLOAD_MODE[] = {
-    &DIS_USB_DOWNLOAD_MODE[0],    		// Disable download through USB
+const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE[] = {
+    &DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE[0],    		// [DIS_USB_DOWNLOAD_MODE] Set this bit to disable UART download mode through USB
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ENABLE_SECURITY_DOWNLOAD[] = {
-    &ENABLE_SECURITY_DOWNLOAD[0],    		// Enable security download mode
+    &ENABLE_SECURITY_DOWNLOAD[0],    		// [] Set this bit to enable secure UART download mode
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_UART_PRINT_CONTROL[] = {
-    &UART_PRINT_CONTROL[0],    		// b00:force print. b01:control by GPIO46 - low level print. b10:control by GPIO46 - high level print. b11:force disable print.
+    &UART_PRINT_CONTROL[0],    		// [] Set the default UART boot message output mode {0: "Enable"; 1: "Enable when GPIO46 is low at reset"; 2: "Enable when GPIO46 is high at reset"; 3: "Disable"}
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_PIN_POWER_SELECTION[] = {
-    &PIN_POWER_SELECTION[0],    		// GPIO33-GPIO37 power supply selection in ROM code. 0:VDD3P3_CPU. 1:VDD_SPI.
+    &PIN_POWER_SELECTION[0],    		// [] Set default power supply for GPIO33-GPIO37; set when SPI flash is initialized {0: "VDD3P3_CPU"; 1: "VDD_SPI"}
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_FLASH_TYPE[] = {
-    &FLASH_TYPE[0],    		// Connected Flash interface type. 0: 4 data line. 1: 8 data line
+    &FLASH_TYPE[0],    		// [] SPI flash type {0: "4 data lines"; 1: "8 data lines"}
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_FLASH_PAGE_SIZE[] = {
-    &FLASH_PAGE_SIZE[0],    		// Sets the size of flash page
+    &FLASH_PAGE_SIZE[0],    		// [] Set Flash page size
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_FLASH_ECC_EN[] = {
-    &FLASH_ECC_EN[0],    		// Enables ECC in Flash boot mode
+    &FLASH_ECC_EN[0],    		// [] Set 1 to enable ECC for flash boot
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_FORCE_SEND_RESUME[] = {
-    &FORCE_SEND_RESUME[0],    		// Force ROM code to send a resume command during SPI boot
+    &FORCE_SEND_RESUME[0],    		// [] Set this bit to force ROM code to send a resume command during SPI boot
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SECURE_VERSION[] = {
-    &SECURE_VERSION[0],    		// Secure version for anti-rollback
+    &SECURE_VERSION[0],    		// [] Secure version (used by ESP-IDF anti-rollback feature)
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_MAC_FACTORY[] = {
-    &MAC_FACTORY[0],    		// Factory MAC addr [0]
-    &MAC_FACTORY[1],    		// Factory MAC addr [1]
-    &MAC_FACTORY[2],    		// Factory MAC addr [2]
-    &MAC_FACTORY[3],    		// Factory MAC addr [3]
-    &MAC_FACTORY[4],    		// Factory MAC addr [4]
-    &MAC_FACTORY[5],    		// Factory MAC addr [5]
+const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_OTG_DOWNLOAD_MODE[] = {
+    &DIS_USB_OTG_DOWNLOAD_MODE[0],    		// [] Set this bit to disable download through USB-OTG
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_DISABLE_WAFER_VERSION_MAJOR[] = {
+    &DISABLE_WAFER_VERSION_MAJOR[0],    		// [] Disables check of wafer version major
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_DISABLE_BLK_VERSION_MAJOR[] = {
+    &DISABLE_BLK_VERSION_MAJOR[0],    		// [] Disables check of blk version major
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_MAC[] = {
+    &MAC[0],    		// [MAC_FACTORY] MAC address
+    &MAC[1],    		// [MAC_FACTORY] MAC address
+    &MAC[2],    		// [MAC_FACTORY] MAC address
+    &MAC[3],    		// [MAC_FACTORY] MAC address
+    &MAC[4],    		// [MAC_FACTORY] MAC address
+    &MAC[5],    		// [MAC_FACTORY] MAC address
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_CLK[] = {
-    &SPI_PAD_CONFIG_CLK[0],    		// SPI_PAD_configure CLK
+    &SPI_PAD_CONFIG_CLK[0],    		// [] SPI_PAD_configure CLK
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_Q_D1[] = {
-    &SPI_PAD_CONFIG_Q_D1[0],    		// SPI_PAD_configure Q(D1)
+const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_Q[] = {
+    &SPI_PAD_CONFIG_Q[0],    		// [] SPI_PAD_configure Q(D1)
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_D_D0[] = {
-    &SPI_PAD_CONFIG_D_D0[0],    		// SPI_PAD_configure D(D0)
+const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_D[] = {
+    &SPI_PAD_CONFIG_D[0],    		// [] SPI_PAD_configure D(D0)
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_CS[] = {
-    &SPI_PAD_CONFIG_CS[0],    		// SPI_PAD_configure CS
+    &SPI_PAD_CONFIG_CS[0],    		// [] SPI_PAD_configure CS
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_HD_D3[] = {
-    &SPI_PAD_CONFIG_HD_D3[0],    		// SPI_PAD_configure HD(D3)
+const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_HD[] = {
+    &SPI_PAD_CONFIG_HD[0],    		// [] SPI_PAD_configure HD(D3)
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_WP_D2[] = {
-    &SPI_PAD_CONFIG_WP_D2[0],    		// SPI_PAD_configure WP(D2)
+const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_WP[] = {
+    &SPI_PAD_CONFIG_WP[0],    		// [] SPI_PAD_configure WP(D2)
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_DQS[] = {
-    &SPI_PAD_CONFIG_DQS[0],    		// SPI_PAD_configure DQS
+    &SPI_PAD_CONFIG_DQS[0],    		// [] SPI_PAD_configure DQS
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_D4[] = {
-    &SPI_PAD_CONFIG_D4[0],    		// SPI_PAD_configure D4
+    &SPI_PAD_CONFIG_D4[0],    		// [] SPI_PAD_configure D4
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_D5[] = {
-    &SPI_PAD_CONFIG_D5[0],    		// SPI_PAD_configure D5
+    &SPI_PAD_CONFIG_D5[0],    		// [] SPI_PAD_configure D5
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_D6[] = {
-    &SPI_PAD_CONFIG_D6[0],    		// SPI_PAD_configure D6
+    &SPI_PAD_CONFIG_D6[0],    		// [] SPI_PAD_configure D6
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_D7[] = {
-    &SPI_PAD_CONFIG_D7[0],    		// SPI_PAD_configure D7
+    &SPI_PAD_CONFIG_D7[0],    		// [] SPI_PAD_configure D7
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_WAFER_VERSION[] = {
-    &WAFER_VERSION[0],    		// WAFER version 0:A
+const esp_efuse_desc_t* ESP_EFUSE_WAFER_VERSION_MINOR_LO[] = {
+    &WAFER_VERSION_MINOR_LO[0],    		// [] WAFER_VERSION_MINOR least significant bits
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_PKG_VERSION[] = {
-    &PKG_VERSION[0],    		// Package version
+    &PKG_VERSION[0],    		// [] Package version
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_BLK_VER_MINOR[] = {
-    &BLK_VER_MINOR[0],    		// BLK_VERSION_MINOR
+const esp_efuse_desc_t* ESP_EFUSE_BLK_VERSION_MINOR[] = {
+    &BLK_VERSION_MINOR[0],    		// [] BLK_VERSION_MINOR
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_FLASH_CAP[] = {
+    &FLASH_CAP[0],    		// [] Flash capacity {0: "None"; 1: "8M"; 2: "4M"}
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_FLASH_TEMP[] = {
+    &FLASH_TEMP[0],    		// [] Flash temperature {0: "None"; 1: "105C"; 2: "85C"}
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_FLASH_VENDOR[] = {
+    &FLASH_VENDOR[0],    		// [] Flash vendor {0: "None"; 1: "XMC"; 2: "GD"; 3: "FM"; 4: "TT"; 5: "BY"}
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_PSRAM_CAP[] = {
+    &PSRAM_CAP[0],    		// [] PSRAM capacity {0: "None"; 1: "8M"; 2: "2M"}
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_PSRAM_TEMP[] = {
+    &PSRAM_TEMP[0],    		// [] PSRAM temperature {0: "None"; 1: "105C"; 2: "85C"}
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_PSRAM_VENDOR[] = {
+    &PSRAM_VENDOR[0],    		// [] PSRAM vendor {0: "None"; 1: "AP_3v3"; 2: "AP_1v8"}
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_K_RTC_LDO[] = {
+    &K_RTC_LDO[0],    		// [] BLOCK1 K_RTC_LDO
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_K_DIG_LDO[] = {
+    &K_DIG_LDO[0],    		// [] BLOCK1 K_DIG_LDO
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_V_RTC_DBIAS20[] = {
+    &V_RTC_DBIAS20[0],    		// [] BLOCK1 voltage of rtc dbias20
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_V_DIG_DBIAS20[] = {
+    &V_DIG_DBIAS20[0],    		// [] BLOCK1 voltage of digital dbias20
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_DIG_DBIAS_HVT[] = {
+    &DIG_DBIAS_HVT[0],    		// [] BLOCK1 digital dbias when hvt
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WAFER_VERSION_MINOR_HI[] = {
+    &WAFER_VERSION_MINOR_HI[0],    		// [] WAFER_VERSION_MINOR most significant bit
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_WAFER_VERSION_MAJOR[] = {
+    &WAFER_VERSION_MAJOR[0],    		// [] WAFER_VERSION_MAJOR
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC2_CAL_VOL_ATTEN3[] = {
-    &ADC2_CAL_VOL_ATTEN3[0],    		// ADC2 calibration voltage at atten3
+    &ADC2_CAL_VOL_ATTEN3[0],    		// [] ADC2 calibration voltage at atten3
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_OPTIONAL_UNIQUE_ID[] = {
-    &OPTIONAL_UNIQUE_ID[0],    		// Optional unique 128-bit ID
+    &OPTIONAL_UNIQUE_ID[0],    		// [] Optional unique 128-bit ID
     NULL
 };
 
-const esp_efuse_desc_t* ESP_EFUSE_BLK_VER_MAJOR[] = {
-    &BLK_VER_MAJOR[0],    		// BLK_VERSION_MAJOR
+const esp_efuse_desc_t* ESP_EFUSE_BLK_VERSION_MAJOR[] = {
+    &BLK_VERSION_MAJOR[0],    		// [] BLK_VERSION_MAJOR of BLOCK2 {0: "No calib"; 1: "ADC calib V1"}
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_TEMP_CALIB[] = {
-    &TEMP_CALIB[0],    		// Temperature calibration data
+    &TEMP_CALIB[0],    		// [] Temperature calibration data
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_OCODE[] = {
-    &OCODE[0],    		// ADC OCode
+    &OCODE[0],    		// [] ADC OCode
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC1_INIT_CODE_ATTEN0[] = {
-    &ADC1_INIT_CODE_ATTEN0[0],    		// ADC1 init code at atten0
+    &ADC1_INIT_CODE_ATTEN0[0],    		// [] ADC1 init code at atten0
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC1_INIT_CODE_ATTEN1[] = {
-    &ADC1_INIT_CODE_ATTEN1[0],    		// ADC1 init code at atten1
+    &ADC1_INIT_CODE_ATTEN1[0],    		// [] ADC1 init code at atten1
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC1_INIT_CODE_ATTEN2[] = {
-    &ADC1_INIT_CODE_ATTEN2[0],    		// ADC1 init code at atten2
+    &ADC1_INIT_CODE_ATTEN2[0],    		// [] ADC1 init code at atten2
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC1_INIT_CODE_ATTEN3[] = {
-    &ADC1_INIT_CODE_ATTEN3[0],    		// ADC1 init code at atten3
+    &ADC1_INIT_CODE_ATTEN3[0],    		// [] ADC1 init code at atten3
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC2_INIT_CODE_ATTEN0[] = {
-    &ADC2_INIT_CODE_ATTEN0[0],    		// ADC2 init code at atten0
+    &ADC2_INIT_CODE_ATTEN0[0],    		// [] ADC2 init code at atten0
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC2_INIT_CODE_ATTEN1[] = {
-    &ADC2_INIT_CODE_ATTEN1[0],    		// ADC2 init code at atten1
+    &ADC2_INIT_CODE_ATTEN1[0],    		// [] ADC2 init code at atten1
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC2_INIT_CODE_ATTEN2[] = {
-    &ADC2_INIT_CODE_ATTEN2[0],    		// ADC2 init code at atten2
+    &ADC2_INIT_CODE_ATTEN2[0],    		// [] ADC2 init code at atten2
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC2_INIT_CODE_ATTEN3[] = {
-    &ADC2_INIT_CODE_ATTEN3[0],    		// ADC2 init code at atten3
+    &ADC2_INIT_CODE_ATTEN3[0],    		// [] ADC2 init code at atten3
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC1_CAL_VOL_ATTEN0[] = {
-    &ADC1_CAL_VOL_ATTEN0[0],    		// ADC1 calibration voltage at atten0
+    &ADC1_CAL_VOL_ATTEN0[0],    		// [] ADC1 calibration voltage at atten0
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC1_CAL_VOL_ATTEN1[] = {
-    &ADC1_CAL_VOL_ATTEN1[0],    		// ADC1 calibration voltage at atten1
+    &ADC1_CAL_VOL_ATTEN1[0],    		// [] ADC1 calibration voltage at atten1
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC1_CAL_VOL_ATTEN2[] = {
-    &ADC1_CAL_VOL_ATTEN2[0],    		// ADC1 calibration voltage at atten2
+    &ADC1_CAL_VOL_ATTEN2[0],    		// [] ADC1 calibration voltage at atten2
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC1_CAL_VOL_ATTEN3[] = {
-    &ADC1_CAL_VOL_ATTEN3[0],    		// ADC1 calibration voltage at atten3
+    &ADC1_CAL_VOL_ATTEN3[0],    		// [] ADC1 calibration voltage at atten3
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC2_CAL_VOL_ATTEN0[] = {
-    &ADC2_CAL_VOL_ATTEN0[0],    		// ADC2 calibration voltage at atten0
+    &ADC2_CAL_VOL_ATTEN0[0],    		// [] ADC2 calibration voltage at atten0
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC2_CAL_VOL_ATTEN1[] = {
-    &ADC2_CAL_VOL_ATTEN1[0],    		// ADC2 calibration voltage at atten1
+    &ADC2_CAL_VOL_ATTEN1[0],    		// [] ADC2 calibration voltage at atten1
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_ADC2_CAL_VOL_ATTEN2[] = {
-    &ADC2_CAL_VOL_ATTEN2[0],    		// ADC2 calibration voltage at atten2
+    &ADC2_CAL_VOL_ATTEN2[0],    		// [] ADC2 calibration voltage at atten2
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_USER_DATA[] = {
-    &USER_DATA[0],    		// User data
+    &USER_DATA[0],    		// [BLOCK_USR_DATA] User data
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_USER_DATA_MAC_CUSTOM[] = {
-    &USER_DATA_MAC_CUSTOM[0],    		// Custom MAC
+    &USER_DATA_MAC_CUSTOM[0],    		// [MAC_CUSTOM CUSTOM_MAC] Custom MAC
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_KEY0[] = {
-    &KEY0[0],    		// Key0 or user data
+    &KEY0[0],    		// [BLOCK_KEY0] Key0 or user data
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_KEY1[] = {
-    &KEY1[0],    		// Key1 or user data
+    &KEY1[0],    		// [BLOCK_KEY1] Key1 or user data
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_KEY2[] = {
-    &KEY2[0],    		// Key2 or user data
+    &KEY2[0],    		// [BLOCK_KEY2] Key2 or user data
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_KEY3[] = {
-    &KEY3[0],    		// Key3 or user data
+    &KEY3[0],    		// [BLOCK_KEY3] Key3 or user data
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_KEY4[] = {
-    &KEY4[0],    		// Key4 or user data
+    &KEY4[0],    		// [BLOCK_KEY4] Key4 or user data
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_KEY5[] = {
-    &KEY5[0],    		// Key5 or user data
+    &KEY5[0],    		// [BLOCK_KEY5] Key5 or user data
     NULL
 };
 
 const esp_efuse_desc_t* ESP_EFUSE_SYS_DATA_PART2[] = {
-    &SYS_DATA_PART2[0],    		// System configuration
+    &SYS_DATA_PART2[0],    		// [BLOCK_SYS_DATA2] System data part 2 (reserved)
     NULL
 };

--- a/components/efuse/esp32s3/include/esp_efuse_table.h
+++ b/components/efuse/esp32s3/include/esp_efuse_table.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2017-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2017-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,8 +8,9 @@
 extern "C" {
 #endif
 
+#include "esp_efuse.h"
 
-// md5_digest_table 9444b887379d924049af42806ca71d45
+// md5_digest_table e0674ff40a1e124670c6eecf33410e76
 // This file was generated from the file esp_efuse_table.csv. DO NOT CHANGE THIS FILE MANUALLY.
 // If you want to change some fields, you need to change esp_efuse_table.csv file
 // then run `efuse_common_table` or `efuse_custom_table` command it will generate this file.
@@ -18,54 +19,172 @@ extern "C" {
 
 extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS[];
 extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_RD_DIS[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_GROUP_1[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_GROUP_2[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_ICACHE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_DCACHE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_DOWNLOAD_ICACHE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_DOWNLOAD_DCACHE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_FORCE_DOWNLOAD[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_USB_OTG[];
+#define ESP_EFUSE_WR_DIS_DIS_USB ESP_EFUSE_WR_DIS_DIS_USB_OTG
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_TWAI[];
+#define ESP_EFUSE_WR_DIS_DIS_CAN ESP_EFUSE_WR_DIS_DIS_TWAI
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_APP_CPU[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_PAD_JTAG[];
+#define ESP_EFUSE_WR_DIS_HARD_DIS_JTAG ESP_EFUSE_WR_DIS_DIS_PAD_JTAG
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_DOWNLOAD_MANUAL_ENCRYPT[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_USB_JTAG[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_USB_SERIAL_JTAG[];
+#define ESP_EFUSE_WR_DIS_DIS_USB_DEVICE ESP_EFUSE_WR_DIS_DIS_USB_SERIAL_JTAG
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_STRAP_JTAG_SEL[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_USB_PHY_SEL[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_VDD_SPI_XPD[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_VDD_SPI_TIEH[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_VDD_SPI_FORCE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_WDT_DELAY_SEL[];
 extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_BOOT_CRYPT_CNT[];
 extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SECURE_BOOT_KEY_REVOKE0[];
 extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SECURE_BOOT_KEY_REVOKE1[];
 extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SECURE_BOOT_KEY_REVOKE2[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY0_PURPOSE[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY1_PURPOSE[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY2_PURPOSE[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY3_PURPOSE[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY4_PURPOSE[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY5_PURPOSE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY_PURPOSE_0[];
+#define ESP_EFUSE_WR_DIS_KEY0_PURPOSE ESP_EFUSE_WR_DIS_KEY_PURPOSE_0
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY_PURPOSE_1[];
+#define ESP_EFUSE_WR_DIS_KEY1_PURPOSE ESP_EFUSE_WR_DIS_KEY_PURPOSE_1
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY_PURPOSE_2[];
+#define ESP_EFUSE_WR_DIS_KEY2_PURPOSE ESP_EFUSE_WR_DIS_KEY_PURPOSE_2
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY_PURPOSE_3[];
+#define ESP_EFUSE_WR_DIS_KEY3_PURPOSE ESP_EFUSE_WR_DIS_KEY_PURPOSE_3
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY_PURPOSE_4[];
+#define ESP_EFUSE_WR_DIS_KEY4_PURPOSE ESP_EFUSE_WR_DIS_KEY_PURPOSE_4
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY_PURPOSE_5[];
+#define ESP_EFUSE_WR_DIS_KEY5_PURPOSE ESP_EFUSE_WR_DIS_KEY_PURPOSE_5
 extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SECURE_BOOT_EN[];
 extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SECURE_BOOT_AGGRESSIVE_REVOKE[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_GROUP_3[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_TPUW[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_DOWNLOAD_MODE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_DIRECT_BOOT[];
+#define ESP_EFUSE_WR_DIS_DIS_LEGACY_SPI_BOOT ESP_EFUSE_WR_DIS_DIS_DIRECT_BOOT
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_USB_SERIAL_JTAG_ROM_PRINT[];
+#define ESP_EFUSE_WR_DIS_UART_PRINT_CHANNEL ESP_EFUSE_WR_DIS_DIS_USB_SERIAL_JTAG_ROM_PRINT
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_ECC_MODE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE[];
+#define ESP_EFUSE_WR_DIS_DIS_USB_DOWNLOAD_MODE ESP_EFUSE_WR_DIS_DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ENABLE_SECURITY_DOWNLOAD[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_UART_PRINT_CONTROL[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_PIN_POWER_SELECTION[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_TYPE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_PAGE_SIZE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_ECC_EN[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FORCE_SEND_RESUME[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SECURE_VERSION[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIS_USB_OTG_DOWNLOAD_MODE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DISABLE_WAFER_VERSION_MAJOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DISABLE_BLK_VERSION_MAJOR[];
 extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLK1[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_MAC[];
+#define ESP_EFUSE_WR_DIS_MAC_FACTORY ESP_EFUSE_WR_DIS_MAC
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_CLK[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_Q[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_D[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_CS[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_HD[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_WP[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_DQS[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_D4[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_D5[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_D6[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SPI_PAD_CONFIG_D7[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_WAFER_VERSION_MINOR_LO[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_PKG_VERSION[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLK_VERSION_MINOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_CAP[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_TEMP[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_FLASH_VENDOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_PSRAM_CAP[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_PSRAM_TEMP[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_PSRAM_VENDOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_K_RTC_LDO[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_K_DIG_LDO[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_V_RTC_DBIAS20[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_V_DIG_DBIAS20[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_DIG_DBIAS_HVT[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_WAFER_VERSION_MINOR_HI[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_WAFER_VERSION_MAJOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_CAL_VOL_ATTEN3[];
 extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SYS_DATA_PART1[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_USER_DATA[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY0[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY1[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY2[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY3[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY4[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_KEY5[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SYS_DATA_PART2[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_OPTIONAL_UNIQUE_ID[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLK_VERSION_MAJOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_TEMP_CALIB[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_OCODE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_INIT_CODE_ATTEN0[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_INIT_CODE_ATTEN1[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_INIT_CODE_ATTEN2[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_INIT_CODE_ATTEN3[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_INIT_CODE_ATTEN0[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_INIT_CODE_ATTEN1[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_INIT_CODE_ATTEN2[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_INIT_CODE_ATTEN3[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_CAL_VOL_ATTEN0[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_CAL_VOL_ATTEN1[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_CAL_VOL_ATTEN2[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC1_CAL_VOL_ATTEN3[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_CAL_VOL_ATTEN0[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_CAL_VOL_ATTEN1[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_ADC2_CAL_VOL_ATTEN2[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_USR_DATA[];
+#define ESP_EFUSE_WR_DIS_USER_DATA ESP_EFUSE_WR_DIS_BLOCK_USR_DATA
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_CUSTOM_MAC[];
+#define ESP_EFUSE_WR_DIS_MAC_CUSTOM ESP_EFUSE_WR_DIS_CUSTOM_MAC
+#define ESP_EFUSE_WR_DIS_USER_DATA_MAC_CUSTOM ESP_EFUSE_WR_DIS_CUSTOM_MAC
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_KEY0[];
+#define ESP_EFUSE_WR_DIS_KEY0 ESP_EFUSE_WR_DIS_BLOCK_KEY0
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_KEY1[];
+#define ESP_EFUSE_WR_DIS_KEY1 ESP_EFUSE_WR_DIS_BLOCK_KEY1
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_KEY2[];
+#define ESP_EFUSE_WR_DIS_KEY2 ESP_EFUSE_WR_DIS_BLOCK_KEY2
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_KEY3[];
+#define ESP_EFUSE_WR_DIS_KEY3 ESP_EFUSE_WR_DIS_BLOCK_KEY3
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_KEY4[];
+#define ESP_EFUSE_WR_DIS_KEY4 ESP_EFUSE_WR_DIS_BLOCK_KEY4
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_KEY5[];
+#define ESP_EFUSE_WR_DIS_KEY5 ESP_EFUSE_WR_DIS_BLOCK_KEY5
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_BLOCK_SYS_DATA2[];
+#define ESP_EFUSE_WR_DIS_SYS_DATA_PART2 ESP_EFUSE_WR_DIS_BLOCK_SYS_DATA2
 extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_USB_EXCHG_PINS[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_USB_EXT_PHY_ENABLE[];
+#define ESP_EFUSE_WR_DIS_EXT_PHY_ENABLE ESP_EFUSE_WR_DIS_USB_EXT_PHY_ENABLE
+extern const esp_efuse_desc_t* ESP_EFUSE_WR_DIS_SOFT_DIS_JTAG[];
 extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS[];
-extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_KEY0[];
-extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_KEY1[];
-extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_KEY2[];
-extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_KEY3[];
-extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_KEY4[];
-extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_KEY5[];
-extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_SYS_DATA_PART2[];
+extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_KEY0[];
+#define ESP_EFUSE_RD_DIS_KEY0 ESP_EFUSE_RD_DIS_BLOCK_KEY0
+extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_KEY1[];
+#define ESP_EFUSE_RD_DIS_KEY1 ESP_EFUSE_RD_DIS_BLOCK_KEY1
+extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_KEY2[];
+#define ESP_EFUSE_RD_DIS_KEY2 ESP_EFUSE_RD_DIS_BLOCK_KEY2
+extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_KEY3[];
+#define ESP_EFUSE_RD_DIS_KEY3 ESP_EFUSE_RD_DIS_BLOCK_KEY3
+extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_KEY4[];
+#define ESP_EFUSE_RD_DIS_KEY4 ESP_EFUSE_RD_DIS_BLOCK_KEY4
+extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_KEY5[];
+#define ESP_EFUSE_RD_DIS_KEY5 ESP_EFUSE_RD_DIS_BLOCK_KEY5
+extern const esp_efuse_desc_t* ESP_EFUSE_RD_DIS_BLOCK_SYS_DATA2[];
+#define ESP_EFUSE_RD_DIS_SYS_DATA_PART2 ESP_EFUSE_RD_DIS_BLOCK_SYS_DATA2
 extern const esp_efuse_desc_t* ESP_EFUSE_DIS_ICACHE[];
 extern const esp_efuse_desc_t* ESP_EFUSE_DIS_DCACHE[];
 extern const esp_efuse_desc_t* ESP_EFUSE_DIS_DOWNLOAD_ICACHE[];
 extern const esp_efuse_desc_t* ESP_EFUSE_DIS_DOWNLOAD_DCACHE[];
 extern const esp_efuse_desc_t* ESP_EFUSE_DIS_FORCE_DOWNLOAD[];
-extern const esp_efuse_desc_t* ESP_EFUSE_DIS_USB[];
-extern const esp_efuse_desc_t* ESP_EFUSE_DIS_CAN[];
+extern const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_OTG[];
+#define ESP_EFUSE_DIS_USB ESP_EFUSE_DIS_USB_OTG
+extern const esp_efuse_desc_t* ESP_EFUSE_DIS_TWAI[];
+#define ESP_EFUSE_DIS_CAN ESP_EFUSE_DIS_TWAI
 extern const esp_efuse_desc_t* ESP_EFUSE_DIS_APP_CPU[];
 extern const esp_efuse_desc_t* ESP_EFUSE_SOFT_DIS_JTAG[];
-extern const esp_efuse_desc_t* ESP_EFUSE_HARD_DIS_JTAG[];
+extern const esp_efuse_desc_t* ESP_EFUSE_DIS_PAD_JTAG[];
+#define ESP_EFUSE_HARD_DIS_JTAG ESP_EFUSE_DIS_PAD_JTAG
 extern const esp_efuse_desc_t* ESP_EFUSE_DIS_DOWNLOAD_MANUAL_ENCRYPT[];
 extern const esp_efuse_desc_t* ESP_EFUSE_USB_EXCHG_PINS[];
 extern const esp_efuse_desc_t* ESP_EFUSE_USB_EXT_PHY_ENABLE[];
-extern const esp_efuse_desc_t* ESP_EFUSE_BTLC_GPIO_ENABLE[];
+#define ESP_EFUSE_EXT_PHY_ENABLE ESP_EFUSE_USB_EXT_PHY_ENABLE
 extern const esp_efuse_desc_t* ESP_EFUSE_VDD_SPI_XPD[];
 extern const esp_efuse_desc_t* ESP_EFUSE_VDD_SPI_TIEH[];
 extern const esp_efuse_desc_t* ESP_EFUSE_VDD_SPI_FORCE[];
@@ -75,23 +194,33 @@ extern const esp_efuse_desc_t* ESP_EFUSE_SECURE_BOOT_KEY_REVOKE0[];
 extern const esp_efuse_desc_t* ESP_EFUSE_SECURE_BOOT_KEY_REVOKE1[];
 extern const esp_efuse_desc_t* ESP_EFUSE_SECURE_BOOT_KEY_REVOKE2[];
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY_PURPOSE_0[];
+#define ESP_EFUSE_KEY0_PURPOSE ESP_EFUSE_KEY_PURPOSE_0
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY_PURPOSE_1[];
+#define ESP_EFUSE_KEY1_PURPOSE ESP_EFUSE_KEY_PURPOSE_1
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY_PURPOSE_2[];
+#define ESP_EFUSE_KEY2_PURPOSE ESP_EFUSE_KEY_PURPOSE_2
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY_PURPOSE_3[];
+#define ESP_EFUSE_KEY3_PURPOSE ESP_EFUSE_KEY_PURPOSE_3
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY_PURPOSE_4[];
+#define ESP_EFUSE_KEY4_PURPOSE ESP_EFUSE_KEY_PURPOSE_4
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY_PURPOSE_5[];
+#define ESP_EFUSE_KEY5_PURPOSE ESP_EFUSE_KEY_PURPOSE_5
 extern const esp_efuse_desc_t* ESP_EFUSE_SECURE_BOOT_EN[];
 extern const esp_efuse_desc_t* ESP_EFUSE_SECURE_BOOT_AGGRESSIVE_REVOKE[];
 extern const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_JTAG[];
 extern const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_SERIAL_JTAG[];
+#define ESP_EFUSE_DIS_USB_DEVICE ESP_EFUSE_DIS_USB_SERIAL_JTAG
 extern const esp_efuse_desc_t* ESP_EFUSE_STRAP_JTAG_SEL[];
 extern const esp_efuse_desc_t* ESP_EFUSE_USB_PHY_SEL[];
 extern const esp_efuse_desc_t* ESP_EFUSE_FLASH_TPUW[];
 extern const esp_efuse_desc_t* ESP_EFUSE_DIS_DOWNLOAD_MODE[];
-extern const esp_efuse_desc_t* ESP_EFUSE_DIS_LEGACY_SPI_BOOT[];
-extern const esp_efuse_desc_t* ESP_EFUSE_UART_PRINT_CHANNEL[];
+extern const esp_efuse_desc_t* ESP_EFUSE_DIS_DIRECT_BOOT[];
+#define ESP_EFUSE_DIS_LEGACY_SPI_BOOT ESP_EFUSE_DIS_DIRECT_BOOT
+extern const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_SERIAL_JTAG_ROM_PRINT[];
+#define ESP_EFUSE_UART_PRINT_CHANNEL ESP_EFUSE_DIS_USB_SERIAL_JTAG_ROM_PRINT
 extern const esp_efuse_desc_t* ESP_EFUSE_FLASH_ECC_MODE[];
-extern const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_DOWNLOAD_MODE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE[];
+#define ESP_EFUSE_DIS_USB_DOWNLOAD_MODE ESP_EFUSE_DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE
 extern const esp_efuse_desc_t* ESP_EFUSE_ENABLE_SECURITY_DOWNLOAD[];
 extern const esp_efuse_desc_t* ESP_EFUSE_UART_PRINT_CONTROL[];
 extern const esp_efuse_desc_t* ESP_EFUSE_PIN_POWER_SELECTION[];
@@ -100,24 +229,41 @@ extern const esp_efuse_desc_t* ESP_EFUSE_FLASH_PAGE_SIZE[];
 extern const esp_efuse_desc_t* ESP_EFUSE_FLASH_ECC_EN[];
 extern const esp_efuse_desc_t* ESP_EFUSE_FORCE_SEND_RESUME[];
 extern const esp_efuse_desc_t* ESP_EFUSE_SECURE_VERSION[];
-extern const esp_efuse_desc_t* ESP_EFUSE_MAC_FACTORY[];
+extern const esp_efuse_desc_t* ESP_EFUSE_DIS_USB_OTG_DOWNLOAD_MODE[];
+extern const esp_efuse_desc_t* ESP_EFUSE_DISABLE_WAFER_VERSION_MAJOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_DISABLE_BLK_VERSION_MAJOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_MAC[];
+#define ESP_EFUSE_MAC_FACTORY ESP_EFUSE_MAC
 extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_CLK[];
-extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_Q_D1[];
-extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_D_D0[];
+extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_Q[];
+extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_D[];
 extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_CS[];
-extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_HD_D3[];
-extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_WP_D2[];
+extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_HD[];
+extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_WP[];
 extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_DQS[];
 extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_D4[];
 extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_D5[];
 extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_D6[];
 extern const esp_efuse_desc_t* ESP_EFUSE_SPI_PAD_CONFIG_D7[];
-extern const esp_efuse_desc_t* ESP_EFUSE_WAFER_VERSION[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WAFER_VERSION_MINOR_LO[];
 extern const esp_efuse_desc_t* ESP_EFUSE_PKG_VERSION[];
-extern const esp_efuse_desc_t* ESP_EFUSE_BLK_VER_MINOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_BLK_VERSION_MINOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_FLASH_CAP[];
+extern const esp_efuse_desc_t* ESP_EFUSE_FLASH_TEMP[];
+extern const esp_efuse_desc_t* ESP_EFUSE_FLASH_VENDOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_PSRAM_CAP[];
+extern const esp_efuse_desc_t* ESP_EFUSE_PSRAM_TEMP[];
+extern const esp_efuse_desc_t* ESP_EFUSE_PSRAM_VENDOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_K_RTC_LDO[];
+extern const esp_efuse_desc_t* ESP_EFUSE_K_DIG_LDO[];
+extern const esp_efuse_desc_t* ESP_EFUSE_V_RTC_DBIAS20[];
+extern const esp_efuse_desc_t* ESP_EFUSE_V_DIG_DBIAS20[];
+extern const esp_efuse_desc_t* ESP_EFUSE_DIG_DBIAS_HVT[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WAFER_VERSION_MINOR_HI[];
+extern const esp_efuse_desc_t* ESP_EFUSE_WAFER_VERSION_MAJOR[];
 extern const esp_efuse_desc_t* ESP_EFUSE_ADC2_CAL_VOL_ATTEN3[];
 extern const esp_efuse_desc_t* ESP_EFUSE_OPTIONAL_UNIQUE_ID[];
-extern const esp_efuse_desc_t* ESP_EFUSE_BLK_VER_MAJOR[];
+extern const esp_efuse_desc_t* ESP_EFUSE_BLK_VERSION_MAJOR[];
 extern const esp_efuse_desc_t* ESP_EFUSE_TEMP_CALIB[];
 extern const esp_efuse_desc_t* ESP_EFUSE_OCODE[];
 extern const esp_efuse_desc_t* ESP_EFUSE_ADC1_INIT_CODE_ATTEN0[];
@@ -136,14 +282,24 @@ extern const esp_efuse_desc_t* ESP_EFUSE_ADC2_CAL_VOL_ATTEN0[];
 extern const esp_efuse_desc_t* ESP_EFUSE_ADC2_CAL_VOL_ATTEN1[];
 extern const esp_efuse_desc_t* ESP_EFUSE_ADC2_CAL_VOL_ATTEN2[];
 extern const esp_efuse_desc_t* ESP_EFUSE_USER_DATA[];
+#define ESP_EFUSE_BLOCK_USR_DATA ESP_EFUSE_USER_DATA
 extern const esp_efuse_desc_t* ESP_EFUSE_USER_DATA_MAC_CUSTOM[];
+#define ESP_EFUSE_MAC_CUSTOM ESP_EFUSE_USER_DATA_MAC_CUSTOM
+#define ESP_EFUSE_CUSTOM_MAC ESP_EFUSE_USER_DATA_MAC_CUSTOM
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY0[];
+#define ESP_EFUSE_BLOCK_KEY0 ESP_EFUSE_KEY0
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY1[];
+#define ESP_EFUSE_BLOCK_KEY1 ESP_EFUSE_KEY1
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY2[];
+#define ESP_EFUSE_BLOCK_KEY2 ESP_EFUSE_KEY2
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY3[];
+#define ESP_EFUSE_BLOCK_KEY3 ESP_EFUSE_KEY3
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY4[];
+#define ESP_EFUSE_BLOCK_KEY4 ESP_EFUSE_KEY4
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY5[];
+#define ESP_EFUSE_BLOCK_KEY5 ESP_EFUSE_KEY5
 extern const esp_efuse_desc_t* ESP_EFUSE_SYS_DATA_PART2[];
+#define ESP_EFUSE_BLOCK_SYS_DATA2 ESP_EFUSE_SYS_DATA_PART2
 
 #ifdef __cplusplus
 }

--- a/components/esp_common/include/esp_assert.h
+++ b/components/esp_common/include/esp_assert.h
@@ -16,15 +16,21 @@
 
 #include "assert.h"
 
+#ifndef __cplusplus
+    #define ESP_STATIC_ASSERT _Static_assert
+#else // __cplusplus
+    #define ESP_STATIC_ASSERT static_assert
+#endif // __cplusplus
+
 /* Assert at compile time if possible, runtime otherwise */
 #ifndef __cplusplus
 /* __builtin_choose_expr() is only in C, makes this a lot cleaner */
 #define TRY_STATIC_ASSERT(CONDITION, MSG) do {                                                              \
-            _Static_assert(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
+            ESP_STATIC_ASSERT(__builtin_choose_expr(__builtin_constant_p(CONDITION), (CONDITION), 1), #MSG);   \
             assert(#MSG && (CONDITION));                                                                    \
         } while(0)
 #else
-/* for C++, use __attribute__((error)) - works almost as well as _Static_assert */
+/* for C++, use __attribute__((error)) - works almost as well as ESP_STATIC_ASSERT */
 #define TRY_STATIC_ASSERT(CONDITION, MSG) do {                                                              \
             if (__builtin_constant_p(CONDITION) && !(CONDITION)) {          \
                 extern __attribute__((error(#MSG))) void failed_compile_time_assert(void);      \

--- a/components/esp_hw_support/include/esp_private/sar_periph_ctrl.h
+++ b/components/esp_hw_support/include/esp_private/sar_periph_ctrl.h
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * SAR related peripherals are interdependent. This file
+ * provides a united control to these registers, as multiple
+ * components require these controls.
+ *
+ * See target/sar_periph_ctrl.c to know involved peripherals
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialise SAR related peripheral register settings
+ * Should only be used when running into app stage
+ */
+void sar_periph_ctrl_init(void);
+
+
+/*------------------------------------------------------------------------------
+* ADC Power
+*----------------------------------------------------------------------------*/
+/**
+ * @brief Acquire the ADC oneshot mode power
+ */
+void sar_periph_ctrl_adc_oneshot_power_acquire(void);
+
+/**
+ * @brief Release the ADC oneshot mode power
+ */
+void sar_periph_ctrl_adc_oneshot_power_release(void);
+
+/**
+ * @brief Acquire the ADC continuous mode power
+ */
+void sar_periph_ctrl_adc_continuous_power_acquire(void);
+
+/**
+ * @brief Release the ADC ADC continuous mode power
+ */
+void sar_periph_ctrl_adc_continuous_power_release(void);
+
+
+/*------------------------------------------------------------------------------
+* PWDET Power
+*----------------------------------------------------------------------------*/
+/**
+ * @brief Acquire the PWDET Power
+ */
+void sar_periph_ctrl_pwdet_power_acquire(void);
+
+/**
+ * @brief Release the PWDET Power
+ */
+void sar_periph_ctrl_pwdet_power_release(void);
+
+/**
+ * @brief Enable SAR power when system wakes up
+ */
+void sar_periph_ctrl_power_enable(void);
+
+/**
+ * @brief Disable SAR power when system goes to sleep
+ */
+void sar_periph_ctrl_power_disable(void);
+
+/**
+ * @brief Acquire the temperature sensor power
+ */
+void temperature_sensor_power_acquire(void);
+
+/**
+ * @brief Release the temperature sensor power
+ */
+void temperature_sensor_power_release(void);
+
+/**
+ * @brief Get the temperature value and choose the temperature sensor range. Will be both used in phy and peripheral.
+ *
+ * @param range_changed Pointer to whether range has been changed here. If you don't need this param, you can
+ *        set NULL directly.
+ *
+ * @return temperature sensor value.
+ */
+int16_t temp_sensor_get_raw_value(bool *range_changed);
+
+/**
+ * @brief Synchronize the tsens_idx between sar_periph and driver
+ *
+ * @param tsens_idx index value of temperature sensor attribute
+ */
+void temp_sensor_sync_tsens_idx(int tsens_idx);
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/esp_hw_support/port/esp32s3/rtc_init.c
+++ b/components/esp_hw_support/port/esp32s3/rtc_init.c
@@ -22,6 +22,9 @@
 #include "esp_efuse.h"
 #include "esp_efuse_table.h"
 #include "esp_private/spi_flash_os.h"
+#ifndef BOOTLOADER_BUILD
+#include "esp_private/sar_periph_ctrl.h"
+#endif
 
 
 #define RTC_CNTL_MEM_FORCE_NOISO (RTC_CNTL_SLOWMEM_FORCE_NOISO | RTC_CNTL_FASTMEM_FORCE_NOISO)
@@ -30,6 +33,13 @@ static const char *TAG = "rtcinit";
 
 static void set_ocode_by_efuse(int calib_version);
 static void calibrate_ocode(void);
+static void rtc_set_stored_dbias(void);
+
+// Initial values are used for bootloader, and these variables will be re-assigned based on efuse values during application startup
+uint32_t g_dig_dbias_pvt_240m = 28;
+uint32_t g_rtc_dbias_pvt_240m = 28;
+uint32_t g_dig_dbias_pvt_non_240m = 27;
+uint32_t g_rtc_dbias_pvt_non_240m = 27;
 
 void rtc_init(rtc_config_t cfg)
 {
@@ -67,10 +77,12 @@ void rtc_init(rtc_config_t cfg)
     /* Reset RTC bias to default value (needed if waking up from deep sleep) */
     REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_EXT_RTC_DREG_SLEEP, RTC_CNTL_DBIAS_1V10);
     REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_EXT_RTC_DREG, RTC_CNTL_DBIAS_1V10);
+    /* Set the wait time to the default value. */
+    REG_SET_FIELD(RTC_CNTL_TIMER2_REG, RTC_CNTL_ULPCP_TOUCH_START_WAIT, RTC_CNTL_ULPCP_TOUCH_START_WAIT_DEFAULT);
 
     if (cfg.cali_ocode) {
         uint32_t blk_ver_major = 0;
-        esp_err_t err = esp_efuse_read_field_blob(ESP_EFUSE_BLK_VER_MAJOR, &blk_ver_major, ESP_EFUSE_BLK_VER_MAJOR[0]->bit_count);
+        esp_err_t err = esp_efuse_read_field_blob(ESP_EFUSE_BLK_VERSION_MAJOR, &blk_ver_major, ESP_EFUSE_BLK_VERSION_MAJOR[0]->bit_count); // IDF-5366
         if (err != ESP_OK) {
             blk_ver_major = 0;
             SOC_LOGW(TAG, "efuse read fail, set default blk_ver_major: %d\n", blk_ver_major);
@@ -84,6 +96,12 @@ void rtc_init(rtc_config_t cfg)
             calibrate_ocode();
         }
     }
+
+    //LDO dbias initialization
+    rtc_set_stored_dbias();
+
+    REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_EXT_RTC_DREG, g_rtc_dbias_pvt_non_240m);
+    REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_EXT_DIG_DREG, g_dig_dbias_pvt_non_240m);
 
     if (cfg.clkctl_init) {
         //clear CMMU clock force on
@@ -179,6 +197,11 @@ void rtc_init(rtc_config_t cfg)
 
     REG_WRITE(RTC_CNTL_INT_ENA_REG, 0);
     REG_WRITE(RTC_CNTL_INT_CLR_REG, UINT32_MAX);
+
+#ifndef BOOTLOADER_BUILD
+    //initialise SAR related peripheral register settings
+    // sar_periph_ctrl_init();
+#endif
 }
 
 rtc_vddsdio_config_t rtc_vddsdio_get_config(void)
@@ -298,4 +321,123 @@ static void calibrate_ocode(void)
     //System clock is switched back to PLL. Here we switch to the MSPI high speed mode, add the delays back
     spi_timing_change_speed_mode_cache_safe(false);
 #endif
+}
+
+static uint32_t get_dig_dbias_by_efuse(uint8_t pvt_scheme_ver)
+{
+    assert(pvt_scheme_ver == 1);
+    uint32_t dig_dbias = 28;
+    esp_err_t err = esp_efuse_read_field_blob(ESP_EFUSE_DIG_DBIAS_HVT, &dig_dbias, ESP_EFUSE_DIG_DBIAS_HVT[0]->bit_count);
+    if (err != ESP_OK) {
+        dig_dbias = 28;
+        SOC_LOGW(TAG, "efuse read fail, set default dig_dbias value: %d\n", dig_dbias);
+    }
+    return dig_dbias;
+}
+
+static uint32_t get_rtc_dbias_by_efuse(uint8_t pvt_scheme_ver, uint32_t dig_dbias)
+{
+    assert(pvt_scheme_ver == 1);
+    uint32_t rtc_dbias = 0;
+    signed int k_rtc_ldo = 0, k_dig_ldo = 0, v_rtc_bias20 = 0, v_dig_bias20 = 0;
+    esp_err_t err0 = esp_efuse_read_field_blob(ESP_EFUSE_K_RTC_LDO, &k_rtc_ldo, ESP_EFUSE_K_RTC_LDO[0]->bit_count);
+    esp_err_t err1 = esp_efuse_read_field_blob(ESP_EFUSE_K_DIG_LDO, &k_dig_ldo, ESP_EFUSE_K_DIG_LDO[0]->bit_count);
+    esp_err_t err2 = esp_efuse_read_field_blob(ESP_EFUSE_V_RTC_DBIAS20, &v_rtc_bias20, ESP_EFUSE_V_RTC_DBIAS20[0]->bit_count);
+    esp_err_t err3 = esp_efuse_read_field_blob(ESP_EFUSE_V_DIG_DBIAS20, &v_dig_bias20, ESP_EFUSE_V_DIG_DBIAS20[0]->bit_count);
+    if ((err0 != ESP_OK) | (err1 != ESP_OK) | (err2 != ESP_OK) | (err3 != ESP_OK)) {
+        k_rtc_ldo = 0;
+        k_dig_ldo = 0;
+        v_rtc_bias20 = 0;
+        v_dig_bias20 = 0;
+        SOC_LOGW(TAG, "efuse read fail, k_rtc_ldo: %d, k_dig_ldo: %d, v_rtc_bias20: %d,  v_dig_bias20: %d\n", k_rtc_ldo, k_dig_ldo, v_rtc_bias20, v_dig_bias20);
+        }
+
+    k_rtc_ldo =  ((k_rtc_ldo & BIT(6)) != 0)? -(k_rtc_ldo & 0x3f): (uint8_t)k_rtc_ldo;
+    k_dig_ldo =  ((k_dig_ldo & BIT(6)) != 0)? -(k_dig_ldo & 0x3f): (uint8_t)k_dig_ldo;
+    v_rtc_bias20 =  ((v_rtc_bias20 & BIT(7)) != 0)? -(v_rtc_bias20 & 0x7f): (uint8_t)v_rtc_bias20;
+    v_dig_bias20 =  ((v_dig_bias20 & BIT(7)) != 0)? -(v_dig_bias20 & 0x7f): (uint8_t)v_dig_bias20;
+
+    uint32_t v_rtc_dbias20_real_mul10000 = V_RTC_MID_MUL10000 + v_rtc_bias20 * 10000 / 500;
+    uint32_t v_dig_dbias20_real_mul10000 = V_DIG_MID_MUL10000 + v_dig_bias20 * 10000 / 500;
+    signed int k_rtc_ldo_real_mul10000 = K_RTC_MID_MUL10000 + k_rtc_ldo;
+    signed int k_dig_ldo_real_mul10000 = K_DIG_MID_MUL10000 + k_dig_ldo;
+    uint32_t v_dig_nearest_1v15_mul10000 = v_dig_dbias20_real_mul10000 + k_dig_ldo_real_mul10000 * (dig_dbias - 20);
+    for (rtc_dbias = 15; rtc_dbias < 31; rtc_dbias++) {
+        uint32_t v_rtc_nearest_1v15_mul10000 = 0;
+        v_rtc_nearest_1v15_mul10000 = v_rtc_dbias20_real_mul10000 + k_rtc_ldo_real_mul10000 * (rtc_dbias - 20);
+        if (v_rtc_nearest_1v15_mul10000 >= v_dig_nearest_1v15_mul10000 - 250) {
+            break;
+        }
+    }
+    return rtc_dbias;
+}
+
+static uint32_t get_dig1v3_dbias_by_efuse(uint8_t pvt_scheme_ver)
+{
+    assert(pvt_scheme_ver == 1);
+    signed int k_dig_ldo = 0, v_dig_bias20 = 0;
+    esp_err_t err0 = esp_efuse_read_field_blob(ESP_EFUSE_K_DIG_LDO, &k_dig_ldo, ESP_EFUSE_K_DIG_LDO[0]->bit_count);
+    esp_err_t err1 = esp_efuse_read_field_blob(ESP_EFUSE_V_DIG_DBIAS20, &v_dig_bias20, ESP_EFUSE_V_DIG_DBIAS20[0]->bit_count);
+    if ((err0 != ESP_OK) | (err1 != ESP_OK)) {
+        k_dig_ldo = 0;
+        v_dig_bias20 = 0;
+        SOC_LOGW(TAG, "efuse read fail, k_dig_ldo: %d,  v_dig_bias20: %d\n",  k_dig_ldo, v_dig_bias20);
+    }
+
+    k_dig_ldo =  ((k_dig_ldo & BIT(6)) != 0)? -(k_dig_ldo & 0x3f): (uint8_t)k_dig_ldo;
+    v_dig_bias20 =  ((v_dig_bias20 & BIT(7)) != 0)? -(v_dig_bias20 & 0x7f): (uint8_t)v_dig_bias20;
+
+    uint32_t v_dig_dbias20_real_mul10000 = V_DIG_MID_MUL10000 + v_dig_bias20 * 10000 / 500;
+    signed int k_dig_ldo_real_mul10000 = K_DIG_MID_MUL10000 + k_dig_ldo;
+    uint32_t dig_dbias =15;
+    for (dig_dbias = 15; dig_dbias < 31; dig_dbias++) {
+        uint32_t v_dig_nearest_1v3_mul10000 = 0;
+        v_dig_nearest_1v3_mul10000 = v_dig_dbias20_real_mul10000 + k_dig_ldo_real_mul10000 * (dig_dbias - 20);
+        if (v_dig_nearest_1v3_mul10000 >= 13000) {
+            break;
+        }
+    }
+    return dig_dbias;
+}
+
+static void rtc_set_stored_dbias(void)
+{
+    /*
+    1. a reasonable dig_dbias which by scaning pvt to make 240 CPU run successful stored in efuse;
+    2. also we store some value in efuse, include:
+        k_rtc_ldo (slope of rtc voltage & rtc_dbias);
+        k_dig_ldo (slope of digital voltage & digital_dbias);
+        v_rtc_bias20 (rtc voltage when rtc dbais is 20);
+        v_dig_bias20 (digital voltage when digital dbais is 20).
+    3. a reasonable rtc_dbias can be calculated by a certion formula.
+    4. save these values for reuse
+    */
+    uint32_t  blk_minor = 0, blk_major = 0;
+    esp_err_t err0 = esp_efuse_read_field_blob(ESP_EFUSE_BLK_VERSION_MINOR, &blk_minor, ESP_EFUSE_BLK_VERSION_MINOR[0]->bit_count);
+    esp_err_t err1 = esp_efuse_read_field_blob(ESP_EFUSE_BLK_VERSION_MAJOR, &blk_major, ESP_EFUSE_BLK_VERSION_MAJOR[0]->bit_count);
+    if ((err0 != ESP_OK) | (err1 != ESP_OK)) {
+        blk_minor = 0;
+        blk_major = 0;
+        SOC_LOGW(TAG, "efuse read fail, blk_minor: %d,  blk_major: %d\n",  blk_minor, blk_major);
+    }
+    uint8_t pvt_scheme_ver = 0;
+    if ( (blk_major <= 1 && blk_minor == 1) || blk_major > 1 || (blk_major == 1 && blk_minor >= 2) ) {
+        /* PVT supported after blk_ver 1.2 */
+        pvt_scheme_ver = 1;
+    }
+
+    if (pvt_scheme_ver == 1) {
+        uint32_t dig1v3_dbias = get_dig1v3_dbias_by_efuse(pvt_scheme_ver);
+        uint32_t dig_dbias = get_dig_dbias_by_efuse(pvt_scheme_ver);
+        if (dig_dbias != 0) {
+            g_dig_dbias_pvt_240m = MIN(dig1v3_dbias, dig_dbias + 3);
+            g_dig_dbias_pvt_non_240m = MIN(dig1v3_dbias, dig_dbias + 2);
+            g_rtc_dbias_pvt_240m = get_rtc_dbias_by_efuse(pvt_scheme_ver, g_dig_dbias_pvt_240m);
+            g_rtc_dbias_pvt_non_240m = get_rtc_dbias_by_efuse(pvt_scheme_ver, g_dig_dbias_pvt_non_240m);
+        } else {
+            SOC_LOGD(TAG, "not burn core voltage in efuse or burn wrong voltage value in blk version: 0%d\n", pvt_scheme_ver);
+        }
+    } else {
+        SOC_LOGD(TAG, "core voltage not decided in efuse, use default value.");
+    }
 }

--- a/components/esp_hw_support/port/esp32s3/rtc_pm.c
+++ b/components/esp_hw_support/port/esp32s3/rtc_pm.c
@@ -45,9 +45,7 @@ pm_sw_reject_t pm_set_sleep_mode(pm_sleep_mode_t sleep_mode, void(*pmac_save_par
     switch (sleep_mode) {
     case PM_LIGHT_SLEEP:
         cfg.wifi_pd_en = 1;
-        cfg.dig_dbias_wak = 4;
         cfg.dig_dbias_slp = 0;
-        cfg.rtc_dbias_wak = 0;
         cfg.rtc_dbias_slp = 0;
         rtc_sleep_init(cfg);
         break;

--- a/components/esp_hw_support/port/esp32s3/rtc_sleep.c
+++ b/components/esp_hw_support/port/esp32s3/rtc_sleep.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdint.h>
+#include "esp_attr.h"
 #include "soc/soc.h"
 #include "soc/rtc.h"
 #include "soc/rtc_cntl_reg.h"
@@ -22,13 +23,14 @@
 
 #define RTC_CNTL_MEM_FOLW_CPU (RTC_CNTL_SLOWMEM_FOLW_CPU | RTC_CNTL_FASTMEM_FOLW_CPU)
 
+static const DRAM_ATTR rtc_sleep_pu_config_t pu_cfg = RTC_SLEEP_PU_CONFIG_ALL(1);
+
 /**
  * Configure whether certain peripherals are powered up in sleep
  * @param cfg power down flags as rtc_sleep_pu_config_t structure
  */
 void rtc_sleep_pu(rtc_sleep_pu_config_t cfg)
 {
-#if !CONFIG_IDF_ENV_FPGA
     REG_SET_FIELD(RTC_CNTL_DIG_PWC_REG, RTC_CNTL_LSLP_MEM_FORCE_PU, cfg.dig_fpu);
     REG_SET_FIELD(RTC_CNTL_PWC_REG, RTC_CNTL_FASTMEM_FORCE_LPU, cfg.rtc_fpu);
     REG_SET_FIELD(RTC_CNTL_PWC_REG, RTC_CNTL_SLOWMEM_FORCE_LPU, cfg.rtc_fpu);
@@ -42,7 +44,6 @@ void rtc_sleep_pu(rtc_sleep_pu_config_t cfg)
     REG_SET_FIELD(NRXPD_CTRL, NRX_DEMAP_FORCE_PU, cfg.nrx_fpu);
     REG_SET_FIELD(FE_GEN_CTRL, FE_IQ_EST_FORCE_PU, cfg.fe_fpu);
     REG_SET_FIELD(FE2_TX_INTERP_CTRL, FE2_TX_INF_FORCE_PU, cfg.fe_fpu);
-#endif
     if (cfg.sram_fpu) {
         REG_SET_FIELD(SYSCON_MEM_POWER_UP_REG, SYSCON_SRAM_POWER_UP, SYSCON_SRAM_POWER_UP);
     } else {
@@ -55,13 +56,132 @@ void rtc_sleep_pu(rtc_sleep_pu_config_t cfg)
     }
 }
 
+void rtc_sleep_get_default_config(uint32_t sleep_flags, rtc_sleep_config_t *out_config)
+{
+    *out_config = (rtc_sleep_config_t) {
+        .lslp_mem_inf_fpu = 0,
+        .rtc_mem_inf_follow_cpu = (sleep_flags & RTC_SLEEP_PD_RTC_MEM_FOLLOW_CPU) ? 1 : 0,
+        .rtc_fastmem_pd_en = (sleep_flags & RTC_SLEEP_PD_RTC_FAST_MEM) ? 1 : 0,
+        .rtc_slowmem_pd_en = (sleep_flags & RTC_SLEEP_PD_RTC_SLOW_MEM) ? 1 : 0,
+        .rtc_peri_pd_en = (sleep_flags & RTC_SLEEP_PD_RTC_PERIPH) ? 1 : 0,
+        .wifi_pd_en = (sleep_flags & RTC_SLEEP_PD_WIFI) ? 1 : 0,
+        .bt_pd_en = (sleep_flags & RTC_SLEEP_PD_BT) ? 1 : 0,
+        .cpu_pd_en = (sleep_flags & RTC_SLEEP_PD_CPU) ? 1 : 0,
+        .int_8m_pd_en = (sleep_flags & RTC_SLEEP_PD_INT_8M) ? 1 : 0,
+        .dig_peri_pd_en = (sleep_flags & RTC_SLEEP_PD_DIG_PERIPH) ? 1 : 0,
+        .deep_slp = (sleep_flags & RTC_SLEEP_PD_DIG) ? 1 : 0,
+        .wdt_flashboot_mod_en = 0,
+        .vddsdio_pd_en = (sleep_flags & RTC_SLEEP_PD_VDDSDIO) ? 1 : 0,
+        .xtal_fpu = (sleep_flags & RTC_SLEEP_PD_XTAL) ? 0 : 1,
+        .deep_slp_reject = 1,
+        .light_slp_reject = 1,
+        .rtc_dbias_slp = RTC_CNTL_DBIAS_1V10
+    };
+
+    if (sleep_flags & RTC_SLEEP_PD_DIG) {
+        assert(sleep_flags & RTC_SLEEP_PD_XTAL);
+        out_config->dig_dbias_slp = 0;  //not used
+        //rtc voltage from high to low
+        if ((sleep_flags & RTC_SLEEP_USE_ADC_TESEN_MONITOR) || (!(sleep_flags & RTC_SLEEP_PD_INT_8M))) {
+            /*
+             * rtc voltage in sleep mode >= 0.9v
+             * if 8MD256 select as RTC slow clock src, only need dbg_atten_slp set to 0
+             * Support all features:
+             * - 8MD256 as RTC slow clock src
+             * - ADC/Temperature sensor in monitor mode (ULP) (also need pd_cur_monitor = 0)
+             * - RTC IO as input
+             * - RTC Memory at high temperature
+             * - ULP
+             * - Touch sensor
+             */
+            out_config->rtc_regulator_fpu = 1;
+            out_config->dbg_atten_slp = RTC_CNTL_DBG_ATTEN_DEEPSLEEP_NODROP;
+        } else if (sleep_flags & RTC_SLEEP_NO_ULTRA_LOW) {
+            /*
+             * rtc voltage in sleep mode >= 0.7v (default mode):
+             * Support follow features:
+             * - RTC IO as input
+             * - RTC Memory at high temperature
+             * - ULP
+             * - Touch sensor
+             */
+            out_config->rtc_regulator_fpu = 1;
+            out_config->dbg_atten_slp = RTC_CNTL_DBG_ATTEN_DEEPSLEEP_DEFAULT;
+        } else {
+            /*
+             * rtc regulator not opened and rtc voltage is about 0.66v (ultra low power):
+             * Support follow features:
+             * - ULP
+             * - Touch sensor
+             */
+            out_config->rtc_regulator_fpu = 0;
+            out_config->dbg_atten_slp = RTC_CNTL_DBG_ATTEN_DEEPSLEEP_ULTRA_LOW;
+        }
+    } else {
+        out_config->rtc_regulator_fpu = 1;
+        //voltage from high to low
+        if ((sleep_flags & RTC_SLEEP_DIG_USE_8M) || !(sleep_flags & RTC_SLEEP_PD_XTAL)) {
+            /*
+             * digital voltage not less than 1.1v, rtc voltage is about 1.1v
+             * Support all features:
+             * - XTAL
+             * - RC 8M used by digital system
+             * - 8MD256 as RTC slow clock src (only need dbg_atten_slp to 0)
+             * - ADC/Temperature sensor in monitor mode (ULP) (also need pd_cur_monitor = 0)
+
+             * - ULP
+             * - Touch sensor
+             */
+            out_config->dbg_atten_slp = RTC_CNTL_DBG_ATTEN_LIGHTSLEEP_NODROP;
+            out_config->dig_dbias_slp = RTC_CNTL_DBIAS_1V10;
+        } else if (!(sleep_flags & RTC_SLEEP_PD_INT_8M)){
+            /*
+             * dbg_atten_slp need to set to 0.
+             * digital voltage is about 0.67v, rtc voltage is about 1.1v
+             * Support features:
+             * - 8MD256 as RTC slow clock src
+             * - ADC/Temperature sensor in monitor mode (ULP) (also need pd_cur_monitor = 0)
+             * - ULP
+             * - Touch sensor
+            */
+            out_config->dbg_atten_slp = RTC_CNTL_DBG_ATTEN_LIGHTSLEEP_NODROP;
+            out_config->dig_dbias_slp = 0;
+        } else {
+            /*
+             * digital voltage not less than 0.6v, rtc voltage is about 0.95v
+             * Support features:
+             * - ADC/Temperature sensor in monitor mode (ULP) (also need pd_cur_monitor = 0)
+             * - ULP
+             * - Touch sensor
+            */
+            out_config->dbg_atten_slp = RTC_CNTL_DBG_ATTEN_LIGHTSLEEP_DEFAULT;
+            out_config->dig_dbias_slp = RTC_CNTL_DBIAS_SLP;
+        }
+    }
+
+    if (!(sleep_flags & RTC_SLEEP_PD_XTAL)) {
+        out_config->bias_sleep_monitor = RTC_CNTL_BIASSLP_MONITOR_ON;
+        out_config->pd_cur_monitor = RTC_CNTL_PD_CUR_MONITOR_ON;
+
+        out_config->bias_sleep_slp = RTC_CNTL_BIASSLP_SLEEP_ON;
+        out_config->pd_cur_slp = RTC_CNTL_PD_CUR_SLEEP_ON;
+    } else {
+        out_config->bias_sleep_monitor = RTC_CNTL_BIASSLP_MONITOR_DEFAULT;
+        out_config->pd_cur_monitor = (sleep_flags & RTC_SLEEP_USE_ADC_TESEN_MONITOR)?
+                                    RTC_CNTL_PD_CUR_MONITOR_ON : RTC_CNTL_PD_CUR_MONITOR_DEFAULT;
+
+        out_config->bias_sleep_slp = RTC_CNTL_BIASSLP_SLEEP_DEFAULT;
+        out_config->pd_cur_slp = RTC_CNTL_PD_CUR_SLEEP_DEFAULT;
+    }
+}
+
 void rtc_sleep_init(rtc_sleep_config_t cfg)
 {
     if (cfg.lslp_mem_inf_fpu) {
-        rtc_sleep_pu_config_t pu_cfg = RTC_SLEEP_PU_CONFIG_ALL(1);
         rtc_sleep_pu(pu_cfg);
     }
-
+    /* mem force pu */
+    SET_PERI_REG_MASK(RTC_CNTL_DIG_PWC_REG, RTC_CNTL_LSLP_MEM_FORCE_PU);
     if (cfg.wifi_pd_en) {
         REG_CLR_BIT(RTC_CNTL_DIG_ISO_REG, RTC_CNTL_WIFI_FORCE_NOISO | RTC_CNTL_WIFI_FORCE_ISO);
         REG_CLR_BIT(RTC_CNTL_DIG_PWC_REG, RTC_CNTL_WIFI_FORCE_PU);
@@ -96,34 +216,34 @@ void rtc_sleep_init(rtc_sleep_config_t cfg)
     } else {
         CLEAR_PERI_REG_MASK(RTC_CNTL_PWC_REG, RTC_CNTL_PD_EN);
     }
+
+    assert(!cfg.pd_cur_monitor || cfg.bias_sleep_monitor);
+    assert(!cfg.pd_cur_slp || cfg.bias_sleep_slp);
+    REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_EXT_RTC_DREG_SLEEP, cfg.rtc_dbias_slp);
+    REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_EXT_DIG_DREG_SLEEP, cfg.dig_dbias_slp);
+
+    REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_DBG_ATTEN_DEEP_SLP, cfg.dbg_atten_slp);
+    REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_BIAS_SLEEP_DEEP_SLP, cfg.bias_sleep_slp);
+    REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_PD_CUR_DEEP_SLP, cfg.pd_cur_slp);
+
     REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_DBG_ATTEN_MONITOR, RTC_CNTL_DBG_ATTEN_MONITOR_DEFAULT);
-    REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_BIAS_SLEEP_MONITOR, RTC_CNTL_BIASSLP_MONITOR_DEFAULT);
-    REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_BIAS_SLEEP_DEEP_SLP,
-            (!cfg.deep_slp && cfg.xtal_fpu) ? RTC_CNTL_BIASSLP_SLEEP_ON : RTC_CNTL_BIASSLP_SLEEP_DEFAULT);
-    REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_PD_CUR_MONITOR, RTC_CNTL_PD_CUR_MONITOR_DEFAULT);
-    REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_PD_CUR_DEEP_SLP,
-            (!cfg.deep_slp && cfg.xtal_fpu) ? RTC_CNTL_PD_CUR_SLEEP_ON : RTC_CNTL_PD_CUR_SLEEP_DEFAULT);
+    REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_BIAS_SLEEP_MONITOR, cfg.bias_sleep_monitor);
+    REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_PD_CUR_MONITOR, cfg.pd_cur_monitor);
+
     if (cfg.deep_slp) {
-        CLEAR_PERI_REG_MASK(RTC_CNTL_REG, RTC_CNTL_REGULATOR_FORCE_PU);
-        REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_DBG_ATTEN_DEEP_SLP, RTC_CNTL_DBG_ATTEN_DEEPSLEEP_DEFAULT);
         SET_PERI_REG_MASK(RTC_CNTL_DIG_PWC_REG, RTC_CNTL_DG_WRAP_PD_EN);
         CLEAR_PERI_REG_MASK(RTC_CNTL_ANA_CONF_REG,
                             RTC_CNTL_CKGEN_I2C_PU | RTC_CNTL_PLL_I2C_PU |
                             RTC_CNTL_RFRX_PBUS_PU | RTC_CNTL_TXRF_I2C_PU);
-        CLEAR_PERI_REG_MASK(RTC_CNTL_OPTIONS0_REG, RTC_CNTL_BB_I2C_FORCE_PU);
     } else {
         REG_SET_FIELD(RTC_CNTL_REGULATOR_DRV_CTRL_REG, RTC_CNTL_DG_VDD_DRV_B_SLP, RTC_CNTL_DG_VDD_DRV_B_SLP_DEFAULT);
-        SET_PERI_REG_MASK(RTC_CNTL_REG, RTC_CNTL_REGULATOR_FORCE_PU);
         CLEAR_PERI_REG_MASK(RTC_CNTL_DIG_PWC_REG, RTC_CNTL_DG_WRAP_PD_EN);
-        REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_DBG_ATTEN_DEEP_SLP,
-                cfg.int_8m_pd_en ? RTC_CNTL_DBG_ATTEN_LIGHTSLEEP_DEFAULT : RTC_CNTL_DBG_ATTEN_LIGHTSLEEP_NODROP);
     }
     /* mem pd */
     CLEAR_PERI_REG_MASK(RTC_CNTL_DIG_PWC_REG, RTC_CNTL_LSLP_MEM_FORCE_PU);
 
-    //Keep the RTC8M_CLK on in light_sleep mode if the ledc low-speed channel is clocked by RTC8M_CLK.
-    if (!cfg.int_8m_pd_en && GET_PERI_REG_MASK(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_DIG_CLK8M_EN_M)) {
-        REG_CLR_BIT(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_CK8M_FORCE_PD);
+    REG_SET_FIELD(RTC_CNTL_REG, RTC_CNTL_REGULATOR_FORCE_PU, cfg.rtc_regulator_fpu);
+    if (!cfg.int_8m_pd_en) {
         REG_SET_BIT(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_CK8M_FORCE_PU);
     } else {
         REG_CLR_BIT(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_CK8M_FORCE_PU);
@@ -133,13 +253,10 @@ void rtc_sleep_init(rtc_sleep_config_t cfg)
     REG_CLR_BIT(RTC_CNTL_SDIO_CONF_REG, RTC_CNTL_SDIO_FORCE);
     REG_SET_FIELD(RTC_CNTL_SDIO_CONF_REG, RTC_CNTL_SDIO_PD_EN, cfg.vddsdio_pd_en);
 
-    REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_EXT_RTC_DREG_SLEEP, cfg.rtc_dbias_slp);
-    REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_EXT_RTC_DREG, cfg.rtc_dbias_wak);
-    REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_EXT_DIG_DREG_SLEEP, cfg.dig_dbias_slp);
-    REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_EXT_DIG_DREG, cfg.dig_dbias_wak);
-
     REG_SET_FIELD(RTC_CNTL_SLP_REJECT_CONF_REG, RTC_CNTL_DEEP_SLP_REJECT_EN, cfg.deep_slp_reject);
     REG_SET_FIELD(RTC_CNTL_SLP_REJECT_CONF_REG, RTC_CNTL_LIGHT_SLP_REJECT_EN, cfg.light_slp_reject);
+    /* Set wait cycle for touch or COCPU after deep sleep and light sleep. */
+    REG_SET_FIELD(RTC_CNTL_TIMER2_REG, RTC_CNTL_ULPCP_TOUCH_START_WAIT, RTC_CNTL_ULPCP_TOUCH_START_WAIT_IN_SLEEP);
 
     REG_SET_FIELD(RTC_CNTL_OPTIONS0_REG, RTC_CNTL_XTL_FORCE_PU, cfg.xtal_fpu);
     REG_SET_FIELD(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_XTAL_GLOBAL_FORCE_NOGATING, cfg.xtal_fpu);
@@ -188,8 +305,11 @@ static uint32_t rtc_sleep_finish(uint32_t lslp_mem_inf_fpu)
 
     /* restore config if it is a light sleep */
     if (lslp_mem_inf_fpu) {
-        rtc_sleep_pu_config_t pu_cfg = RTC_SLEEP_PU_CONFIG_ALL(1);
         rtc_sleep_pu(pu_cfg);
     }
+
+    /* Recover default wait cycle for touch or COCPU after wakeup. */
+    REG_SET_FIELD(RTC_CNTL_TIMER2_REG, RTC_CNTL_ULPCP_TOUCH_START_WAIT, RTC_CNTL_ULPCP_TOUCH_START_WAIT_DEFAULT);
+
     return reject;
 }

--- a/components/soc/esp32s3/include/soc/rtc.h
+++ b/components/soc/esp32s3/include/soc/rtc.h
@@ -52,7 +52,10 @@ extern "C" {
 #define RTC_SLOW_CLK_8MD256_CAL_TIMEOUT_THRES(cycles)  (cycles << 12)
 #define RTC_SLOW_CLK_150K_CAL_TIMEOUT_THRES(cycles)  (cycles << 10)
 
-#define RTC_SLOW_CLK_FREQ_150K      150000
+// On esp32s3, RC_SLOW_CLK has a freq of ~136kHz
+#define SOC_CLK_RC_SLOW_FREQ_APPROX    136000
+// '150K' does not mean the actual freq, it represents the clock source is RC_SLOW_CLK. RC_SLOW_CLK has a freq of ~150kHz only on esp32.
+#define RTC_SLOW_CLK_FREQ_150K      SOC_CLK_RC_SLOW_FREQ_APPROX
 #define RTC_SLOW_CLK_FREQ_8MD256    (RTC_FAST_CLK_FREQ_APPROX / 256)
 #define RTC_SLOW_CLK_FREQ_32K       32768
 
@@ -61,9 +64,8 @@ extern "C" {
 
 /* Approximate mapping of voltages to RTC_CNTL_DBIAS_WAK, RTC_CNTL_DBIAS_SLP,
  * RTC_CNTL_DIG_DBIAS_WAK, RTC_CNTL_DIG_DBIAS_SLP values.
- * Valid if RTC_CNTL_DBG_ATTEN is 0.
  */
-#define RTC_CNTL_DBIAS_SLP  0   ///< sleep dig_dbias & rtc_dbias
+#define RTC_CNTL_DBIAS_SLP  5   ///< sleep dig_dbias & rtc_dbias
 #define RTC_CNTL_DBIAS_0V90 13  ///< digital voltage
 #define RTC_CNTL_DBIAS_0V95 16
 #define RTC_CNTL_DBIAS_1V00 18
@@ -78,7 +80,7 @@ extern "C" {
 #define DELAY_SLOW_CLK_SWITCH           300
 #define DELAY_8M_ENABLE                 50
 
-/* Number of 8M/256 clock cycles to use for XTAL frequency estimation.
+/* Number of RC_FAST_D256 clock cycles to use for XTAL frequency estimation.
  * 10 cycles will take approximately 300 microseconds.
  */
 #define XTAL_FREQ_EST_CYCLES            10
@@ -106,6 +108,7 @@ extern "C" {
 #define RTC_CNTL_PLL_BUF_WAIT_SLP_CYCLES    (1)
 #define RTC_CNTL_CK8M_WAIT_SLP_CYCLES       (4)
 #define RTC_CNTL_WAKEUP_DELAY_CYCLES        (4)
+#define RTC_CNTL_MIN_SLP_VAL_MIN            (2)
 
 #define RTC_CNTL_CK8M_DFREQ_DEFAULT 100
 #define RTC_CNTL_SCK_DCAP_DEFAULT   255
@@ -118,15 +121,34 @@ set sleep_init default param
 */
 #define RTC_CNTL_DBG_ATTEN_LIGHTSLEEP_DEFAULT  5
 #define RTC_CNTL_DBG_ATTEN_LIGHTSLEEP_NODROP  0
-#define RTC_CNTL_DBG_ATTEN_DEEPSLEEP_DEFAULT  15
-#define RTC_CNTL_DBG_ATTEN_MONITOR_DEFAULT  0
-#define RTC_CNTL_BIASSLP_MONITOR_DEFAULT  0
-#define RTC_CNTL_BIASSLP_SLEEP_ON  0
+#define RTC_CNTL_DBG_ATTEN_DEEPSLEEP_DEFAULT  14
+#define RTC_CNTL_DBG_ATTEN_DEEPSLEEP_ULTRA_LOW 15
+#define RTC_CNTL_DBG_ATTEN_DEEPSLEEP_NODROP  0
 #define RTC_CNTL_BIASSLP_SLEEP_DEFAULT  1
-#define RTC_CNTL_PD_CUR_MONITOR_DEFAULT  1
-#define RTC_CNTL_PD_CUR_SLEEP_ON  0
+#define RTC_CNTL_BIASSLP_SLEEP_ON  0
 #define RTC_CNTL_PD_CUR_SLEEP_DEFAULT  1
+#define RTC_CNTL_PD_CUR_SLEEP_ON  0
 #define RTC_CNTL_DG_VDD_DRV_B_SLP_DEFAULT 0xf
+
+#define RTC_CNTL_DBG_ATTEN_MONITOR_DEFAULT  0
+#define RTC_CNTL_BIASSLP_MONITOR_DEFAULT  1
+#define RTC_CNTL_BIASSLP_MONITOR_ON  0
+#define RTC_CNTL_PD_CUR_MONITOR_DEFAULT  1
+#define RTC_CNTL_PD_CUR_MONITOR_ON  0
+
+/*
+The follow value is used to get a reasonable rtc voltage dbias value according to digital dbias & some other value
+storing in efuse
+*/
+#define K_RTC_MID_MUL10000 198
+#define K_DIG_MID_MUL10000 211
+#define V_RTC_MID_MUL10000  10181
+#define V_DIG_MID_MUL10000  10841
+
+/*
+set LDO slave during CPU switch
+*/
+#define DEFAULT_LDO_SLAVE 0x7
 
 /**
  * @brief Possible main XTAL frequency values.
@@ -158,7 +180,7 @@ typedef enum {
 typedef enum {
     RTC_CPU_FREQ_SRC_XTAL,  //!< XTAL
     RTC_CPU_FREQ_SRC_PLL,   //!< PLL (480M or 320M)
-    RTC_CPU_FREQ_SRC_8M,    //!< Internal 8M RTC oscillator
+    RTC_CPU_FREQ_SRC_8M,    //!< Internal 17.5M RC oscillator
     RTC_CPU_FREQ_SRC_APLL   //!< APLL
 } rtc_cpu_freq_src_t;
 
@@ -176,9 +198,9 @@ typedef struct rtc_cpu_freq_config_s {
  * @brief RTC SLOW_CLK frequency values
  */
 typedef enum {
-    RTC_SLOW_FREQ_RTC = 0,      //!< Internal 150 kHz RC oscillator
+    RTC_SLOW_FREQ_RTC = 0,      //!< Internal 136 kHz RC oscillator
     RTC_SLOW_FREQ_32K_XTAL = 1, //!< External 32 kHz XTAL
-    RTC_SLOW_FREQ_8MD256 = 2,   //!< Internal 8 MHz RC oscillator, divided by 256
+    RTC_SLOW_FREQ_8MD256 = 2,   //!< Internal 17.5 MHz RC oscillator, divided by 256
 } rtc_slow_freq_t;
 
 /**
@@ -186,11 +208,11 @@ typedef enum {
  */
 typedef enum {
     RTC_FAST_FREQ_XTALD4 = 0,   //!< Main XTAL, divided by 4
-    RTC_FAST_FREQ_8M = 1,       //!< Internal 8 MHz RC oscillator
+    RTC_FAST_FREQ_8M = 1,       //!< Internal 17.5 MHz RC oscillator
 } rtc_fast_freq_t;
 
-/* With the default value of CK8M_DFREQ, 8M clock frequency is 8.5 MHz +/- 7% */
-#define RTC_FAST_CLK_FREQ_APPROX 8500000
+/* With the default value of CK8M_DFREQ, RTC_FAST clock frequency is 17.5 MHz +/- 7% */
+#define RTC_FAST_CLK_FREQ_APPROX 17500000
 
 #define RTC_CLK_CAL_FRACT  19  //!< Number of fractional bits in values returned by rtc_clk_cal
 
@@ -202,9 +224,9 @@ typedef enum {
  */
 typedef enum {
     RTC_CAL_RTC_MUX = 0,       //!< Currently selected RTC SLOW_CLK
-    RTC_CAL_8MD256 = 1,        //!< Internal 8 MHz RC oscillator, divided by 256
+    RTC_CAL_8MD256 = 1,        //!< Internal 17.5 MHz RC oscillator, divided by 256
     RTC_CAL_32K_XTAL = 2,      //!< External 32 kHz XTAL
-    RTC_CAL_INTERNAL_OSC = 3   //!< Internal 150 kHz oscillator
+    RTC_CAL_INTERNAL_OSC = 3   //!< Internal 136 kHz oscillator
 } rtc_cal_sel_t;
 
 /**
@@ -216,9 +238,9 @@ typedef struct {
     rtc_fast_freq_t fast_freq : 1;  //!< RTC_FAST_CLK frequency to set
     rtc_slow_freq_t slow_freq : 2;  //!< RTC_SLOW_CLK frequency to set
     uint32_t clk_rtc_clk_div : 8;
-    uint32_t clk_8m_clk_div : 3;        //!< RTC 8M clock divider (division is by clk_8m_div+1, i.e. 0 means 8MHz frequency)
-    uint32_t slow_clk_dcap : 8;     //!< RTC 150k clock adjustment parameter (higher value leads to lower frequency)
-    uint32_t clk_8m_dfreq : 8;      //!< RTC 8m clock adjustment parameter (higher value leads to higher frequency)
+    uint32_t clk_8m_clk_div : 3;        //!< RTC_FAST_CLK source RC_FAST clock divider (division is by clk_8m_div+1, i.e. 0 means ～17.5MHz frequency)
+    uint32_t slow_clk_dcap : 8;     //!< RC_SLOW clock adjustment parameter (higher value leads to lower frequency)
+    uint32_t clk_8m_dfreq : 8;      //!< RC_FAST clock adjustment parameter (higher value leads to higher frequency)
 } rtc_clk_config_t;
 
 /**
@@ -344,31 +366,31 @@ bool rtc_clk_32k_enabled(void);
 void rtc_clk_32k_bootstrap(uint32_t cycle);
 
 /**
- * @brief Enable or disable 8 MHz internal oscillator
+ * @brief Enable or disable 17.5 MHz internal oscillator
  *
- * Output from 8 MHz internal oscillator is passed into a configurable
+ * Output from 17.5 MHz internal oscillator is passed into a configurable
  * divider, which by default divides the input clock frequency by 256.
  * Output of the divider may be used as RTC_SLOW_CLK source.
  * Output of the divider is referred to in register descriptions and code as
  * 8md256 or simply d256. Divider values other than 256 may be configured, but
  * this facility is not currently needed, so is not exposed in the code.
  *
- * When 8MHz/256 divided output is not needed, the divider should be disabled
+ * When RC_FAST_D256 divided output is not needed, the divider should be disabled
  * to reduce power consumption.
  *
- * @param clk_8m_en true to enable 8MHz generator
+ * @param clk_8m_en true to enable 17.5MHz generator
  * @param d256_en true to enable /256 divider
  */
 void rtc_clk_8m_enable(bool clk_8m_en, bool d256_en);
 
 /**
- * @brief Get the state of 8 MHz internal oscillator
+ * @brief Get the state of 17.5 MHz internal oscillator
  * @return true if the oscillator is enabled
  */
 bool rtc_clk_8m_enabled(void);
 
 /**
- * @brief Get the state of /256 divider which is applied to 8MHz clock
+ * @brief Get the state of /256 divider which is applied to 17.5MHz clock
  * @return true if the divided output is enabled
  */
 bool rtc_clk_8md256_enabled(void);
@@ -406,9 +428,9 @@ rtc_slow_freq_t rtc_clk_slow_freq_get(void);
 /**
  * @brief Get the approximate frequency of RTC_SLOW_CLK, in Hz
  *
- * - if RTC_SLOW_FREQ_RTC is selected, returns ~150000
+ * - if RTC_SLOW_FREQ_RTC is selected, returns 136000
  * - if RTC_SLOW_FREQ_32K_XTAL is selected, returns 32768
- * - if RTC_SLOW_FREQ_8MD256 is selected, returns ~33000
+ * - if RTC_SLOW_FREQ_8MD256 is selected, returns ~68000
  *
  * rtc_clk_cal function can be used to get more precise value by comparing
  * RTC_SLOW_CLK frequency to the frequency of main XTAL.
@@ -517,6 +539,11 @@ uint32_t rtc_clk_cal_internal(rtc_cal_sel_t cal_clk, uint32_t slowclk_cycles);
  * 32k XTAL is being calibrated, but the oscillator has not started up (due to
  * incorrect loading capacitance, board design issue, or lack of 32 XTAL on board).
  *
+ * @note When 32k CLK is being calibrated, this function will check the accuracy
+ * of the clock. Since the xtal 32k or ext osc 32k is generally very stable, if
+ * the check fails, then consider this an invalid 32k clock and return 0. This
+ * check can filter some jamming signal.
+ *
  * @param cal_clk  clock to be measured
  * @param slow_clk_cycles  number of slow clock cycles to average
  * @return average slow clock period in microseconds, Q13.19 fixed point format,
@@ -578,19 +605,24 @@ uint64_t rtc_deep_slp_time_get(void);
 void rtc_clk_wait_for_slow_cycle(void);
 
 /**
- * @brief Enable the rtc digital 8M clock
+ * @brief Enable the digital RC_FAST_CLK
  *
- * This function is used to enable the digital rtc 8M clock to support peripherals.
- * For enabling the analog 8M clock, using `rtc_clk_8M_enable` function above.
+ * This function is used to enable the digital RC_FAST clock to support peripherals.
+ * For enabling the analog 17.5M clock, using `rtc_clk_8M_enable` function above.
  */
 void rtc_dig_clk8m_enable(void);
 
 /**
- * @brief Disable the rtc digital 8M clock
+ * @brief Disable the digital RC_FAST_CLK
  *
- * This function is used to disable the digital rtc 8M clock, which is only used to support peripherals.
+ * This function is used to disable the digital RC_FAST clock, which is only used to support peripherals.
  */
 void rtc_dig_clk8m_disable(void);
+
+/**
+ * @brief Get whether the digital RC_FAST_CLK is enabled
+ */
+bool rtc_dig_8m_enabled(void);
 
 /**
  * @brief Calculate the real clock value after the clock calibration
@@ -644,55 +676,23 @@ typedef struct {
     uint32_t wifi_pd_en : 1;            //!< power down WiFi
     uint32_t bt_pd_en : 1;              //!< power down BT
     uint32_t cpu_pd_en : 1;             //!< power down CPU, but not restart when lightsleep.
-    uint32_t int_8m_pd_en : 1;          //!< Power down Internal 8M oscillator
+    uint32_t int_8m_pd_en : 1;          //!< Power down Internal 17.5M oscillator
     uint32_t dig_peri_pd_en : 1;        //!< power down digital peripherals
     uint32_t deep_slp : 1;              //!< power down digital domain
     uint32_t wdt_flashboot_mod_en : 1;  //!< enable WDT flashboot mode
-    uint32_t dig_dbias_wak : 5;         //!< set bias for digital domain, in active mode
     uint32_t dig_dbias_slp : 5;         //!< set bias for digital domain, in sleep mode
-    uint32_t rtc_dbias_wak : 5;         //!< set bias for RTC domain, in active mode
     uint32_t rtc_dbias_slp : 5;         //!< set bias for RTC domain, in sleep mode
+    uint32_t bias_sleep_monitor : 1;    //!< circuit control parameter, in monitor mode
+    uint32_t dbg_atten_slp : 4;         //!< voltage parameter, in sleep mode
+    uint32_t bias_sleep_slp : 1;        //!< circuit control parameter, in sleep mode
+    uint32_t pd_cur_monitor : 1;        //!< circuit control parameter, in monitor mode
+    uint32_t pd_cur_slp : 1;            //!< circuit control parameter, in sleep mode
     uint32_t vddsdio_pd_en : 1;         //!< power down VDDSDIO regulator
     uint32_t xtal_fpu : 1;              //!< keep main XTAL powered up in sleep
+    uint32_t rtc_regulator_fpu  : 1;    //!< keep rtc regulator powered up in sleep
     uint32_t deep_slp_reject : 1;
     uint32_t light_slp_reject : 1;
 } rtc_sleep_config_t;
-
-/**
- * Default initializer for rtc_sleep_config_t
- *
- * This initializer sets all fields to "reasonable" values (e.g. suggested for
- * production use) based on a combination of RTC_SLEEP_PD_x flags.
- *
- * @param RTC_SLEEP_PD_x flags combined using bitwise OR
- */
-#define is_dslp(pd_flags)   ((pd_flags) & RTC_SLEEP_PD_DIG)
-#define RTC_SLEEP_CONFIG_DEFAULT(sleep_flags) { \
-    .lslp_mem_inf_fpu = 0, \
-    .rtc_mem_inf_follow_cpu = ((sleep_flags) & RTC_SLEEP_PD_RTC_MEM_FOLLOW_CPU) ? 1 : 0, \
-    .rtc_fastmem_pd_en = ((sleep_flags) & RTC_SLEEP_PD_RTC_FAST_MEM) ? 1 : 0, \
-    .rtc_slowmem_pd_en = ((sleep_flags) & RTC_SLEEP_PD_RTC_SLOW_MEM) ? 1 : 0, \
-    .rtc_peri_pd_en = ((sleep_flags) & RTC_SLEEP_PD_RTC_PERIPH) ? 1 : 0, \
-    .wifi_pd_en = ((sleep_flags) & RTC_SLEEP_PD_WIFI) ? 1 : 0, \
-    .bt_pd_en = ((sleep_flags) & RTC_SLEEP_PD_BT) ? 1 : 0, \
-    .cpu_pd_en = ((sleep_flags) & RTC_SLEEP_PD_CPU) ? 1 : 0, \
-    .int_8m_pd_en = is_dslp(sleep_flags) ? 1 : ((sleep_flags) & RTC_SLEEP_PD_INT_8M) ? 1 : 0, \
-    .dig_peri_pd_en = ((sleep_flags) & RTC_SLEEP_PD_DIG_PERIPH) ? 1 : 0, \
-    .deep_slp = ((sleep_flags) & RTC_SLEEP_PD_DIG) ? 1 : 0, \
-    .wdt_flashboot_mod_en = 0, \
-    .dig_dbias_wak = RTC_CNTL_DBIAS_1V10, \
-    .dig_dbias_slp = is_dslp(sleep_flags)                   ? RTC_CNTL_DBIAS_SLP  \
-                   : !((sleep_flags) & RTC_SLEEP_PD_INT_8M) ? RTC_CNTL_DBIAS_1V10 \
-                   : RTC_CNTL_DBIAS_SLP, \
-    .rtc_dbias_wak = RTC_CNTL_DBIAS_1V10, \
-    .rtc_dbias_slp = is_dslp(sleep_flags)                   ? RTC_CNTL_DBIAS_SLP  \
-                   : !((sleep_flags) & RTC_SLEEP_PD_INT_8M) ? RTC_CNTL_DBIAS_1V10 \
-                   : RTC_CNTL_DBIAS_SLP, \
-    .vddsdio_pd_en = ((sleep_flags) & RTC_SLEEP_PD_VDDSDIO) ? 1 : 0, \
-    .xtal_fpu = is_dslp(sleep_flags) ? 0 : ((sleep_flags) & RTC_SLEEP_PD_XTAL) ? 0 : 1, \
-    .deep_slp_reject = 1, \
-    .light_slp_reject = 1 \
-};
 
 #define RTC_SLEEP_PD_DIG                BIT(0)  //!< Deep sleep (power down digital domain)
 #define RTC_SLEEP_PD_RTC_PERIPH         BIT(1)  //!< Power down RTC peripherals
@@ -704,8 +704,23 @@ typedef struct {
 #define RTC_SLEEP_PD_BT                 BIT(7)  //!< Power down BT
 #define RTC_SLEEP_PD_CPU                BIT(8)  //!< Power down CPU when in lightsleep, but not restart
 #define RTC_SLEEP_PD_DIG_PERIPH         BIT(9)  //!< Power down DIG peripherals
-#define RTC_SLEEP_PD_INT_8M             BIT(10) //!< Power down Internal 8M oscillator
+#define RTC_SLEEP_PD_INT_8M             BIT(10) //!< Power down Internal 17.5M oscillator
 #define RTC_SLEEP_PD_XTAL               BIT(11) //!< Power down main XTAL
+
+//These flags are not power domains, but will affect some sleep parameters
+#define RTC_SLEEP_DIG_USE_8M            BIT(16)
+#define RTC_SLEEP_USE_ADC_TESEN_MONITOR BIT(17)
+#define RTC_SLEEP_NO_ULTRA_LOW          BIT(18) //!< Avoid using ultra low power in deep sleep, in which RTCIO cannot be used as input, and RTCMEM can't work under high temperature
+
+/**
+ * Default initializer for rtc_sleep_config_t
+ *
+ * This initializer sets all fields to "reasonable" values (e.g. suggested for
+ * production use) based on a combination of RTC_SLEEP_PD_x flags.
+ *
+ * @param RTC_SLEEP_PD_x flags combined using bitwise OR
+ */
+void rtc_sleep_get_default_config(uint32_t sleep_flags, rtc_sleep_config_t *out_config);
 
 /**
  * @brief Prepare the chip to enter sleep mode
@@ -816,7 +831,7 @@ uint32_t rtc_deep_sleep_start(uint32_t wakeup_opt, uint32_t reject_opt);
  * RTC power and clock control initialization settings
  */
 typedef struct {
-    uint32_t ck8m_wait : 8;         //!< Number of rtc_fast_clk cycles to wait for 8M clock to be ready
+    uint32_t ck8m_wait : 8;         //!< Number of rtc_fast_clk cycles to wait for 17.5M clock to be ready
     uint32_t xtal_wait : 8;         //!< Number of rtc_fast_clk cycles to wait for XTAL clock to be ready
     uint32_t pll_wait : 8;          //!< Number of rtc_fast_clk cycles to wait for PLL to be ready
     uint32_t clkctl_init : 1;       //!< Perform clock control related initialization

--- a/components/soc/esp32s3/include/soc/rtc_cntl_reg.h
+++ b/components/soc/esp32s3/include/soc/rtc_cntl_reg.h
@@ -369,7 +369,6 @@ ork.*/
 #define RTC_CNTL_MIN_SLP_VAL_M  ((RTC_CNTL_MIN_SLP_VAL_V)<<(RTC_CNTL_MIN_SLP_VAL_S))
 #define RTC_CNTL_MIN_SLP_VAL_V  0xFF
 #define RTC_CNTL_MIN_SLP_VAL_S  8
-#define RTC_CNTL_MIN_SLP_VAL_MIN 2
 
 #define RTC_CNTL_TIMER6_REG          (DR_REG_RTCCNTL_BASE + 0x30)
 /* RTC_CNTL_DG_PERI_POWERUP_TIMER : R/W ;bitpos:[31:25] ;default: 7'h8 ; */
@@ -3578,7 +3577,7 @@ ork.*/
 #define RTC_CNTL_FIB_SEL_S  0
 
 #define RTC_CNTL_FIB_GLITCH_RST BIT(0)
-#define RTC_CNTL_FIB_BOR_RST BIT(1)
+#define RTC_CNTL_FIB_BOD_RST BIT(1)
 #define RTC_CNTL_FIB_SUPER_WDT_RST BIT(2)
 
 #define RTC_CNTL_TOUCH_DAC_REG          (DR_REG_RTCCNTL_BASE + 0x14C)
@@ -3683,6 +3682,9 @@ ork.*/
 #define RTC_CNTL_DISABLE_RTC_CPU_V  0x1
 #define RTC_CNTL_DISABLE_RTC_CPU_S  31
 
+/*
+Due to the LDO slaves, RTC_CNTL_DATE_REG[18:13] can only be used for LDO adjustment.
+*/
 #define RTC_CNTL_DATE_REG          (DR_REG_RTCCNTL_BASE + 0x1FC)
 /* RTC_CNTL_DATE : R/W ;bitpos:[27:0] ;default: 28'h2101271 ; */
 /*description: .*/
@@ -3690,7 +3692,12 @@ ork.*/
 #define RTC_CNTL_DATE_M  ((RTC_CNTL_DATE_V)<<(RTC_CNTL_DATE_S))
 #define RTC_CNTL_DATE_V  0xFFFFFFF
 #define RTC_CNTL_DATE_S  0
-
+/*LDO SLAVE : R/W ;bitpos:[18:13] ; default: 6'd0 ;*/
+/*description: .*/
+#define RTC_CNTL_SLAVE_PD    0x0000003F
+#define RTC_CNTL_SLAVE_PD_M  ((RTC_CNTL_SLAVE_V)<<(RTC_CNTL_SLAVE_S))
+#define RTC_CNTL_SLAVE_PD_V  0x3F
+#define RTC_CNTL_SLAVE_PD_S  13
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Current ESP32-S3 bootloader only supports up to 16MB internal flash. Due to this reason, boards with flash size greater then 16MB will fallback to 2MB, making device tree regions incorrect and bugged.