### PR TITLE
Fix typos in SoCs sources list

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -120,7 +120,7 @@ if(CONFIG_SOC_SERIES_ESP32)
 
   zephyr_compile_definitions(ESP_PLATFORM)
 
-  zephyr_library_sources(src/hal/windowspill_asm.S)
+  zephyr_sources(src/hal/windowspill_asm.S)
 
   if(CONFIG_SOC_FLASH_ESP32 OR NOT CONFIG_BOOTLOADER_MCUBOOT)
     zephyr_sources(
@@ -151,7 +151,7 @@ if(CONFIG_SOC_SERIES_ESP32)
     )
   endif()
 
-  zephyr_library_sources_ifdef(
+  zephyr_sources_ifdef(
     CONFIG_COUNTER_TMR_ESP32
     ../../components/hal/timer_hal.c
   )

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -91,7 +91,10 @@ if(CONFIG_SOC_SERIES_ESP32C2)
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/soc/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.peripherals.ld
   )
 
-  zephyr_library_sources_ifdef(CONFIG_COUNTER_TMR_ESP32 ../../components/hal/timer_hal.c)
+  zephyr_sources_ifdef(
+    CONFIG_COUNTER_TMR_ESP32
+    ../../components/hal/timer_hal.c
+  )
 
   zephyr_sources_ifdef(
     CONFIG_ESP32_SPIM

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -169,7 +169,10 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     ../../components/hal/i2s_hal.c
     )
 
-  zephyr_library_sources_ifdef(CONFIG_COUNTER_TMR_ESP32 ../../components/hal/timer_hal.c)
+  zephyr_sources_ifdef(
+    CONFIG_COUNTER_TMR_ESP32
+    ../../components/hal/timer_hal.c
+  )
 
   zephyr_sources_ifdef(
     CONFIG_UART_ESP32

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -141,7 +141,10 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     )
   endif()
 
-  zephyr_library_sources_ifdef(CONFIG_COUNTER_TMR_ESP32 ../../components/hal/timer_hal.c)
+  zephyr_sources_ifdef(
+    CONFIG_COUNTER_TMR_ESP32
+    ../../components/hal/timer_hal.c
+  )
 
   zephyr_sources_ifdef(
     CONFIG_ESP32_SPIM

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -167,7 +167,10 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     ../../components/hal/gdma_hal.c
     )
 
-  zephyr_library_sources_ifdef(CONFIG_COUNTER_TMR_ESP32 ../../components/hal/timer_hal.c)
+  zephyr_sources_ifdef(
+    CONFIG_COUNTER_TMR_ESP32
+    ../../components/hal/timer_hal.c
+  )
 
   zephyr_sources_ifdef(
     CONFIG_I2C_ESP32


### PR DESCRIPTION
Fix typos in the sources lists of SOCs CMakeLists.txt.