### PR TITLE
mcuboot: add missing assertion function

### DIFF
--- a/zephyr/esp_shared/src/boot/esp_loader.c
+++ b/zephyr/esp_shared/src/boot/esp_loader.c
@@ -126,3 +126,10 @@ void start_cpu1_image(int image_index, int slot, unsigned int hdr_offset)
     appcpu_start(entry_addr);
 }
 #endif
+
+void mcuboot_assert_handler(const char *file, int line, const char *func)
+{
+    ets_printf("ASSERTION FAIL @ %s:%d in function %s\n", file, line, func);
+    abort();
+}
+


### PR DESCRIPTION
MCUboot requires that assert function in order to work when MCUBOOT_HAVE_ASSERT_H is set.

Fix #239
Fix https://github.com/mcu-tools/mcuboot/issues/1879