### PR TITLE
zephyr: cache_utils: add missing include

### DIFF
--- a/zephyr/esp_shared/include/host_flash/cache_utils.h
+++ b/zephyr/esp_shared/include/host_flash/cache_utils.h
@@ -19,6 +19,7 @@
 #endif
 
 #include <zephyr/kernel.h>
+#include <soc.h>
 
 void IRAM_ATTR esp32_spiflash_start(void);
 


### PR DESCRIPTION
The file relied on soc.h being indirectly included from kernel.h.