### PR TITLE
wpa_supplicant: Fix include for suseconds_t

### DIFF
--- a/components/wpa_supplicant/port/include/os.h
+++ b/components/wpa_supplicant/port/include/os.h
@@ -15,7 +15,7 @@
 #ifndef OS_H
 #define OS_H
 #include <zephyr/kernel.h>
-#include <zephyr/sys/timeutil.h>
+#include <sys/_timeval.h>
 #include <strings.h>
 #include "esp_types.h"
 #include <string.h>


### PR DESCRIPTION
Fixes include for suseconds_t after SDK bump to 0.16.9-rc2