### PR TITLE
cmakelists: let bootloader sources into mcuboot build

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -259,7 +259,6 @@ if(CONFIG_SOC_SERIES_ESP32)
       )
 
     zephyr_sources(
-      ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_soc.c
       ../../components/bootloader_support/src/bootloader_mem.c
       ../../components/bootloader_support/src/bootloader_clock_init.c
       ../../components/bootloader_support/src/bootloader_console.c
@@ -268,7 +267,6 @@ if(CONFIG_SOC_SERIES_ESP32)
       ../../components/hal/mpu_hal.c
       ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_${CONFIG_SOC_SERIES}.c
       ../../components/bootloader_support/src/bootloader_init.c
-      ../../components/bootloader_support/src/bootloader_random_${CONFIG_SOC_SERIES}.c
       ../../components/bootloader_support/src/bootloader_common.c
       ../../components/bootloader_support/src/bootloader_common_loader.c
       )
@@ -290,6 +288,8 @@ if(CONFIG_SOC_SERIES_ESP32)
     ../../components/bootloader_support/bootloader_flash/src/bootloader_flash.c
     ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
     ../../components/bootloader_support/src/bootloader_efuse.c
+    ../../components/bootloader_support/src/bootloader_random_${CONFIG_SOC_SERIES}.c
+    ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_soc.c
 
     ../../components/esp_hw_support/cpu.c
     ../../components/esp_hw_support/clk_ctrl_os.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -237,7 +237,6 @@ if(CONFIG_SOC_SERIES_ESP32C3)
       )
 
     zephyr_sources(
-      ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_soc.c
       ../../components/bootloader_support/src/bootloader_mem.c
       ../../components/bootloader_support/src/bootloader_clock_init.c
       ../../components/bootloader_support/src/bootloader_console.c
@@ -247,7 +246,6 @@ if(CONFIG_SOC_SERIES_ESP32C3)
       ../../components/hal/mpu_hal.c
       ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_${CONFIG_SOC_SERIES}.c
       ../../components/bootloader_support/src/bootloader_init.c
-      ../../components/bootloader_support/src/bootloader_random_${CONFIG_SOC_SERIES}.c
       ../../components/bootloader_support/src/bootloader_common.c
       ../../components/bootloader_support/src/bootloader_common_loader.c
 	  )
@@ -266,6 +264,8 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     ../../components/bootloader_support/bootloader_flash/src/flash_qio_mode.c
     ../../components/bootloader_support/bootloader_flash/src/bootloader_flash.c
     ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
+    ../../components/bootloader_support/src/bootloader_random_${CONFIG_SOC_SERIES}.c
+    ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_soc.c
 
     ../../components/esp_hw_support/cpu.c
     ../../components/esp_hw_support/clk_ctrl_os.c

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -159,7 +159,6 @@ if(CONFIG_SOC_SERIES_ESP32C6)
       )
 
     zephyr_sources(
-      ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_soc.c
       ../../components/bootloader_support/src/bootloader_mem.c
       ../../components/bootloader_support/src/bootloader_clock_init.c
       ../../components/bootloader_support/src/bootloader_console.c
@@ -169,7 +168,6 @@ if(CONFIG_SOC_SERIES_ESP32C6)
       ../../components/hal/mpu_hal.c
       ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_${CONFIG_SOC_SERIES}.c
       ../../components/bootloader_support/src/bootloader_init.c
-      ../../components/bootloader_support/src/bootloader_random_${CONFIG_SOC_SERIES}.c
       ../../components/bootloader_support/src/bootloader_common.c
       ../../components/bootloader_support/src/bootloader_common_loader.c
       )
@@ -183,6 +181,8 @@ if(CONFIG_SOC_SERIES_ESP32C6)
     ../../components/bootloader_support/bootloader_flash/src/flash_qio_mode.c
     ../../components/bootloader_support/bootloader_flash/src/bootloader_flash.c
     ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
+    ../../components/bootloader_support/src/bootloader_random_${CONFIG_SOC_SERIES}.c
+    ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_soc.c
 
     ../../components/esp_hw_support/cpu.c
     ../../components/esp_hw_support/esp_clk.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -258,7 +258,6 @@ if(CONFIG_SOC_SERIES_ESP32S2)
       )
 
     zephyr_sources(
-      ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_soc.c
       ../../components/bootloader_support/src/bootloader_mem.c
       ../../components/bootloader_support/src/bootloader_clock_init.c
       ../../components/bootloader_support/src/bootloader_console.c
@@ -267,7 +266,6 @@ if(CONFIG_SOC_SERIES_ESP32S2)
       ../../components/hal/mpu_hal.c
       ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_${CONFIG_SOC_SERIES}.c
       ../../components/bootloader_support/src/bootloader_init.c
-      ../../components/bootloader_support/src/bootloader_random_${CONFIG_SOC_SERIES}.c
       ../../components/bootloader_support/src/bootloader_common.c
       ../../components/bootloader_support/src/bootloader_common_loader.c
       )
@@ -288,6 +286,8 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     ../../components/bootloader_support/bootloader_flash/src/bootloader_flash.c
     ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
     ../../components/bootloader_support/src/bootloader_efuse.c
+    ../../components/bootloader_support/src/bootloader_random_${CONFIG_SOC_SERIES}.c
+    ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_soc.c
 
     ../../components/esp_hw_support/cpu.c
     ../../components/esp_hw_support/clk_ctrl_os.c

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -283,7 +283,6 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       )
 
     zephyr_sources(
-      ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_soc.c
       ../../components/bootloader_support/src/bootloader_mem.c
       ../../components/bootloader_support/src/bootloader_clock_init.c
       ../../components/bootloader_support/src/bootloader_console.c
@@ -292,7 +291,6 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       ../../components/hal/mpu_hal.c
       ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_${CONFIG_SOC_SERIES}.c
       ../../components/bootloader_support/src/bootloader_init.c
-      ../../components/bootloader_support/src/bootloader_random_${CONFIG_SOC_SERIES}.c
       ../../components/bootloader_support/src/bootloader_common.c
       ../../components/bootloader_support/src/bootloader_common_loader.c
       )
@@ -311,7 +309,9 @@ if(CONFIG_SOC_SERIES_ESP32S3)
 
     ../../components/bootloader_support/bootloader_flash/src/flash_qio_mode.c
     ../../components/bootloader_support/bootloader_flash/src/bootloader_flash.c
-	../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
+    ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
+    ../../components/bootloader_support/src/bootloader_random_${CONFIG_SOC_SERIES}.c
+    ../../components/bootloader_support/src/${CONFIG_SOC_SERIES}/bootloader_soc.c
 
     ../../components/esp_hw_support/cpu.c
     ../../components/esp_hw_support/clk_ctrl_os.c


### PR DESCRIPTION
bootloader_random_disable() call needs to be available for both mcuboot and simple boot builds.