### PR TITLE
system: make reset reason init public

### DIFF
--- a/components/esp_system/port/soc/esp32/reset_reason.c
+++ b/components/esp_system/port/soc/esp32/reset_reason.c
@@ -64,7 +64,7 @@ static esp_reset_reason_t get_reset_reason(uint32_t rtc_reset_reason, esp_reset_
     }
 }
 
-static void __attribute__((constructor)) esp_reset_reason_init(void)
+void esp_reset_reason_init(void)
 {
     esp_reset_reason_t hint = esp_reset_reason_get_hint();
     s_reset_reason = get_reset_reason(esp_rom_get_reset_reason(PRO_CPU_NUM), hint);

--- a/components/esp_system/port/soc/esp32c3/reset_reason.c
+++ b/components/esp_system/port/soc/esp32c3/reset_reason.c
@@ -63,7 +63,7 @@ static esp_reset_reason_t get_reset_reason(soc_reset_reason_t rtc_reset_reason, 
     }
 }
 
-static void __attribute__((constructor)) esp_reset_reason_init(void)
+void esp_reset_reason_init(void)
 {
     esp_reset_reason_t hint = esp_reset_reason_get_hint();
     s_reset_reason = get_reset_reason(esp_rom_get_reset_reason(PRO_CPU_NUM), hint);

--- a/components/esp_system/port/soc/esp32s2/reset_reason.c
+++ b/components/esp_system/port/soc/esp32s2/reset_reason.c
@@ -63,7 +63,7 @@ static esp_reset_reason_t get_reset_reason(soc_reset_reason_t rtc_reset_reason, 
     }
 }
 
-static void __attribute__((constructor)) esp_reset_reason_init(void)
+void esp_reset_reason_init(void)
 {
     esp_reset_reason_t hint = esp_reset_reason_get_hint();
     s_reset_reason = get_reset_reason(esp_rom_get_reset_reason(PRO_CPU_NUM), hint);

--- a/components/esp_system/port/soc/esp32s3/reset_reason.c
+++ b/components/esp_system/port/soc/esp32s3/reset_reason.c
@@ -63,7 +63,7 @@ static esp_reset_reason_t get_reset_reason(soc_reset_reason_t rtc_reset_reason, 
     }
 }
 
-static void __attribute__((constructor)) esp_reset_reason_init(void)
+void esp_reset_reason_init(void)
 {
     esp_reset_reason_t hint = esp_reset_reason_get_hint();
     s_reset_reason = get_reset_reason(esp_rom_get_reset_reason(PRO_CPU_NUM), hint);


### PR DESCRIPTION
Zephyr won't init constructor functions if CPP is disabled. By default, it is disabled.
This makes reset_reason_init public so Zephyr calls this during SoC startup.