### PR TITLE
phy: enable usb when phy is initiallized

### DIFF
--- a/components/esp_phy/src/phy_init.c
+++ b/components/esp_phy/src/phy_init.c
@@ -674,7 +674,7 @@ void esp_phy_load_cal_and_init(void)
     }
 #endif
 
-#if CONFIG_SERIAL_ESP32_USB
+#if CONFIG_SOC_SERIES_ESP32S3 || CONFIG_SOC_SERIES_ESP32C3
     phy_bbpll_en_usb(true);
 #endif
 


### PR DESCRIPTION
ESP32S3 and ESP32C3 requires USB to be enabled
during phy initialization. In case it is not, USB interface won't work and will be disabled. The impact is that USB ACM0 port won't appear by default for flashing neither debugging.