### PR TITLE
zephyr: esp_wifi_adapter: Use priority config

### DIFF
--- a/components/esp_system/include/esp_task.h
+++ b/components/esp_system/include/esp_task.h
@@ -22,7 +22,7 @@
 
 #include "sdkconfig.h"
 
-#define ESP_TASK_PRIO_MAX (5)
+#define ESP_TASK_PRIO_MAX (CONFIG_ESP_WIFI_MAX_THREAD_PRIORITY)
 #define ESP_TASK_PRIO_MIN (0)
 
 /* Bt contoller Task */

--- a/zephyr/esp32/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32/src/wifi/esp_wifi_adapter.c
@@ -407,7 +407,7 @@ static int32_t IRAM_ATTR task_ms_to_tick_wrapper(uint32_t ms)
 
 static int32_t task_get_max_priority_wrapper(void)
 {
-	return (int32_t)(4);
+	return (int32_t)(CONFIG_ESP_WIFI_MAX_THREAD_PRIORITY);
 }
 
 static int32_t esp_event_post_wrapper(const char* event_base, int32_t event_id, void* event_data, size_t event_data_size, uint32_t ticks_to_wait)

--- a/zephyr/esp32c3/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32c3/src/wifi/esp_wifi_adapter.c
@@ -418,7 +418,7 @@ static int32_t IRAM_ATTR task_ms_to_tick_wrapper(uint32_t ms)
 
 static int32_t task_get_max_priority_wrapper(void)
 {
-	return (int32_t)(4);
+	return (int32_t)(CONFIG_ESP_WIFI_MAX_THREAD_PRIORITY);
 }
 
 static int32_t esp_event_post_wrapper(const char* event_base, int32_t event_id, void* event_data, size_t event_data_size, uint32_t ticks_to_wait)

--- a/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
@@ -403,7 +403,7 @@ static int32_t IRAM_ATTR task_ms_to_tick_wrapper(uint32_t ms)
 
 static int32_t task_get_max_priority_wrapper(void)
 {
-	return (int32_t)(4);
+	return (int32_t)(CONFIG_ESP_WIFI_MAX_THREAD_PRIORITY);
 }
 
 static int32_t esp_event_post_wrapper(const char* event_base, int32_t event_id, void* event_data, size_t event_data_size, uint32_t ticks_to_wait)

--- a/zephyr/esp32s3/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32s3/src/wifi/esp_wifi_adapter.c
@@ -424,7 +424,7 @@ static int32_t IRAM_ATTR task_ms_to_tick_wrapper(uint32_t ms)
 
 static int32_t task_get_max_priority_wrapper(void)
 {
-	return (int32_t)(4);
+	return (int32_t)(CONFIG_ESP_WIFI_MAX_THREAD_PRIORITY);
 }
 
 static int32_t esp_event_post_wrapper(const char* event_base, int32_t event_id, void* event_data, size_t event_data_size, uint32_t ticks_to_wait)


### PR DESCRIPTION
Use CONFIG_ESP_WIFI_MAX_THREAD_PRIO instead of
hardcoded value in the `task_get_max_priority_wrapper`. The real priority is then calculated as
prio = (CONFIG_ESP_WIFI_MAX_THREAD_PRIO - 2)
during the wifi runtime.