### PR TITLE
wpa_supplicant: remove base64 from sources

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -436,7 +436,6 @@ if(CONFIG_SOC_SERIES_ESP32)
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/pmksa_cache.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/wpa.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/wpa_ie.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/base64.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/common.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/ext_password.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/uuid.c"

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -416,7 +416,6 @@ if(CONFIG_SOC_SERIES_ESP32C3)
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/pmksa_cache.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/wpa.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/wpa_ie.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/base64.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/common.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/ext_password.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/uuid.c"

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -411,7 +411,6 @@ if(CONFIG_SOC_SERIES_ESP32S2)
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/pmksa_cache.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/wpa.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/wpa_ie.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/base64.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/common.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/ext_password.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/uuid.c"

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -462,7 +462,6 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/pmksa_cache.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/wpa.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/wpa_ie.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/base64.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/common.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/ext_password.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/uuid.c"


### PR DESCRIPTION
After hal_v5.1 update, base64 sources were re-included in wpa_supplicant files. This conflicts with Zephyr's base64 sources, so we remove it.