### PR TITLE
hal: esp32c6: Clock control for USB JTAG peripheral

### DIFF
--- a/components/hal/esp32c6/include/hal/clk_gate_ll.h
+++ b/components/hal/esp32c6/include/hal/clk_gate_ll.h
@@ -79,6 +79,8 @@ static inline uint32_t periph_ll_get_clk_en_mask(periph_module_t periph)
             return PCR_SDIO_SLAVE_CLK_EN;
         case PERIPH_REGDMA_MODULE:
             return PCR_REGDMA_CLK_EN;
+        case PERIPH_USB_DEVICE_MODULE:
+            return PCR_USB_DEVICE_CLK_EN;
         //TODO: LP_PERIPH modules are added temporarily and will be moved to a separate API (IDF-7374).
         case PERIPH_LP_I2C0_MODULE:
             return LPPERI_LP_EXT_I2C_CK_EN;
@@ -163,6 +165,8 @@ static inline uint32_t periph_ll_get_rst_en_mask(periph_module_t periph, bool en
             return PCR_SDIO_SLAVE_RST_EN;
         case PERIPH_REGDMA_MODULE:
             return PCR_REGDMA_RST_EN;
+        case PERIPH_USB_DEVICE_MODULE:
+            return PCR_USB_DEVICE_RST_EN;
         //TODO: LP_PERIPH modules are added temporarily and will be moved to a separate API (IDF-7374).
         case PERIPH_LP_I2C0_MODULE:
             return LPPERI_LP_EXT_I2C_RESET_EN;
@@ -232,6 +236,8 @@ static uint32_t periph_ll_get_clk_en_reg(periph_module_t periph)
             return PCR_SDIO_SLAVE_CONF_REG;
         case PERIPH_REGDMA_MODULE:
             return PCR_REGDMA_CONF_REG;
+        case PERIPH_USB_DEVICE_MODULE:
+            return PCR_USB_DEVICE_CONF_REG;
         //TODO: LP_PERIPH modules are added temporarily and will be moved to a separate API (IDF-7374).
         case PERIPH_LP_I2C0_MODULE:
             return LPPERI_CLK_EN_REG;
@@ -301,6 +307,8 @@ static uint32_t periph_ll_get_rst_en_reg(periph_module_t periph)
             return PCR_SDIO_SLAVE_CONF_REG;
         case PERIPH_REGDMA_MODULE:
             return PCR_REGDMA_CONF_REG;
+        case PERIPH_USB_DEVICE_MODULE:
+            return PCR_USB_DEVICE_CONF_REG;
         //TODO: LP_PERIPH modules are added temporarily and will be moved to a separate API (IDF-7374).
         case PERIPH_LP_I2C0_MODULE:
             return LPPERI_RESET_EN_REG;

--- a/components/hal/esp32c6/include/hal/usb_serial_jtag_ll.h
+++ b/components/hal/esp32c6/include/hal/usb_serial_jtag_ll.h
@@ -1,23 +1,22 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// The LL layer of the USB-serial-jtag controller
-
 #pragma once
+
+#include <stdbool.h>
+#include "esp_attr.h"
+#include "soc/pcr_struct.h"
 #include "soc/usb_serial_jtag_reg.h"
 #include "soc/usb_serial_jtag_struct.h"
+#include "hal/usb_serial_jtag_types.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+/* ----------------------------- Macros & Types ----------------------------- */
 
-//The in and out endpoints are this long.
-#define USB_SERIAL_JTAG_PACKET_SZ_BYTES 64
-
-#define USB_SERIAL_JTAG_LL_INTR_MASK         (0x7ffff) //All interrupt mask
+#define USB_SERIAL_JTAG_LL_INTR_MASK            (0x7ffff)   // All interrupts mask
+#define USB_SERIAL_JTAG_LL_PHY_DEPENDS_ON_BBPLL (1)
 
 // Define USB_SERIAL_JTAG interrupts
 // Note the hardware has more interrupts, but they're only useful for debugging
@@ -30,6 +29,13 @@ typedef enum {
     USB_SERIAL_JTAG_INTR_BUS_RESET              = (1 << 9),
     USB_SERIAL_JTAG_INTR_EP1_ZERO_PAYLOAD       = (1 << 10),
 } usb_serial_jtag_ll_intr_t;
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ----------------------------- USJ Peripheral ----------------------------- */
 
 /**
  * @brief  Enable the USB_SERIAL_JTAG interrupt based on the given mask.
@@ -120,7 +126,7 @@ static inline int usb_serial_jtag_ll_read_rxfifo(uint8_t *buf, uint32_t rd_len)
  *         is room in the buffer.
  *
  * @param  buf The data buffer.
- * @param  wr_len The data length needs to be writen.
+ * @param  wr_len The data length needs to be written.
  *
  * @return Amount of bytes actually written. May be less than wr_len.
  */
@@ -158,8 +164,14 @@ static inline int usb_serial_jtag_ll_txfifo_writable(void)
  * @brief  Flushes the TX buffer, that is, make it available for the
  *         host to pick up.
  *
- * @note  When fifo is full (with 64 byte), HW will flush the buffer automatically.
- *        It won't be executed if there is nothing in the fifo.
+ * @note  When fifo is full (with 64 byte), HW will flush the buffer automatically,
+ *        if this function is called directly after, this effectively turns into a
+ *        no-op. Because a 64-byte packet will be interpreted as a not-complete USB
+ *        transaction, you need to transfer either more data or a zero-length packet
+ *        for the data to actually end up at the program listening to the CDC-ACM
+ *        serial port. To send a zero-length packet, call
+ *        usb_serial_jtag_ll_txfifo_flush() again when
+ *        usb_serial_jtag_ll_txfifo_writable() returns true.
  *
  * @return na
  */
@@ -168,6 +180,154 @@ static inline void usb_serial_jtag_ll_txfifo_flush(void)
     USB_SERIAL_JTAG.ep1_conf.wr_done=1;
 }
 
