### PR TITLE
hal: remove all constructor attribute

### DIFF
--- a/components/driver/deprecated/adc_dma_legacy.c
+++ b/components/driver/deprecated/adc_dma_legacy.c
@@ -576,7 +576,6 @@ esp_err_t adc_digi_controller_configure(const adc_digi_configuration_t *config)
 /**
  * @brief This function will be called during start up, to check that adc_continuous driver is not running along with the legacy adc_continuous driver
  */
-__attribute__((constructor))
 static void check_adc_continuous_driver_conflict(void)
 {
     // This function was declared as weak here. adc_continuous driver has one implementation.
@@ -593,7 +592,7 @@ static void check_adc_continuous_driver_conflict(void)
 /*---------------------------------------------------------------
             ADC Hardware Calibration
 ---------------------------------------------------------------*/
-static __attribute__((constructor)) void adc_hw_calibration(void)
+static void adc_hw_calibration(void)
 {
     //Calculate all ICode
     for (int i = 0; i < SOC_ADC_PERIPH_NUM; i++) {

--- a/components/driver/deprecated/adc_legacy.c
+++ b/components/driver/deprecated/adc_legacy.c
@@ -924,7 +924,6 @@ static esp_err_t adc_hal_convert(adc_unit_t adc_n, int channel, uint32_t clk_src
 /**
  * @brief This function will be called during start up, to check that adc_oneshot driver is not running along with the legacy adc oneshot driver
  */
-__attribute__((constructor))
 static void check_adc_oneshot_driver_conflict(void)
 {
     // This function was declared as weak here. adc_oneshot driver has one implementation.
@@ -941,7 +940,7 @@ static void check_adc_oneshot_driver_conflict(void)
 /*---------------------------------------------------------------
             ADC Hardware Calibration
 ---------------------------------------------------------------*/
-static __attribute__((constructor)) void adc_hw_calibration(void)
+static void adc_hw_calibration(void)
 {
     //Calculate all ICode
     for (int i = 0; i < SOC_ADC_PERIPH_NUM; i++) {

--- a/components/driver/deprecated/dac_common_legacy.c
+++ b/components/driver/deprecated/dac_common_legacy.c
@@ -132,19 +132,3 @@ esp_err_t dac_cw_generator_config(dac_cw_config_t *cw)
 
     return ESP_OK;
 }
-
-/**
- * @brief This function will be called during start up, to check that this legacy DAC driver is not running along with the new driver
- */
-__attribute__((constructor))
-static void check_dac_legacy_driver_conflict(void)
-{
-    // This function was declared as weak here. The new DAC driver has one implementation.
-    // So if the new DAC driver is not linked in, then `dac_priv_register_channel()` should be NULL at runtime.
-    extern __attribute__((weak)) esp_err_t dac_priv_register_channel(dac_channel_t chan_id, const char *mode_name);
-    if ((void *)dac_priv_register_channel != NULL) {
-        ESP_EARLY_LOGE(TAG, "CONFLICT! The new DAC driver is not allowed to be used together with the legacy driver");
-        abort();
-    }
-    ESP_EARLY_LOGW(TAG, "legacy driver is deprecated, please migrate to `driver/dac_oneshot.h`, `driver/dac_cosine.h` or `driver/dac_continuous.h` instead");
-}

--- a/components/driver/deprecated/timer_legacy.c
+++ b/components/driver/deprecated/timer_legacy.c
@@ -444,7 +444,6 @@ bool IRAM_ATTR timer_group_get_auto_reload_in_isr(timer_group_t group_num, timer
 /**
  * @brief This function will be called during start up, to check that this legacy timer group driver is not running along with the gptimer driver
  */
-__attribute__((constructor))
 static void check_legacy_timer_driver_conflict(void)
 {
     // This function was declared as weak here. gptimer driver has one implementation.

--- a/components/efuse/src/esp_efuse_utility.c
+++ b/components/efuse/src/esp_efuse_utility.c
@@ -27,7 +27,7 @@ uint32_t virt_blocks[EFUSE_BLK_MAX][COUNT_EFUSE_REG_PER_BLOCK];
 #ifndef BOOTLOADER_BUILD
 #ifndef CONFIG_EFUSE_VIRTUAL_KEEP_IN_FLASH
 /* Call the update function to seed virtual efuses during initialization */
-__attribute__((constructor)) void esp_efuse_utility_update_virt_blocks(void);
+void esp_efuse_utility_update_virt_blocks(void);
 #endif // CONFIG_EFUSE_VIRTUAL_KEEP_IN_FLASH
 #endif // NOT BOOTLOADER_BUILD
 

--- a/components/esp_adc/adc_common.c
+++ b/components/esp_adc/adc_common.c
@@ -91,7 +91,7 @@ esp_err_t adc_channel_to_io(adc_unit_t unit_id, adc_channel_t channel, int *io_n
 /*---------------------------------------------------------------
             ADC Hardware Calibration
 ---------------------------------------------------------------*/
-static __attribute__((constructor)) void adc_hw_calibration(void)
+static void adc_hw_calibration(void)
 {
     //Calculate all ICode
     for (int i = 0; i < SOC_ADC_PERIPH_NUM; i++) {

--- a/components/esp_hw_support/port/esp32c3/adc2_init_cal.c
+++ b/components/esp_hw_support/port/esp32c3/adc2_init_cal.c
@@ -23,7 +23,7 @@ extern int rtc_spinlock;
  * @brief Set initial code to ADC2 after calibration. ADC2 RTC and ADC2 PWDET controller share the initial code.
  *        This API be called in before `app_main()`.
  */
-static __attribute__((constructor)) void adc2_init_code_calibration(void)
+static void adc2_init_code_calibration(void)
 {
     adc_hal_calibration_init(ADC_UNIT_2);
     adc_calc_hw_calibration_code(ADC_UNIT_2, ADC_ATTEN_DB_11);

--- a/components/esp_hw_support/port/esp32s2/adc2_init_cal.c
+++ b/components/esp_hw_support/port/esp32s2/adc2_init_cal.c
@@ -23,7 +23,7 @@ extern int rtc_spinlock;
  * @brief Set initial code to ADC2 after calibration. ADC2 RTC and ADC2 PWDET controller share the initial code.
  *        This API be called in before `app_main()`.
  */
-static __attribute__((constructor)) void adc2_init_code_calibration(void)
+static void adc2_init_code_calibration(void)
 {
     adc_hal_calibration_init(ADC_UNIT_2);
     adc_calc_hw_calibration_code(ADC_UNIT_2, ADC_ATTEN_DB_11);

--- a/components/esp_hw_support/port/linux/esp_random.c
+++ b/components/esp_hw_support/port/linux/esp_random.c
@@ -14,7 +14,7 @@
 
 static const char* TAG = "esp-random";
 
-static void __attribute__((constructor)) esp_random_init(void)
+static void esp_random_init(void)
 {
     srand(time(NULL));
     ESP_LOGW(TAG, "esp_random do not provide a cryptographically secure numbers on Linux, and should never be used for anything security related");

--- a/components/esp_system/port/soc/esp32c2/reset_reason.c
+++ b/components/esp_system/port/soc/esp32c2/reset_reason.c
@@ -51,7 +51,7 @@ static esp_reset_reason_t get_reset_reason(soc_reset_reason_t rtc_reset_reason, 
     }
 }
 
-static void __attribute__((constructor)) esp_reset_reason_init(void)
+static void esp_reset_reason_init(void)
 {
     esp_reset_reason_t hint = esp_reset_reason_get_hint();
     s_reset_reason = get_reset_reason(esp_rom_get_reset_reason(PRO_CPU_NUM), hint);

--- a/components/esp_system/port/soc/esp32h2/reset_reason.c
+++ b/components/esp_system/port/soc/esp32h2/reset_reason.c
@@ -55,7 +55,7 @@ static esp_reset_reason_t get_reset_reason(soc_reset_reason_t rtc_reset_reason, 
     }
 }
 
-static void __attribute__((constructor)) esp_reset_reason_init(void)
+static void esp_reset_reason_init(void)
 {
     esp_reset_reason_t hint = esp_reset_reason_get_hint();
     s_reset_reason = get_reset_reason(esp_rom_get_reset_reason(PRO_CPU_NUM), hint);


### PR DESCRIPTION
After #74682, constrcutor attribution was enabled in Zephyr. Remove this from hal until we can test all cases before allowing it to work.