### PR TITLE
components: Remove improper k_free() in esp_timer

### DIFF
--- a/components/esp_timer/src/esp_timer.c
+++ b/components/esp_timer/src/esp_timer.c
@@ -471,7 +471,6 @@ esp_err_t esp_timer_init(void)
 
 out:
 	LOG_ERR("could not start esp timer");
-	k_free(&s_timer_task);
 	init_status = false;
 
     return ESP_ERR_NO_MEM;
@@ -503,7 +502,6 @@ esp_err_t esp_timer_deinit(void)
 
     esp_timer_impl_deinit();
 
-    k_free(&s_timer_task);
     init_status = false;
     return ESP_OK;
 }


### PR DESCRIPTION
The thread object s_timer_task is statically allocated. Therefore its memory should not be freed via k_free().