### PR TITLE
emac: fix typo in emac function name

### DIFF
--- a/components/hal/emac_hal.c
+++ b/components/hal/emac_hal.c
@@ -83,7 +83,7 @@ void emac_hal_iomux_rmii_clk_input(void)
     PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[0]);
 }
 
-void emac_hal_iomux_rmii_clk_ouput(int num)
+void emac_hal_iomux_rmii_clk_output(int num)
 {
     switch (num) {
     case 0:

--- a/components/hal/include/hal/emac_hal.h
+++ b/components/hal/include/hal/emac_hal.h
@@ -187,7 +187,7 @@ void emac_hal_iomux_init_rmii(void);
 
 void emac_hal_iomux_rmii_clk_input(void);
 
-void emac_hal_iomux_rmii_clk_ouput(int num);
+void emac_hal_iomux_rmii_clk_output(int num);
 
 void emac_hal_iomux_init_tx_er(void);
 


### PR DESCRIPTION
Fix "ouput" to "output" keyword.