### PR TITLE
hal: esp32c2: Add LEDC PWM support

### DIFF
--- a/components/hal/esp32c2/include/hal/ledc_ll.h
+++ b/components/hal/esp32c2/include/hal/ledc_ll.h
@@ -166,6 +166,23 @@ static inline void ledc_ll_get_clock_divider(ledc_dev_t *hw, ledc_mode_t speed_m
 }
 
 /**
+ * @brief Set LEDC timer clock source
+ *
+ * @param hw Beginning address of the peripheral registers
+ * @param speed_mode LEDC speed_mode, high-speed mode or low-speed mode
+ * @param timer_sel LEDC timer index (0-3), select from ledc_timer_t
+ * @param clk_src Timer clock source
+ *
+ * @note  This function is here to satisfy hal interface, but it is not supported in hardware.
+ *
+ * @return None
+ */
+static inline void ledc_ll_set_clock_source(ledc_dev_t *hw, ledc_mode_t speed_mode, ledc_timer_t timer_sel, ledc_clk_src_t clk_src)
+{
+    // do nothing;
+}
+
+/**
  * @brief Get LEDC timer clock source
  *
  * @param hw Beginning address of the peripheral registers

--- a/components/soc/esp32c2/include/soc/soc.h
+++ b/components/soc/esp32c2/include/soc/soc.h
@@ -147,6 +147,7 @@
 #define  CPU_CLK_FREQ_MHZ_BTLD                       (80)           // The cpu clock frequency (in MHz) to set at 2nd stage bootloader system clock configuration
 #define  CPU_CLK_FREQ                                APB_CLK_FREQ
 #define  APB_CLK_FREQ                                ( CONFIG_XTAL_FREQ * 1000000 )
+#define  SCLK_CLK_FREQ                               ( 60*1000000 )
 #define  MODEM_REQUIRED_MIN_APB_CLK_FREQ             ( 80*1000000 )
 #define  REF_CLK_FREQ                                ( 1000000 )
 #define  UART_CLK_FREQ                               APB_CLK_FREQ

--- a/zephyr/port/pincfgs/esp32c2.yml
+++ b/zephyr/port/pincfgs/esp32c2.yml
@@ -69,3 +69,23 @@ spim2:
   csel5:
     sigo: fspics5_out
     gpio: [[0, 10], [18, 20]]
+
+ledc:
+  ch0:
+    sigo: ledc_ls_sig_out0
+    gpio: [[0, 10], [18, 20]]
+  ch1:
+    sigo: ledc_ls_sig_out1
+    gpio: [[0, 10], [18, 20]]
+  ch2:
+    sigo: ledc_ls_sig_out2
+    gpio: [[0, 10], [18, 20]]
+  ch3:
+    sigo: ledc_ls_sig_out3
+    gpio: [[0, 10], [18, 20]]
+  ch4:
+    sigo: ledc_ls_sig_out4
+    gpio: [[0, 10], [18, 20]]
+  ch5:
+    sigo: ledc_ls_sig_out5
+    gpio: [[0, 10], [18, 20]]


### PR DESCRIPTION
Add LEDC PWM driver support for ESP32C2 and ESP8684