### PR TITLE
rf: unify runtime heap call for bt and wifi adapters

### DIFF
--- a/zephyr/esp32/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32/src/wifi/esp_wifi_adapter.c
@@ -31,6 +31,7 @@
 #include "esp_modem_wrapper.h"
 #include "wifi/wifi_event.h"
 #include "esp_private/adc_share_hw_ctrl.h"
+#include "esp_heap_runtime.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
@@ -40,30 +41,9 @@ ESP_EVENT_DEFINE_BASE(WIFI_EVENT);
 /* Select heap to be used for WiFi adapter */
 #if defined(CONFIG_ESP_WIFI_HEAP_RUNTIME)
 
-extern struct k_heap esp_runtime_heap;
-
-static inline void *esp_wifi_malloc_func(size_t size)
-{
-	return k_heap_alloc(&esp_runtime_heap, size, K_NO_WAIT);
-}
-
-static inline void *esp_wifi_calloc_func(size_t n, size_t size)
-{
-	size_t sz;
-	if (__builtin_mul_overflow(n, size, &sz)) {
-		return NULL;
-	}
-	void *ptr = k_heap_alloc(&esp_runtime_heap, sz, K_NO_WAIT);
-	if (ptr) {
-		memset(ptr, 0, sz);
-	}
-	return ptr;
-}
-
-static inline void esp_wifi_free_func(void *mem)
-{
-	k_heap_free(&esp_runtime_heap, mem);
-}
+#define esp_wifi_malloc_func(_size) esp_heap_runtime_malloc(_size)
+#define esp_wifi_calloc_func(_nmemb, _size) esp_heap_runtime_calloc(_nmemb, _size)
+#define esp_wifi_free_func(_mem) esp_heap_runtime_free(_mem)
 
 #else
 
@@ -71,7 +51,7 @@ static inline void esp_wifi_free_func(void *mem)
 #define esp_wifi_calloc_func(_nmemb, _size) k_calloc(_nmemb, _size)
 #define esp_wifi_free_func(_mem) k_free(_mem)
 
-#endif /* CONFIG_ESP_WIFI_HEAP_* */
+#endif /* CONFIG_ESP_WIFI_HEAP_RUNTIME */
 
 static void *wifi_msgq_buffer;
 

--- a/zephyr/esp32c2/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32c2/src/wifi/esp_wifi_adapter.c
@@ -32,6 +32,7 @@
 #include "esp32c3/rom/ets_sys.h"
 #include "esp_mac.h"
 #include "wifi/wifi_event.h"
+#include "esp_heap_runtime.h"
 
 #include <soc.h>
 #include <zephyr/kernel.h>
@@ -48,30 +49,9 @@ ESP_EVENT_DEFINE_BASE(WIFI_EVENT);
 /* Select heap to be used for WiFi adapter */
 #if defined(CONFIG_ESP_WIFI_HEAP_RUNTIME)
 
-extern struct k_heap esp_runtime_heap;
-
-static inline void *esp_wifi_malloc_func(size_t size)
-{
-	return k_heap_alloc(&esp_runtime_heap, size, K_NO_WAIT);
-}
-
-static inline void *esp_wifi_calloc_func(size_t n, size_t size)
-{
-	size_t sz;
-	if (__builtin_mul_overflow(n, size, &sz)) {
-		return NULL;
-	}
-	void *ptr = k_heap_alloc(&esp_runtime_heap, sz, K_NO_WAIT);
-	if (ptr) {
-		memset(ptr, 0, sz);
-	}
-	return ptr;
-}
-
-static inline void esp_wifi_free_func(void *mem)
-{
-	k_heap_free(&esp_runtime_heap, mem);
-}
+#define esp_wifi_malloc_func(_size) esp_heap_runtime_malloc(_size)
+#define esp_wifi_calloc_func(_nmemb, _size) esp_heap_runtime_calloc(_nmemb, _size)
+#define esp_wifi_free_func(_mem) esp_heap_runtime_free(_mem)
 
 #else
 
@@ -79,7 +59,7 @@ static inline void esp_wifi_free_func(void *mem)
 #define esp_wifi_calloc_func(_nmemb, _size) k_calloc(_nmemb, _size)
 #define esp_wifi_free_func(_mem) k_free(_mem)
 
-#endif /* CONFIG_ESP_WIFI_HEAP_* */
+#endif /* CONFIG_ESP_WIFI_HEAP_RUNTIME */
 
 static void esp_wifi_free(void *mem);
 

