### PR TITLE
uart: add call to retrieve port_num by its register address

### DIFF
--- a/components/hal/include/hal/uart_hal.h
+++ b/components/hal/include/hal/uart_hal.h
@@ -495,6 +495,15 @@ uint16_t uart_hal_get_max_rx_timeout_thrd(uart_hal_context_t *hal);
  */
 #define uart_hal_get_rxfifo_len(hal) uart_ll_get_rxfifo_len((hal)->dev)
 
+/**
+ * @brief  Get UART port number from its address
+ *
+ * @param  hw Beginning address of the peripheral registers.
+ *
+ * @return UART port number
+ */
+int8_t uart_hal_get_port_num(uart_hal_context_t *hal);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/hal/uart_hal.c
+++ b/components/hal/uart_hal.c
@@ -188,3 +188,17 @@ uint16_t uart_hal_get_max_rx_timeout_thrd(uart_hal_context_t *hal)
     uint16_t max_tout_thresh = uart_ll_max_tout_thrd(hal->dev);
     return (max_tout_thresh / symb_len);
 }
+
+int8_t uart_hal_get_port_num(uart_hal_context_t *hal)
+{
+	if (hal->dev == (uart_dev_t *)&UART0) {
+		return 0;
+	} else if (hal->dev == (uart_dev_t *)&UART1) {
+		return 1;
+#if CONFIG_SOC_SERIES_ESP32 || CONFIG_SOC_SERIES_ESP32S3
+	} else if (hal->dev == (uart_dev_t *)&UART2) {
+		return 2;
+#endif
+	}
+	return -1;
+}


### PR DESCRIPTION
Current uart does not offer a way to retrieve port number. This is needed in Zephyr.