### PR TITLE
zephyr: refactor esp32_net

### DIFF
--- a/components/esp_timer/src/esp_timer_impl_lac.c
+++ b/components/esp_timer/src/esp_timer_impl_lac.c
@@ -30,8 +30,7 @@
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #endif
 
-/* TODO: Remove _ESP32_NET condition when AMP support will be added */
-#if CONFIG_SOC_SERIES_ESP32 || CONFIG_SOC_SERIES_ESP32_NET
+#if CONFIG_SOC_SERIES_ESP32
 #include "esp32/rom/rtc.h"
 #include "esp32/clk.h"
 #elif CONFIG_SOC_SERIES_ESP32S2

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -27,7 +27,6 @@ if(CONFIG_BT_ESP32 OR CONFIG_WIFI_ESP32)
 endif()
 
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32 esp32)
-add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32_NET esp32)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32C3 esp32c3)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32S2 esp32s2)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32S3 esp32s3)

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_SOC_SERIES_ESP32 OR CONFIG_SOC_SERIES_ESP32_NET)
+if(CONFIG_SOC_SERIES_ESP32)
 
   zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
 
@@ -198,7 +198,7 @@ if(CONFIG_SOC_SERIES_ESP32 OR CONFIG_SOC_SERIES_ESP32_NET)
     src/esp_adc_cal/esp_adc_cal.c
     )
 
-  if (NOT CONFIG_SOC_SERIES_ESP32_NET)
+  if (NOT CONFIG_SOC_ESP32_PROCPU)
     zephyr_sources(
       ../../components/esp_system/port/soc/esp32/clk.c
     )

--- a/zephyr/esp_shared/include/stubs.h
+++ b/zephyr/esp_shared/include/stubs.h
@@ -16,7 +16,7 @@
 
 #include <zephyr/devicetree.h>
 
-#if defined(CONFIG_SOC_SERIES_ESP32) || defined(CONFIG_SOC_SERIES_ESP32_NET)
+#if defined(CONFIG_SOC_SERIES_ESP32)
 #define DT_CPU_COMPAT cdns_tensilica_xtensa_lx6
 #elif defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3)
 #define DT_CPU_COMPAT cdns_tensilica_xtensa_lx7


### PR DESCRIPTION
ESP32_NET is now SOC_ESP32_APPCPU and a subset of SOC_SERIES_ESP32.