### PR TITLE
drivers: adc/wifi: esp32s2/esp32c3: adc2_init_code_calibration() call prep

### DIFF
--- a/components/esp_hw_support/include/esp_private/adc_share_hw_ctrl.h
+++ b/components/esp_hw_support/include/esp_private/adc_share_hw_ctrl.h
@@ -147,6 +147,12 @@ esp_err_t adc2_wifi_release(void);
  * @note  This is a private function, Don't call `adc2_cal_include` in user code.
  */
 void adc2_cal_include(void);
+
+/**
+ * @brief Set initial code to ADC2 after calibration. ADC2 RTC and ADC2 PWDET controller share the initial code.
+ *        This API be called in before `app_main()`.
+ */
+void adc2_init_code_calibration(void);
 #else
 /**
  * @brief There's no calibration involved on this chip.

--- a/components/esp_hw_support/port/esp32c3/adc2_init_cal.c
+++ b/components/esp_hw_support/port/esp32c3/adc2_init_cal.c
@@ -23,7 +23,7 @@ extern int rtc_spinlock;
  * @brief Set initial code to ADC2 after calibration. ADC2 RTC and ADC2 PWDET controller share the initial code.
  *        This API be called in before `app_main()`.
  */
-static void adc2_init_code_calibration(void)
+void adc2_init_code_calibration(void)
 {
     adc_hal_calibration_init(ADC_UNIT_2);
     adc_calc_hw_calibration_code(ADC_UNIT_2, ADC_ATTEN_DB_11);

--- a/components/esp_hw_support/port/esp32s2/adc2_init_cal.c
+++ b/components/esp_hw_support/port/esp32s2/adc2_init_cal.c
@@ -23,7 +23,7 @@ extern int rtc_spinlock;
  * @brief Set initial code to ADC2 after calibration. ADC2 RTC and ADC2 PWDET controller share the initial code.
  *        This API be called in before `app_main()`.
  */
-static void adc2_init_code_calibration(void)
+void adc2_init_code_calibration(void)
 {
     adc_hal_calibration_init(ADC_UNIT_2);
     adc_calc_hw_calibration_code(ADC_UNIT_2, ADC_ATTEN_DB_11);

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -220,6 +220,7 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     ../../components/hal/adc_hal_common.c
     ../../components/driver/deprecated/adc_legacy.c
     ../../components/esp_hw_support/adc_share_hw_ctrl.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/adc2_init_cal.c
     ../../components/hal/rtc_io_hal.c
     ../../components/driver/gpio/rtc_io.c
     src/esp_adc_cal/esp_adc_cal.c
@@ -381,6 +382,13 @@ if(CONFIG_SOC_SERIES_ESP32C3)
 
   ## WIFI definitions
   if (CONFIG_WIFI_ESP32)
+
+    zephyr_sources(
+      ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_rtc_calib.c
+      ../../components/hal/adc_hal_common.c
+      ../../components/esp_hw_support/adc_share_hw_ctrl.c
+      ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/adc2_init_cal.c
+      )
 
     set(WPA_SUPPLICANT_COMPONENT_DIR "../../components/wpa_supplicant")
     #TODO: Additional WPA supplicant feature like Enterprise mode etc. are yet to be supported.

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -205,6 +205,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     ../../components/hal/adc_hal_common.c
     ../../components/driver/deprecated/adc_legacy.c
     ../../components/esp_hw_support/adc_share_hw_ctrl.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/adc2_init_cal.c
     ../../components/hal/rtc_io_hal.c
     ../../components/driver/gpio/rtc_io.c
     src/esp_adc_cal/esp_adc_cal.c
@@ -348,6 +349,13 @@ if(CONFIG_SOC_SERIES_ESP32S2)
 
   ## WIFI definitions
   if (CONFIG_WIFI_ESP32)
+
+    zephyr_sources(
+      ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_rtc_table.c
+      ../../components/hal/adc_hal_common.c
+      ../../components/esp_hw_support/adc_share_hw_ctrl.c
+      ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/adc2_init_cal.c
+      )
 
     zephyr_sources(
       src/wifi/esp_wifi_adapter.c


### PR DESCRIPTION
Changes to allow adc2_init_code_calibration() to be called during adc and wifi initialization on esp32s2 and esp32c3

Related to [PR#292](https://github.com/zephyrproject-rtos/hal_espressif/pull/292)