### PR TITLE
bt: esp32s3: fix wrong kconfig entry

### DIFF
--- a/zephyr/esp32s3/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32s3/src/bt/esp_bt_adapter.c
@@ -114,7 +114,7 @@ struct bt_queue_t {
 };
 
 /* Select heap to be used for WiFi adapter */
-#if defined(CONFIG_ESP_BLUETOOTH_HEAP_RUNTIME)
+#if defined(CONFIG_ESP_BT_HEAP_RUNTIME)
 
 #define esp_bt_malloc_func(_size) esp_heap_runtime_malloc(_size)
 #define esp_bt_free_func(_mem) esp_heap_runtime_free(_mem)


### PR DESCRIPTION
Make sure CONFIG_ESP_BT_HEAP_RUNTIME is properly checked.