### PR TITLE
touch_sensor support restoration

### DIFF
--- a/components/bootloader_support/src/esp32/bootloader_esp32.c
+++ b/components/bootloader_support/src/esp32/bootloader_esp32.c
@@ -211,6 +211,14 @@ esp_err_t bootloader_init(void)
     // print 2nd bootloader banner
     bootloader_print_banner();
 
+    // Workaround to make flash accesible if no bootloader is enabled
+#ifndef CONFIG_BOOTLOADER_MCUBOOT
+    spi_flash_init_chip_state();
+    if ((ret = esp_flash_init_default_chip()) != ESP_OK) {
+        return ret;
+    }
+#endif
+
 #if !CONFIG_APP_BUILD_TYPE_RAM
     // reset MMU
     bootloader_reset_mmu();
@@ -221,12 +229,6 @@ esp_err_t bootloader_init(void)
         ESP_LOGE(TAG, "failed when running XMC startup flow, reboot!");
         return ret;
     }
-    // Workaround to make flash accesible if no bootloader is enabled
-#ifdef CONFIG_ESP_SIMPLE_BOOT
-    if ((ret = esp_flash_init_default_chip()) != ESP_OK) {
-        return ret;
-    }
-#endif
     // read bootloader header
     if ((ret = bootloader_read_bootloader_header()) != ESP_OK) {
         return ret;

--- a/components/bootloader_support/src/esp32c3/bootloader_esp32c3.c
+++ b/components/bootloader_support/src/esp32c3/bootloader_esp32c3.c
@@ -163,11 +163,10 @@ esp_err_t bootloader_init(void)
     /* print 2nd bootloader banner */
     bootloader_print_banner();
 
-#ifdef CONFIG_ESP_SIMPLE_BOOT
-    esp_rom_spiflash_attach(esp_rom_efuse_get_flash_gpio_info(), false);
-    esp_mspi_pin_init();
+    // Workaround to make flash accesible if no bootloader is enabled
+#ifndef CONFIG_BOOTLOADER_MCUBOOT
+    spi_flash_init_chip_state();
     if ((ret = esp_flash_init_default_chip()) != ESP_OK) {
-        ESP_EARLY_LOGE(TAG, "esp_flash_init_default_chip err=%x\n", ret);
         return ret;
     }
 #endif

--- a/components/bootloader_support/src/esp32c6/bootloader_esp32c6.c
+++ b/components/bootloader_support/src/esp32c6/bootloader_esp32c6.c
@@ -145,13 +145,10 @@ esp_err_t bootloader_init(void)
     /* print 2nd bootloader banner */
     bootloader_print_banner();
 
-    /* TODO: fix the flash init for all scenarios */
-#ifdef CONFIG_ESP_SIMPLE_BOOT
-    esp_mspi_pin_init();
+    // Workaround to make flash accesible if no bootloader is enabled
+#ifndef CONFIG_BOOTLOADER_MCUBOOT
     spi_flash_init_chip_state();
-
     if ((ret = esp_flash_init_default_chip()) != ESP_OK) {
-        ESP_EARLY_LOGE(TAG, "esp_flash_init_default_chip err=%x\n", ret);
         return ret;
     }
 #endif

--- a/components/bootloader_support/src/esp32s2/bootloader_esp32s2.c
+++ b/components/bootloader_support/src/esp32s2/bootloader_esp32s2.c
@@ -147,7 +147,9 @@ esp_err_t bootloader_init(void)
     /* print 2nd bootloader banner */
     bootloader_print_banner();
 
-#ifdef CONFIG_ESP_SIMPLE_BOOT
+    // Workaround to make flash accesible if no bootloader is enabled
+#ifndef CONFIG_BOOTLOADER_MCUBOOT
+    spi_flash_init_chip_state();
     if ((ret = esp_flash_init_default_chip()) != ESP_OK) {
         return ret;
     }

--- a/components/bootloader_support/src/esp32s3/bootloader_esp32s3.c
+++ b/components/bootloader_support/src/esp32s3/bootloader_esp32s3.c
@@ -181,8 +181,12 @@ esp_err_t bootloader_init(void)
     /* print 2nd bootloader banner */
     bootloader_print_banner();
 
-#ifdef CONFIG_ESP_SIMPLE_BOOT
-    esp_flash_init_default_chip();
+    // Workaround to make flash accesible if no bootloader is enabled
+#ifndef CONFIG_BOOTLOADER_MCUBOOT
+    spi_flash_init_chip_state();
+    if ((ret = esp_flash_init_default_chip()) != ESP_OK) {
+        return ret;
+    }
 #endif
 
 #if !CONFIG_APP_BUILD_TYPE_PURE_RAM_APP
@@ -191,8 +195,7 @@ esp_err_t bootloader_init(void)
     //init mmu
     mmu_hal_init();
     // update flash ID
-    /* disabled it to enable octal support */
-    // bootloader_flash_update_id();
+    bootloader_flash_update_id();
     // Check and run XMC startup flow
     if ((ret = bootloader_flash_xmc_startup()) != ESP_OK) {
         ESP_EARLY_LOGE(TAG, "failed when running XMC startup flow, reboot!");

--- a/components/driver/include/esp_private/spi_common_internal.h
+++ b/components/driver/include/esp_private/spi_common_internal.h
@@ -10,7 +10,6 @@
 
 #include <zephyr/kernel.h>
 
-#include <esp_intr_alloc.h>
 #include "driver/spi_common.h"
 #include "hal/spi_types.h"
 #include "esp_pm.h"

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32)
 
   zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
+  zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
 
   if(CONFIG_MCUBOOT)

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -153,6 +153,7 @@ if(CONFIG_SOC_SERIES_ESP32)
     ../../components/spi_flash/spi_flash_chip_th.c
     ../../components/spi_flash/spi_flash_chip_winbond.c
     ../../components/spi_flash/spi_flash_os_func_noos.c
+    ../../components/spi_flash/spi_flash_os_func_app.c
     )
   endif()
 

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32C3)
 
   zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
