### PR TITLE
hal: gcc: Compiler flag for strict volatile bitfields

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32)
 
   zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
+  zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
 
   if(CONFIG_MCUBOOT)

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32C3)
 
   zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
+  zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
 
   if(CONFIG_MCUBOOT)

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32C6)
 
   zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
+  zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
 
   if(CONFIG_MCUBOOT)

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32S2)
 
   zephyr_compile_options(-Wno-unused-variable  -Wno-maybe-uninitialized)
+  zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
 
   if(CONFIG_MCUBOOT)

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32S3)
 
   zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
+  zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
 
   if(CONFIG_MCUBOOT)


### PR DESCRIPTION
Forces gcc to treat register bitfield structs declared volatile as such,
thus treating problem of faulty writes on 32 bit peripheral registers.