### PR TITLE
Add PHY locking mechanism

### DIFF
--- a/components/esp_phy/src/phy_init.c
+++ b/components/esp_phy/src/phy_init.c
@@ -73,6 +73,7 @@ static int64_t s_phy_rf_en_ts = 0;
 
 /* PHY spinlock for libphy.a */
 static DRAM_ATTR int s_phy_int_mux;
+static DRAM_ATTR int s_phy_lock_nest = 0;
 
 /* Indicate PHY is calibrated or not */
 static bool s_is_phy_calibrated = false;
@@ -156,7 +157,14 @@ static phy_country_to_bin_type_t s_country_code_map_type_table[] = {
 #endif
 uint32_t IRAM_ATTR phy_enter_critical(void)
 {
-    s_phy_int_mux = irq_lock();
+    int key = irq_lock();
+    if(s_phy_lock_nest == 0) {
+        s_phy_int_mux = key;
+    }
+
+    if(s_phy_lock_nest < 0xFFFFFFFF) {
+        s_phy_lock_nest++;
+    }
 
     // Interrupt level will be stored in current tcb, so always return zero.
     return 0;
@@ -164,8 +172,14 @@ uint32_t IRAM_ATTR phy_enter_critical(void)
 
 void IRAM_ATTR phy_exit_critical(uint32_t level)
 {
-    // Param level don't need any more, ignore it.
-    irq_unlock(s_phy_int_mux);
+    if(s_phy_lock_nest > 0) {
+        s_phy_lock_nest--;
+    }
+
+    if(s_phy_lock_nest == 0) {
+        // Param level don't need any more, ignore it.
+        irq_unlock(s_phy_int_mux);
+    }
 }
 
 #if CONFIG_IDF_TARGET_ESP32


### PR DESCRIPTION
This fixes issue when CONFIG_ASSERT is enabled and WiFi is used for an ESP32 e.g., 

`west build -p -b esp32_devkitc_wroom/esp32/procpu ./zephyr_os/zephyr/samples/net/wifi`

and setting CONFIG_ASSERT to true will result in:

```
ASSERTION FAIL [arch_irq_unlocked(key) || _kernel.cpus[0].current->base.thread_state & (((1UL << (0))) | ((1UL << (3))))] @ WEST_TOPDIR/zephyr/kernel/include/kswap.h:99
	Context switching while holding lock!
[00:00:01.706,000] <err> os:  ** FATAL EXCEPTION
[00:00:01.706,000] <err> os:  **  A0 0x800d5158  SP 0x3ffb4820  A2 0x4  A3 0x3ffb4830
[00:00:01.706,000] <err> os:  **  PC 0x40085c77 VADDR 0
0x40085c77: xtensa_arch_except_epc at /Users/oscargoldring/git/powerhub-top/zephyr_os/zephyr/arch/xtensa/core/xtensa_asm2_util.S:209

[00:00:01.707,000] <err> os:  ** SAR 0x4
0x40085f46:0x3ffcc270 	Invalid spinlock 0x3ffc68cc
0x40085f46: xtensa_dump_stack at /Users/oscargoldring/git/powerhub-top/zephyr_os/zephyr/arch/xtensa/core/vector_handlers.c:180

[00:00:01.710,000] <err> os:  **  A8 0x8008b431  A9 0x3ffcbe88 A10 0x3f4034e2 A11 0x3ffcbf28
[00:00:01.711,000] <err> os: Current thread: 0x3ffc2108 (unknown)
[00:00:01.714,000] <err> os:  **    (INTLEVEL:0 EXCM: 0 UM:1 RING:0 WOE:1 OWB:9 CALLINC:2)


Backtrace:0x40085d77:0x3ffcbea0 [00:00:01.719,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
0x40085d77: _xstack_call0_5 at /Users/oscargoldring/git/powerhub-top/zephyr_os/zephyr/arch/xtensa/core/xtensa_asm2_util.S:320

[00:00:01.728,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.734,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.738,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.740,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.743,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.752,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.759,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.767,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.769,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.771,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.778,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.785,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.793,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.800,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.807,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.815,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.822,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.829,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.836,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.844,000] <err> os:  ** CPU 0 EXCCAUSE 0 (illegal instruction)
[00:00:01.851,000] <err> os:  ** FATAL EXCEPTION
[00:00:01.858,000] <err> os:  ** FATAL EXCEPTION
[00:00:01.866,000] <err> os:  ** FATAL EXCEPTION
[00:00:01.873,000] <err> os:  ** FATAL EXCEPTION
[00:00:01.880,000] <err> os:  ** FATAL EXCEPTION
[00:00:01.887,000] <err> os:  ** FATAL EXCEPTION
[00:00:01.895,000] <err> os:  ** FATAL EXCEPTION
[00:00:01.902,000] <err> os:  ** FATAL EXCEPTION
[00:00:01.909,000] <err> os:  ** FATAL EXCEPTION
[00:00:01.917,000] <err> os:  ** FATAL EXCEPTION
ASSERTION FAIL [z_spin_lock_valid(l)] @ WEST_TOPDIR/zephyr/include/zephyr/spinlock.h:136
	Invalid spinlock 0x3ffc68b4
--- 275 messages dropped ---
[00:00:01.929,000] <err> os:  ** FATAL EXCEPTION
```

This was previously fixed in https://github.com/zephyrproject-rtos/hal_espressif/pull/43, however this seems to have been lost/removed, during a refactoring (as it is now located under esp_phy, was previously under esp_wifi)? 