--- a/zephyr/esp32c3/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32c3/src/bt/esp_bt_adapter.c
@@ -28,6 +28,7 @@
 #include "esp_sleep.h"
 #include "esp_rom_sys.h"
 #include "esp_private/phy.h"
+#include "esp_heap_runtime.h"
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
@@ -110,6 +111,19 @@ struct bt_queue_t {
 	struct k_msgq queue;
 	void *pool;
 };
+
+/* Select heap to be used for WiFi adapter */
+#if defined(CONFIG_ESP_BT_HEAP_RUNTIME)
+
+#define esp_bt_malloc_func(_size) esp_heap_runtime_malloc(_size)
+#define esp_bt_free_func(_mem) esp_heap_runtime_free(_mem)
+
+#else
+
+#define esp_bt_malloc_func(_size) k_malloc(_size)
+#define esp_bt_free_func(_mem) k_free(_mem)
+
+#endif /* CONFIG_ESP_BLUETOOTH_HEAP_RUNTIME */
 
 /* OSI function */
 struct osi_funcs_t {
@@ -266,7 +280,6 @@ static void btdm_backup_dma_copy_wrapper(uint32_t reg, uint32_t mem_addr, uint32
 static void btdm_slp_tmr_callback(void *arg);
 
 static void bt_controller_deinit_internal(void);
-
 static void esp_bt_free(void *mem);
 
 /* Local variable definition
@@ -353,11 +366,6 @@ K_THREAD_STACK_DEFINE(bt_stack, ESP_TASK_BT_CONTROLLER_STACK);
 static struct k_thread bt_task_handle;
 
 static DRAM_ATTR struct k_sem *s_wakeup_req_sem = NULL;
-
-static void esp_bt_free(void *mem)
-{
-	k_free(mem);
-}
 
 void IRAM_ATTR btdm_hw_mac_power_down_wrapper(void)
 {
@@ -477,7 +485,7 @@ static bool IRAM_ATTR is_in_isr_wrapper(void)
 
 static void *semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-	struct k_sem *sem = (struct k_sem *) k_malloc(sizeof(struct k_sem));
+	struct k_sem *sem = (struct k_sem *) esp_bt_malloc_func(sizeof(struct k_sem));
 
 	if (sem == NULL) {
 		LOG_ERR("semaphore malloc failed");
@@ -542,7 +550,7 @@ static int32_t semphr_give_wrapper(void *semphr)
 
 static void *mutex_create_wrapper(void)
 {
-	struct k_mutex *my_mutex = (struct k_mutex *) k_malloc(sizeof(struct k_mutex));
+	struct k_mutex *my_mutex = (struct k_mutex *) esp_bt_malloc_func(sizeof(struct k_mutex));
 
 	if (my_mutex == NULL) {
 		LOG_ERR("mutex malloc failed");
@@ -577,14 +585,14 @@ static int32_t mutex_unlock_wrapper(void *mutex)
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-	struct bt_queue_t *queue = k_malloc(sizeof(struct bt_queue_t));
+	struct bt_queue_t *queue = esp_bt_malloc_func(sizeof(struct bt_queue_t));
 
 	if (queue == NULL) {
 		LOG_ERR("queue malloc failed");
 		return NULL;
 	}
 
-	queue->pool = (uint8_t *)k_malloc(queue_len * item_size * sizeof(uint8_t));
+	queue->pool = (uint8_t *)esp_bt_malloc_func(queue_len * item_size * sizeof(uint8_t));
 
 	if (queue->pool == NULL) {
 		LOG_ERR("queue pool malloc failed");
@@ -692,7 +700,7 @@ static void task_delete_wrapper(void *task_handle)
 
 static void *malloc_internal_wrapper(size_t size)
 {
-	return k_malloc(sizeof(uint8_t) * size);
+	return esp_bt_malloc_func(sizeof(uint8_t) * size);
 }
 
 static int32_t IRAM_ATTR read_mac_wrapper(uint8_t mac[6])
@@ -1448,4 +1456,9 @@ uint16_t esp_bt_get_tx_buf_num(void)
 static void coex_wifi_sleep_set_hook(bool sleep)
 {
 
+}
+
+static void esp_bt_free(void *mem)
+{
+	esp_bt_free_func(mem);
 }

--- a/zephyr/esp32c3/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32c3/src/wifi/esp_wifi_adapter.c
@@ -32,6 +32,7 @@
 #include "esp32c3/rom/ets_sys.h"
 #include "esp_mac.h"
 #include "wifi/wifi_event.h"
+#include "esp_heap_runtime.h"
 
 #include <soc.h>
 #include <zephyr/kernel.h>
@@ -48,30 +49,9 @@ ESP_EVENT_DEFINE_BASE(WIFI_EVENT);
 /* Select heap to be used for WiFi adapter */
 #if defined(CONFIG_ESP_WIFI_HEAP_RUNTIME)
 
-extern struct k_heap esp_runtime_heap;
-
-static inline void *esp_wifi_malloc_func(size_t size)
-{
-	return k_heap_alloc(&esp_runtime_heap, size, K_NO_WAIT);
-}
-
-static inline void *esp_wifi_calloc_func(size_t n, size_t size)
-{
-	size_t sz;
-	if (__builtin_mul_overflow(n, size, &sz)) {
-		return NULL;
-	}
-	void *ptr = k_heap_alloc(&esp_runtime_heap, sz, K_NO_WAIT);
-	if (ptr) {
-		memset(ptr, 0, sz);
-	}
-	return ptr;
-}
-
-static inline void esp_wifi_free_func(void *mem)
-{
-	k_heap_free(&esp_runtime_heap, mem);
-}
+#define esp_wifi_malloc_func(_size) esp_heap_runtime_malloc(_size)
+#define esp_wifi_calloc_func(_nmemb, _size) esp_heap_runtime_calloc(_nmemb, _size)
+#define esp_wifi_free_func(_mem) esp_heap_runtime_free(_mem)
 
 #else
 
@@ -79,7 +59,7 @@ static inline void esp_wifi_free_func(void *mem)
 #define esp_wifi_calloc_func(_nmemb, _size) k_calloc(_nmemb, _size)
 #define esp_wifi_free_func(_mem) k_free(_mem)
 
-#endif /* CONFIG_ESP_WIFI_HEAP_* */
+#endif /* CONFIG_ESP_WIFI_HEAP_RUNTIME */
 
 static void esp_wifi_free(void *mem);
 

--- a/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
@@ -35,6 +35,7 @@
 #include "esp32s2/rom/ets_sys.h"
 #include "esp_mac.h"
 #include "wifi/wifi_event.h"
+#include "esp_heap_runtime.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
@@ -44,30 +45,9 @@ ESP_EVENT_DEFINE_BASE(WIFI_EVENT);
 /* Select heap to be used for WiFi adapter */
 #if defined(CONFIG_ESP_WIFI_HEAP_RUNTIME)
 
-extern struct k_heap esp_runtime_heap;
-
-static inline void *esp_wifi_malloc_func(size_t size)
-{
-	return k_heap_alloc(&esp_runtime_heap, size, K_NO_WAIT);
-}
-
-static inline void *esp_wifi_calloc_func(size_t n, size_t size)
-{
-	size_t sz;
-	if (__builtin_mul_overflow(n, size, &sz)) {
-		return NULL;
-	}
-	void *ptr = k_heap_alloc(&esp_runtime_heap, sz, K_NO_WAIT);
-	if (ptr) {
-		memset(ptr, 0, sz);
-	}
-	return ptr;
-}
-
-static inline void esp_wifi_free_func(void *mem)
-{
-	k_heap_free(&esp_runtime_heap, mem);
-}
+#define esp_wifi_malloc_func(_size) esp_heap_runtime_malloc(_size)
+#define esp_wifi_calloc_func(_nmemb, _size) esp_heap_runtime_calloc(_nmemb, _size)
+#define esp_wifi_free_func(_mem) esp_heap_runtime_free(_mem)
 
 #else
 
@@ -75,7 +55,7 @@ static inline void esp_wifi_free_func(void *mem)
 #define esp_wifi_calloc_func(_nmemb, _size) k_calloc(_nmemb, _size)
 #define esp_wifi_free_func(_mem) k_free(_mem)
 
-#endif /* CONFIG_ESP_WIFI_HEAP_* */
+#endif /* CONFIG_ESP_WIFI_HEAP_RUNTIME */
 
 static void *wifi_msgq_buffer;
 


### PR DESCRIPTION
Each Wi-Fi and BT adapter uses the same approach to whether
use or not heap runtime feature.

This PR modify such usage in order to unify its access.