### PR TITLE
touch_sensor support restoration

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -232,6 +232,16 @@ if(CONFIG_SOC_SERIES_ESP32)
   endif()
 
   zephyr_sources_ifdef(
+    CONFIG_INPUT_ESP32_TOUCH_SENSOR
+    ../../components/soc/esp32/touch_sensor_periph.c
+    ../../components/driver/gpio/rtc_io.c
+    ../../components/driver/touch_sensor/touch_sensor_common.c
+    ../../components/hal/rtc_io_hal.c
+    ../../components/hal/touch_sensor_hal.c
+    ../../components/hal/esp32/touch_sensor_hal.c
+    )
+
+  zephyr_sources_ifdef(
     CONFIG_ADC_ESP32
     ../../components/hal/adc_hal.c
     ../../components/driver/deprecated/adc_legacy.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -235,6 +235,16 @@ if(CONFIG_SOC_SERIES_ESP32S2)
   endif()
 
   zephyr_sources_ifdef(
+    CONFIG_INPUT_ESP32_TOUCH_SENSOR
+    ../../components/soc/esp32s2/touch_sensor_periph.c
+    ../../components/driver/gpio/rtc_io.c
+    ../../components/driver/touch_sensor/touch_sensor_common.c
+    ../../components/hal/rtc_io_hal.c
+    ../../components/hal/touch_sensor_hal.c
+    ../../components/hal/esp32s2/touch_sensor_hal.c
+    )
+
+  zephyr_sources_ifdef(
     CONFIG_ESP32_TEMP
     ../../components/driver/deprecated/rtc_temperature_legacy.c
     ../../components/soc//${CONFIG_SOC_SERIES}/temperature_sensor_periph.c

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -262,6 +262,16 @@ if(CONFIG_SOC_SERIES_ESP32S3)
   endif()
 
   zephyr_sources_ifdef(
+    CONFIG_INPUT_ESP32_TOUCH_SENSOR
+    ../../components/soc/esp32s3/touch_sensor_periph.c
+    ../../components/driver/gpio/rtc_io.c
+    ../../components/driver/touch_sensor/touch_sensor_common.c
+    ../../components/hal/rtc_io_hal.c
+    ../../components/hal/touch_sensor_hal.c
+    ../../components/hal/esp32s3/touch_sensor_hal.c
+    )
+
+  zephyr_sources_ifdef(
     CONFIG_ESP32_TEMP
     ../../components/driver/deprecated/rtc_temperature_legacy.c
     ../../components/esp_hw_support/sar_periph_ctrl_common.c


### PR DESCRIPTION
The support for touch_sensor was lost when hal was updated to the v5.1.
This PR restores the touch_sensor support was restored for the following SoCs:
- ESP32
- ESP32-S2
- ESP32-S3
