### PR TITLE
components: Fix simple-boot condition

### DIFF
--- a/components/bootloader_support/src/esp32c2/bootloader_esp32c2.c
+++ b/components/bootloader_support/src/esp32c2/bootloader_esp32c2.c
@@ -39,7 +39,7 @@
 #include "esp_efuse.h"
 #include "hal/mmu_hal.h"
 #include "hal/cache_hal.h"
-#ifdef CONFIG_ESP_SIMPLE_BOOT
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT)
 #include "esp_flash_internal.h"
 #endif
 

--- a/components/bootloader_support/src/esp32c3/bootloader_esp32c3.c
+++ b/components/bootloader_support/src/esp32c3/bootloader_esp32c3.c
@@ -44,7 +44,7 @@
 #include "hal/mmu_hal.h"
 #include "hal/cache_hal.h"
 #include "hal/efuse_hal.h"
-#ifdef CONFIG_ESP_SIMPLE_BOOT
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT)
 #include "esp_flash_internal.h"
 #endif
 

--- a/components/bootloader_support/src/esp32c6/bootloader_esp32c6.c
+++ b/components/bootloader_support/src/esp32c6/bootloader_esp32c6.c
@@ -45,7 +45,7 @@
 #include "soc/lp_wdt_reg.h"
 #include "hal/efuse_hal.h"
 #include "modem/modem_lpcon_reg.h"
-#ifdef CONFIG_ESP_SIMPLE_BOOT
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT)
 #include "esp_flash_internal.h"
 #endif
 

--- a/components/bootloader_support/src/esp32s2/bootloader_esp32s2.c
+++ b/components/bootloader_support/src/esp32s2/bootloader_esp32s2.c
@@ -38,7 +38,7 @@
 #include "esp_efuse.h"
 #include "hal/mmu_hal.h"
 #include "hal/cache_hal.h"
-#ifdef CONFIG_ESP_SIMPLE_BOOT
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT)
 #include "esp_flash_internal.h"
 #endif
 

--- a/components/bootloader_support/src/esp32s3/bootloader_esp32s3.c
+++ b/components/bootloader_support/src/esp32s3/bootloader_esp32s3.c
@@ -40,7 +40,7 @@
 #include "hal/cache_hal.h"
 #include "xtensa/config/core.h"
 #include "xt_instr_macros.h"
-#ifdef CONFIG_ESP_SIMPLE_BOOT
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT)
 #include "esp_flash_internal.h"
 #endif
 

--- a/components/spi_flash/esp_flash_spi_init.c
+++ b/components/spi_flash/esp_flash_spi_init.c
@@ -389,7 +389,7 @@ esp_err_t esp_flash_init_default_chip(void)
     }
     /* TODO: Zephyr workaroud to fix start-up issues
      * if case there is no bootloader involved */
-#ifndef CONFIG_ESP_SIMPLE_BOOT
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
     if (default_chip.size < legacy_chip->chip_size) {
         ESP_EARLY_LOGE(TAG, "Detected size(%dk) smaller than the size in the binary image header(%dk). Probe failed.", default_chip.size/1024, legacy_chip->chip_size/1024);
         return ESP_ERR_FLASH_SIZE_NOT_MATCH;


### PR DESCRIPTION
Fix usage of CONFIG_ESP_SIMPLE_BOOT after excluding the CONFIG_MCUBOOT from its area of validity.