### PR TITLE
monitor: support using idf_monitor from a virtualenv on Windows

### DIFF
--- a/west/tools.py
+++ b/west/tools.py
@@ -180,9 +180,5 @@ class Tools(WestCommand):
 
         monitor_path = Path(module_path, "tools/idf_monitor/idf_monitor.py")
         cmd_path = Path(os.getcwd())
-        if platform.system() == 'Windows':
-            cmd_exec((sys.executable, str(monitor_path), "-p", esp_port,
-                     "-b", args.baud, str(elf_path), "--eol", args.eol), cwd=cmd_path)
-        else:
-            cmd_exec((sys.executable, monitor_path, "-p", esp_port, "-b", args.baud,
-                      elf_path, "--eol", args.eol), cwd=cmd_path)
+        cmd_exec((sys.executable, str(monitor_path), "-p", esp_port,
+                 "-b", args.baud, str(elf_path), "--eol", args.eol), cwd=cmd_path)

--- a/west/tools.py
+++ b/west/tools.py
@@ -181,8 +181,8 @@ class Tools(WestCommand):
         monitor_path = Path(module_path, "tools/idf_monitor/idf_monitor.py")
         cmd_path = Path(os.getcwd())
         if platform.system() == 'Windows':
-            cmd_exec(("python.exe", monitor_path, "-p", esp_port,
-                     "-b", args.baud, elf_path, "--eol", args.eol), cwd=cmd_path)
+            cmd_exec((sys.executable, str(monitor_path), "-p", esp_port,
+                     "-b", args.baud, str(elf_path), "--eol", args.eol), cwd=cmd_path)
         else:
             cmd_exec((sys.executable, monitor_path, "-p", esp_port, "-b", args.baud,
                       elf_path, "--eol", args.eol), cwd=cmd_path)


### PR DESCRIPTION
Ensure that the venv's Python executable is used, and convert the WindowsPath to a string.