### PR TITLE
Dynamic heap for ESP Wi-Fi

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -4,7 +4,9 @@ if(CONFIG_SOC_SERIES_ESP32)
 
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
-  zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT BOOTLOADER_BUILD=y) # See Zephyr-ESP / ZEP-820
+
+  zephyr_compile_definitions_ifdef(CONFIG_MCUBOOT BOOTLOADER_BUILD)
+  zephyr_compile_definitions_ifdef(CONFIG_ESP_SIMPLE_BOOT BOOTLOADER_BUILD)
 
   if(CONFIG_MCUBOOT)
     zephyr_compile_options(-fdump-rtl-expand)
@@ -242,12 +244,8 @@ if(CONFIG_SOC_SERIES_ESP32)
     )
   endif()
 
-  if (CONFIG_MCUBOOT)
-    zephyr_compile_definitions(BOOTLOADER_BUILD)
-    zephyr_compile_definitions(NDEBUG)
-  endif()
-
   if (CONFIG_MCUBOOT OR NOT CONFIG_BOOTLOADER_MCUBOOT)
+
     zephyr_include_directories(
       ../../components/esp_rom/${CONFIG_SOC_SERIES}
       ../port/include/boot

--- a/zephyr/esp32/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32/src/wifi/esp_wifi_adapter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,9 +10,6 @@
 #include "zephyr_compat.h"
 
 #define CONFIG_POSIX_FS
-
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include "esp_wifi.h"
 #include "stdlib.h"
@@ -35,7 +32,46 @@ LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 #include "wifi/wifi_event.h"
 #include "esp_private/adc_share_hw_ctrl.h"
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
+
 ESP_EVENT_DEFINE_BASE(WIFI_EVENT);
+
+/* Select heap to be used for WiFi adapter */
+#if defined(CONFIG_ESP_WIFI_HEAP_RUNTIME)
+
+extern struct k_heap esp_runtime_heap;
+
+static inline void *esp_wifi_malloc_func(size_t size)
+{
+	return k_heap_alloc(&esp_runtime_heap, size, K_NO_WAIT);
+}
+
+static inline void *esp_wifi_calloc_func(size_t n, size_t size)
+{
+	size_t sz;
+	if (__builtin_mul_overflow(n, size, &sz)) {
+		return NULL;
+	}
+	void *ptr = k_heap_alloc(&esp_runtime_heap, sz, K_NO_WAIT);
+	if (ptr) {
+		memset(ptr, 0, sz);
+	}
+	return ptr;
+}
+
+static inline void esp_wifi_free_func(void *mem)
+{
+	k_heap_free(&esp_runtime_heap, mem);
+}
+
+#else
+
+#define esp_wifi_malloc_func(_size) k_malloc(_size)
+#define esp_wifi_calloc_func(_nmemb, _size) k_calloc(_nmemb, _size)
+#define esp_wifi_free_func(_mem) k_free(_mem)
+
+#endif /* CONFIG_ESP_WIFI_HEAP_* */
 
 static void *wifi_msgq_buffer;
 
@@ -74,7 +110,7 @@ static void IRAM_ATTR s_esp_dport_access_stall_other_cpu_end(void)
 
 IRAM_ATTR void *wifi_malloc(size_t size)
 {
-	void *ptr = k_malloc(size);
+	void *ptr = esp_wifi_malloc_func(size);
 
 	if (ptr == NULL) {
 		LOG_ERR("memory allocation failed");
@@ -91,7 +127,7 @@ IRAM_ATTR void *wifi_realloc(void *ptr, size_t size)
 
 IRAM_ATTR void *wifi_calloc(size_t n, size_t size)
 {
-	void *ptr = k_calloc(n, size);
+	void *ptr = esp_wifi_calloc_func(n, size);
 
 	if (ptr == NULL) {
 		LOG_ERR("memory allocation failed");
@@ -103,6 +139,11 @@ IRAM_ATTR void *wifi_calloc(size_t n, size_t size)
 static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
 {
 	return wifi_calloc(1, size);
+}
+
+static void esp_wifi_free(void *mem)
+{
+	esp_wifi_free_func(mem);
 }
 
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
@@ -964,9 +1005,4 @@ esp_err_t esp_wifi_init(const wifi_init_config_t *config)
     adc2_cal_include(); //This enables the ADC2 calibration constructor at start up.
 
 	return result;
-}
-
-static void esp_wifi_free(void *mem)
-{
-	k_free(mem);
 }

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -4,6 +4,8 @@ if(CONFIG_SOC_SERIES_ESP32C2)
 
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
+  zephyr_compile_definitions_ifdef(CONFIG_MCUBOOT BOOTLOADER_BUILD)
+
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
 
   if(CONFIG_MCUBOOT)
@@ -173,9 +175,6 @@ if(CONFIG_SOC_SERIES_ESP32C2)
     )
 
   if (CONFIG_MCUBOOT)
-    zephyr_compile_definitions(BOOTLOADER_BUILD)
-    zephyr_compile_definitions(NDEBUG)
-
     zephyr_sources(
         ../port/boot/esp_image_loader.c
         )

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -4,6 +4,8 @@ if(CONFIG_SOC_SERIES_ESP32C3)
 
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
+  zephyr_compile_definitions_ifdef(CONFIG_MCUBOOT BOOTLOADER_BUILD)
+
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
 
   if(CONFIG_MCUBOOT)
@@ -234,11 +236,6 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     ../../components/soc/lldesc.c
     ../../components/hal/gdma_hal.c
     )
-
-  if (CONFIG_MCUBOOT)
-    zephyr_compile_definitions(BOOTLOADER_BUILD)
-    zephyr_compile_definitions(NDEBUG)
-  endif()
 
   if (CONFIG_MCUBOOT OR NOT CONFIG_BOOTLOADER_MCUBOOT)
     zephyr_include_directories(

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -4,6 +4,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
 
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
+  zephyr_compile_definitions_ifdef(CONFIG_MCUBOOT BOOTLOADER_BUILD)
 
   if(CONFIG_MCUBOOT)
     zephyr_compile_options(-fdump-rtl-expand)
@@ -243,11 +244,6 @@ if(CONFIG_SOC_SERIES_ESP32S2)
   zephyr_link_libraries("-Wl,--wrap=longjmp")
 
   if (CONFIG_MCUBOOT OR NOT CONFIG_BOOTLOADER_MCUBOOT)
-
-    if (CONFIG_MCUBOOT)
-      zephyr_compile_definitions(BOOTLOADER_BUILD)
-      zephyr_compile_definitions(NDEBUG)
-    endif()
 
     zephyr_include_directories(
       ../../components/esp_rom/${CONFIG_SOC_SERIES}

--- a/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,9 +10,6 @@
 #include "zephyr_compat.h"
 
 #define CONFIG_POSIX_FS
-
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include "esp_system.h"
 #include "esp_wifi.h"
@@ -39,7 +36,46 @@ LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 #include "esp_mac.h"
 #include "wifi/wifi_event.h"
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
+
 ESP_EVENT_DEFINE_BASE(WIFI_EVENT);
+
+/* Select heap to be used for WiFi adapter */
+#if defined(CONFIG_ESP_WIFI_HEAP_RUNTIME)
+
+extern struct k_heap esp_runtime_heap;
+
+static inline void *esp_wifi_malloc_func(size_t size)
+{
+	return k_heap_alloc(&esp_runtime_heap, size, K_NO_WAIT);
+}
+
+static inline void *esp_wifi_calloc_func(size_t n, size_t size)
+{
+	size_t sz;
+	if (__builtin_mul_overflow(n, size, &sz)) {
+		return NULL;
+	}
+	void *ptr = k_heap_alloc(&esp_runtime_heap, sz, K_NO_WAIT);
+	if (ptr) {
+		memset(ptr, 0, sz);
+	}
+	return ptr;
+}
+
+static inline void esp_wifi_free_func(void *mem)
+{
+	k_heap_free(&esp_runtime_heap, mem);
+}
+
+#else
+
+#define esp_wifi_malloc_func(_size) k_malloc(_size)
+#define esp_wifi_calloc_func(_nmemb, _size) k_calloc(_nmemb, _size)
+#define esp_wifi_free_func(_mem) k_free(_mem)
+
+#endif /* CONFIG_ESP_WIFI_HEAP_* */
 
 static void *wifi_msgq_buffer;
 
@@ -51,7 +87,7 @@ static void esp_wifi_free(void *mem);
 #if CONFIG_ESP_WIFI_ENABLE_WPA3_SAE
 	CONFIG_FEATURE_WPA3_SAE_BIT |
 #endif
-#if CONFIG_SPIRAM
+#ifdef CONFIG_SPIRAM
 	CONFIG_FEATURE_CACHE_TX_BUF_BIT |
 #endif
 #if CONFIG_ESP_WIFI_FTM_INITIATOR_SUPPORT
@@ -64,7 +100,7 @@ static void esp_wifi_free(void *mem);
 
 IRAM_ATTR void *wifi_malloc(size_t size)
 {
-	void *ptr = k_malloc(size);
+	void *ptr = esp_wifi_malloc_func(size);
 
 	if (ptr == NULL) {
 		LOG_ERR("memory allocation failed");
@@ -81,7 +117,7 @@ IRAM_ATTR void *wifi_realloc(void *ptr, size_t size)
 
 IRAM_ATTR void *wifi_calloc(size_t n, size_t size)
 {
-	void *ptr = k_calloc(n, size);
+	void *ptr = esp_wifi_calloc_func(n, size);
 
 	if (ptr == NULL) {
 		LOG_ERR("memory allocation failed");
@@ -99,6 +135,11 @@ static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
 	}
 
 	return ptr;
+}
+
+static void esp_wifi_free(void *mem)
+{
+	esp_wifi_free_func(mem);
 }
 
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
@@ -966,9 +1007,4 @@ esp_err_t esp_wifi_init(const wifi_init_config_t *config)
 	}
 
 	return result;
-}
-
-static void esp_wifi_free(void *mem)
-{
-	k_free(mem);
 }

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -4,6 +4,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
 
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
+  zephyr_compile_definitions_ifdef(CONFIG_MCUBOOT BOOTLOADER_BUILD)
 
   if(CONFIG_MCUBOOT)
     zephyr_compile_options(-fdump-rtl-expand)
@@ -277,11 +278,6 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     ../../components/efuse/src/esp_efuse_utility.c
     ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_utility.c
     )
-
-  if (CONFIG_MCUBOOT)
-    zephyr_compile_definitions(BOOTLOADER_BUILD)
-    zephyr_compile_definitions(NDEBUG)
-  endif()
 
   if (CONFIG_MCUBOOT OR NOT CONFIG_BOOTLOADER_MCUBOOT)
     zephyr_include_directories(

--- a/zephyr/esp32s3/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32s3/src/wifi/esp_wifi_adapter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -43,6 +43,42 @@ K_THREAD_STACK_DEFINE(wifi_stack, 8192);
 
 ESP_EVENT_DEFINE_BASE(WIFI_EVENT);
 
+/* Select heap to be used for WiFi adapter */
+#if defined(CONFIG_ESP_WIFI_HEAP_RUNTIME)
+
+extern struct k_heap esp_runtime_heap;
+
+static inline void *esp_wifi_malloc_func(size_t size)
+{
+	return k_heap_alloc(&esp_runtime_heap, size, K_NO_WAIT);
+}
+
+static inline void *esp_wifi_calloc_func(size_t n, size_t size)
+{
+	size_t sz;
+	if (__builtin_mul_overflow(n, size, &sz)) {
+		return NULL;
+	}
+	void *ptr = k_heap_alloc(&esp_runtime_heap, sz, K_NO_WAIT);
+	if (ptr) {
+		memset(ptr, 0, sz);
+	}
+	return ptr;
+}
+
+static inline void esp_wifi_free_func(void *mem)
+{
+	k_heap_free(&esp_runtime_heap, mem);
+}
+
+#else
+
+#define esp_wifi_malloc_func(_size) k_malloc(_size)
+#define esp_wifi_calloc_func(_nmemb, _size) k_calloc(_nmemb, _size)
+#define esp_wifi_free_func(_mem) k_free(_mem)
+
+#endif /* CONFIG_ESP_WIFI_HEAP_* */
+
 static void *wifi_msgq_buffer;
 
 static struct k_thread wifi_task_handle;
@@ -53,7 +89,7 @@ uint64_t g_wifi_feature_caps =
 #if CONFIG_ESP_WIFI_ENABLE_WPA3_SAE
 	CONFIG_FEATURE_WPA3_SAE_BIT |
 #endif
-#if CONFIG_SPIRAM
+#if defined(CONFIG_SPIRAM)
 	CONFIG_FEATURE_CACHE_TX_BUF_BIT |
 #endif
 #if CONFIG_ESP_WIFI_FTM_INITIATOR_SUPPORT
@@ -66,7 +102,7 @@ uint64_t g_wifi_feature_caps =
 
 IRAM_ATTR void *wifi_malloc(size_t size)
 {
-	void *ptr = k_malloc(size);
+	void *ptr = esp_wifi_malloc_func(size);
 
 	if (ptr == NULL) {
 		LOG_ERR("memory allocation failed");
@@ -83,7 +119,7 @@ IRAM_ATTR void *wifi_realloc(void *ptr, size_t size)
 
 IRAM_ATTR void *wifi_calloc(size_t n, size_t size)
 {
-	void *ptr = k_calloc(n, size);
+	void *ptr = esp_wifi_calloc_func(n, size);
 
 	if (ptr == NULL) {
 		LOG_ERR("memory allocation failed");
@@ -101,6 +137,11 @@ static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
 	}
 
 	return ptr;
+}
+
+static void esp_wifi_free(void *mem)
+{
+	esp_wifi_free_func(mem);
 }
 
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
@@ -1007,9 +1048,4 @@ esp_err_t esp_wifi_init(const wifi_init_config_t *config)
 	adc2_cal_include();
 
 	return result;
-}
-
-static void esp_wifi_free(void *mem)
-{
-	k_free(mem);
 }


### PR DESCRIPTION
Utilize the memory left unused by static allocation, and re-claim it dynamically using the Zephyr `k_heap` API for the ESP WiFi adapter purposes.