+  zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
 
   if(CONFIG_MCUBOOT)

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -153,6 +153,7 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     ../../components/spi_flash/spi_flash_chip_th.c
     ../../components/spi_flash/spi_flash_chip_winbond.c
     ../../components/spi_flash/spi_flash_os_func_noos.c
+    ../../components/spi_flash/spi_flash_os_func_app.c
     )
   endif()
 

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32C6)
 
   zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
+  zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
 
   if(CONFIG_MCUBOOT)

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -128,6 +128,7 @@ if(CONFIG_SOC_SERIES_ESP32C6)
     ../../components/spi_flash/spi_flash_chip_th.c
     ../../components/spi_flash/spi_flash_chip_winbond.c
     ../../components/spi_flash/spi_flash_os_func_noos.c
+    ../../components/spi_flash/spi_flash_os_func_app.c
     )
   endif()
 

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32S2)
 
   zephyr_compile_options(-Wno-unused-variable  -Wno-maybe-uninitialized)
+  zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
 
   if(CONFIG_MCUBOOT)

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -134,6 +134,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     ../../components/spi_flash/flash_mmap.c
     ../../components/spi_flash/flash_ops.c
     ../../components/spi_flash/spi_flash_os_func_noos.c
+    ../../components/spi_flash/spi_flash_os_func_app.c
     ../../components/spi_flash/memspi_host_driver.c
     ../../components/spi_flash/spi_flash_chip_boya.c
     ../../components/spi_flash/spi_flash_chip_drivers.c

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_SOC_SERIES_ESP32S3)
 
   zephyr_compile_options(-Wno-unused-variable -Wno-maybe-uninitialized)
+  zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
 
   if(CONFIG_MCUBOOT)

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -154,6 +154,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     ../../components/spi_flash/spi_flash_chip_winbond.c
     ../../components/spi_flash/spi_flash_hpm_enable.c
     ../../components/spi_flash/spi_flash_os_func_noos.c
+    ../../components/spi_flash/spi_flash_os_func_app.c
     # todo: ../../components/spi_flash/spi_flash_wrap.c
     )
   endif()


### PR DESCRIPTION
The support for touch_sensor was lost hal was updated to the v5.1.
This PR restores the touch_sensor support was restored for the following SoCs:
- ESP32
- ESP32-S2
- ESP32-S3
