### PR TITLE
esp_timer: fix semaphore init check

### DIFF
--- a/components/esp_timer/src/esp_timer.c
+++ b/components/esp_timer/src/esp_timer.c
@@ -536,9 +536,9 @@ static esp_err_t init_timer_task(void)
     } else {
         int ret = k_sem_init(&s_timer_semaphore, 0, TIMER_EVENT_QUEUE_SIZE);
 
-        if (!ret) {
+        if (ret) {
             ESP_EARLY_LOGE(TAG, "Not enough memory to run esp_timer");
-            err = ESP_ERR_NO_MEM;
+            return ESP_ERR_NO_MEM;
         }
 
         k_tid_t tid = k_thread_create(&s_timer_task, timer_task_stack,


### PR DESCRIPTION
Semaphore init check is wrong as 0 is the expected return
when success.