+/**
+ * @brief Enable USJ JTAG bridge
+ *
+ * If enabled, USJ is disconnected from internal JTAG interface. JTAG interface
+ * is routed through GPIO matrix instead.
+ *
+ * @param enable Enable USJ JTAG bridge
+ */
+FORCE_INLINE_ATTR void usb_serial_jtag_ll_phy_set_jtag_bridge(bool enable)
+{
+    USB_SERIAL_JTAG.conf0.usb_jtag_bridge_en = enable;
+}
+
+/* ---------------------------- USB PHY Control  ---------------------------- */
+
+/**
+ * @brief Sets PHY defaults
+ *
+ * Some PHY register fields/features of the USJ are redundant on the ESP32-C6.
+ * This function those fields are set to the appropriate default values.
+ *
+ * @param hw Start address of the USB Wrap registers
+ */
+FORCE_INLINE_ATTR void usb_serial_jtag_ll_phy_set_defaults(void)
+{
+    // External FSLS PHY is not supported
+    USB_SERIAL_JTAG.conf0.phy_sel = 0;
+    USB_SERIAL_JTAG.conf0.usb_pad_enable = 1;
+}
+
+/**
+ * @brief Enables/disables exchanging of the D+/D- pins USB PHY
+ *
+ * @param enable Enables pin exchange, disabled otherwise
+ */
+FORCE_INLINE_ATTR void usb_serial_jtag_ll_phy_enable_pin_exchg(bool enable)
+{
+    if (enable) {
+        USB_SERIAL_JTAG.conf0.exchg_pins = 1;
+        USB_SERIAL_JTAG.conf0.exchg_pins_override = 1;
+    } else {
+        USB_SERIAL_JTAG.conf0.exchg_pins_override = 0;
+        USB_SERIAL_JTAG.conf0.exchg_pins = 0;
+    }
+}
+
+/**
+ * @brief Enables and sets voltage threshold overrides for USB FSLS PHY single-ended inputs
+ *
+ * @param vrefh_step High voltage threshold. 0 to 3 indicating 80mV steps from 1.76V to 2V.
+ * @param vrefl_step Low voltage threshold. 0 to 3 indicating 80mV steps from 0.8V to 1.04V.
+ */
+FORCE_INLINE_ATTR void usb_serial_jtag_ll_phy_enable_vref_override(unsigned int vrefh_step, unsigned int vrefl_step)
+{
+    USB_SERIAL_JTAG.conf0.vrefh = vrefh_step;
+    USB_SERIAL_JTAG.conf0.vrefl = vrefl_step;
+    USB_SERIAL_JTAG.conf0.vref_override = 1;
+}
+
+/**
+ * @brief Disables voltage threshold overrides for USB FSLS PHY single-ended inputs
+ */
+FORCE_INLINE_ATTR void usb_serial_jtag_ll_phy_disable_vref_override(void)
+{
+    USB_SERIAL_JTAG.conf0.vref_override = 0;
+}
+
+/**
+ * @brief Enable override of USB FSLS PHY's pull up/down resistors
+ *
+ * @param vals Override values to set
+ */
+FORCE_INLINE_ATTR void usb_serial_jtag_ll_phy_enable_pull_override(const usb_serial_jtag_pull_override_vals_t *vals)
+{
+    USB_SERIAL_JTAG.conf0.dp_pullup = vals->dp_pu;
+    USB_SERIAL_JTAG.conf0.dp_pulldown = vals->dp_pd;
+    USB_SERIAL_JTAG.conf0.dm_pullup = vals->dm_pu;
+    USB_SERIAL_JTAG.conf0.dm_pulldown = vals->dm_pd;
+    USB_SERIAL_JTAG.conf0.pad_pull_override = 1;
+}
+
+/**
+ * @brief Disable override of USB FSLS PHY pull up/down resistors
+ */
+FORCE_INLINE_ATTR void usb_serial_jtag_ll_phy_disable_pull_override(void)
+{
+    USB_SERIAL_JTAG.conf0.pad_pull_override = 0;
+}
+
+/**
+ * @brief Sets the strength of the pullup resistor
+ *
+ * @param strong True is a ~1.4K pullup, false is a ~2.4K pullup
+ */
+FORCE_INLINE_ATTR void usb_serial_jtag_ll_phy_set_pullup_strength(bool strong)
+{
+    USB_SERIAL_JTAG.conf0.pullup_value = strong;
+}
+
+/**
+ * @brief Check if USB FSLS PHY pads are enabled
+ *
+ * @return True if enabled, false otherwise
+ */
+FORCE_INLINE_ATTR bool usb_serial_jtag_ll_phy_is_pad_enabled(void)
+{
+    return USB_SERIAL_JTAG.conf0.usb_pad_enable;
+}
+
+/**
+ * @brief Enable the USB FSLS PHY pads
+ *
+ * @param enable Whether to enable the USB FSLS PHY pads
+ */
+FORCE_INLINE_ATTR void usb_serial_jtag_ll_phy_enable_pad(bool enable)
+{
+    USB_SERIAL_JTAG.conf0.usb_pad_enable = enable;
+}
+
+/* ----------------------------- RCC Functions  ----------------------------- */
+
+/**
+ * @brief Enable the bus clock for USJ module
+ * @param clk_en True if enable the clock of USJ module
+ */
+FORCE_INLINE_ATTR void usb_serial_jtag_ll_enable_bus_clock(bool clk_en)
+{
+    PCR.usb_device_conf.usb_device_clk_en = clk_en;
+}
+
+/**
+ * @brief Reset the USJ module
+ */
+FORCE_INLINE_ATTR void usb_serial_jtag_ll_reset_register(void)
+{
+    PCR.usb_device_conf.usb_device_rst_en = 1;
+    PCR.usb_device_conf.usb_device_rst_en = 0;
+}
+
+/**
+ * Get the enable status of the USJ module
+ *
+ * @return Return true if USJ module is enabled
+ */
+FORCE_INLINE_ATTR bool usb_serial_jtag_ll_module_is_enabled(void)
+{
+    return (PCR.usb_device_conf.usb_device_clk_en && !PCR.usb_device_conf.usb_device_rst_en);
+}
 
 #ifdef __cplusplus
 }

--- a/components/hal/include/hal/usb_serial_jtag_types.h
+++ b/components/hal/include/hal/usb_serial_jtag_types.h
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include "soc/soc_caps.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if SOC_USB_SERIAL_JTAG_SUPPORTED
+
+/**
+ * @brief USJ test mode values
+ *
+ * Specifies the logic values of each of the USB FSLS Serial PHY interface
+ * signals when in test mode.
+ */
+typedef struct {
+    bool dp_pu;     /**< D+ pull-up resistor enable/disable */
+    bool dm_pu;     /**< D- pull-up resistor enable/disable */
+    bool dp_pd;     /**< D+ pull-down resistor enable/disable */
+    bool dm_pd;     /**< D- pull-down resistor enable/disable */
+} usb_serial_jtag_pull_override_vals_t;
+
+#endif // SOC_USB_SERIAL_JTAG_SUPPORTED
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Added LL files for clock control of USB JTAG peripheral