### PR TITLE
emac_hal: fix typo

### DIFF
--- a/components/esp_eth/src/esp_eth_mac_esp.c
+++ b/components/esp_eth/src/esp_eth_mac_esp.c
@@ -552,7 +552,7 @@ static esp_err_t esp_emac_config_data_interface(const eth_mac_config_t *config, 
                               emac->clock_config.rmii.clock_gpio == EMAC_CLK_OUT_GPIO ||
                               emac->clock_config.rmii.clock_gpio == EMAC_CLK_OUT_180_GPIO,
                               ESP_ERR_INVALID_ARG, err, TAG, "invalid EMAC clock output GPIO");
-            emac_hal_iomux_rmii_clk_ouput(emac->clock_config.rmii.clock_gpio);
+            emac_hal_iomux_rmii_clk_output(emac->clock_config.rmii.clock_gpio);
             if (emac->clock_config.rmii.clock_gpio == EMAC_APPL_CLK_OUT_GPIO) {
                 REG_SET_FIELD(PIN_CTRL, CLK_OUT1, 6);
             }

--- a/components/hal/emac_hal.c
+++ b/components/hal/emac_hal.c
@@ -60,7 +60,7 @@ void emac_hal_iomux_rmii_clk_input(void)
     PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[0]);
 }
 
-void emac_hal_iomux_rmii_clk_ouput(int num)
+void emac_hal_iomux_rmii_clk_output(int num)
 {
     switch (num) {
     case 0:

--- a/components/hal/include/hal/emac_hal.h
+++ b/components/hal/include/hal/emac_hal.h
@@ -173,7 +173,7 @@ void emac_hal_iomux_init_rmii(void);
 
 void emac_hal_iomux_rmii_clk_input(void);
 
-void emac_hal_iomux_rmii_clk_ouput(int num);
+void emac_hal_iomux_rmii_clk_output(int num);
 
 void emac_hal_iomux_init_tx_er(void);
 


### PR DESCRIPTION
s/emac_hal_iomux_rmii_clk_ouput/emac_hal_iomux_rmii_clk_output