### PR TITLE
build: remove unused variables when PM is enabled

### DIFF
--- a/components/esp_hw_support/sleep_modes.c
+++ b/components/esp_hw_support/sleep_modes.c
@@ -1661,7 +1661,7 @@ static uint32_t get_power_down_flags(void)
     // If there is any data placed into .rtc.data or .rtc.bss segments, and
     // RTC_SLOW_MEM is Auto, keep it powered up as well.
 
-#if SOC_PM_SUPPORT_RTC_SLOW_MEM_PD && SOC_ULP_SUPPORTED
+#if SOC_PM_SUPPORT_RTC_SLOW_MEM_PD && SOC_ULP_SUPPORTED && !CONFIG_SOC_ESP32_APPCPU && !CONFIG_SOC_ESP32S3_APPCPU
     // Labels are defined in the linker script
     extern int _rtc_slow_length;
     int _rtc_reserved_length = 0;

--- a/components/esp_hw_support/sleep_retention.c
+++ b/components/esp_hw_support/sleep_retention.c
@@ -520,6 +520,7 @@ void sleep_retention_do_extra_retention(bool backup_or_restore)
     int refs = s_retention.extra_refs;
     k_sem_give(&s_retention_lock);
     assert(refs >= 0 && refs <= cnt_modules);
+    (void)refs;
 }
 
 void sleep_retention_module_deinit(void)

--- a/components/esp_pm/pm_impl.c
+++ b/components/esp_pm/pm_impl.c
@@ -582,7 +582,11 @@ void esp_pm_impl_init(void)
     esp_err_t err = esp_clk_tree_src_get_freq_hz((soc_module_clk_t)clk_source,
             ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &sclk_freq);
 
-    assert(err == ESP_OK);
+    if (err != ESP_OK) {
+        ESP_LOGI(TAG, "could not get UART clock frequency");
+        return;
+    }
+
     uart_ll_set_baudrate(UART_LL_GET_HW(CONFIG_ESP_CONSOLE_UART_NUM), CONFIG_ESP_CONSOLE_UART_BAUDRATE, sclk_freq);
 #endif // CONFIG_ESP_CONSOLE_UART
 


### PR DESCRIPTION
When CONFIG_PM=y, some variables are not used. Handle it accordingly.