### PR TITLE
system: make longjmp save for context switch

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32)
 
   zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
+  zephyr_link_libraries(gcc "-Wl,--wrap=longjmp")
 
   zephyr_include_directories(
     include
@@ -244,6 +245,7 @@ if(CONFIG_SOC_SERIES_ESP32)
     ../../components/esp_hw_support/port/esp32/rtc_clk_init.c
     ../../components/esp_hw_support/mac_addr.c
     ../../components/esp_hw_support/regi2c_ctrl.c
+    ../../components/esp_rom/patches/esp_rom_longjmp.S
     ../../components/esp_timer/src/ets_timer_legacy.c
     ../../components/esp_timer/src/esp_timer.c
     ../../components/esp_timer/src/esp_timer_impl_lac.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32S2)
 
   zephyr_compile_options(-Wno-unused-variable)
+  zephyr_link_libraries(gcc "-Wl,--wrap=longjmp")
 
   zephyr_include_directories(
     include
@@ -232,6 +233,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     ../../components/esp_hw_support/port/esp32s2/rtc_sleep.c
     ../../components/esp_hw_support/mac_addr.c
     ../../components/esp_hw_support/port/esp32s2/regi2c_ctrl.c
+    ../../components/esp_rom/patches/esp_rom_longjmp.S
     ../../components/esp_system/port/soc/esp32s2/clk.c
     ../../components/esp_system/port/soc/esp32s2/reset_reason.c
     ../../components/driver/periph_ctrl.c

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32S3)
 
   zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
+  zephyr_link_libraries(gcc "-Wl,--wrap=longjmp")
 
   zephyr_include_directories(
     include
@@ -234,6 +235,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     ../../components/esp_hw_support/port/esp32s3/rtc_sleep.c
     ../../components/esp_hw_support/mac_addr.c
     ../../components/esp_rom/patches/esp_rom_uart.c
+    ../../components/esp_rom/patches/esp_rom_longjmp.S
     ../../components/esp_system/port/soc/esp32s3/clk.c
     ../../components/esp_system/port/soc/esp32s3/reset_reason.c
     ../../components/driver/periph_ctrl.c


### PR DESCRIPTION
Patched longjmp to be context-switch safe
longjmp modifies the windowbase and windowstart
registers, which isn't safe if a context switch
occurs during the modification. After a context
switch, windowstart and windowbase will be
different, leading to a wrongly set windowstart
bit due to longjmp writing it based on the
windowbase before the context switch. This
corrupts the registers at the next window
overflow reaching that wrongly set bit.i