### PR TITLE
psram: add ISSI IS6xWVS2M8ALL psram size

### DIFF
--- a/components/esp_psram/esp_psram_impl.h
+++ b/components/esp_psram/esp_psram_impl.h
@@ -13,6 +13,7 @@
 extern "C" {
 #endif
 
+#define PSRAM_SIZE_1MB                  (1 * 1024 * 1024)
 #define PSRAM_SIZE_2MB                  (2 * 1024 * 1024)
 #define PSRAM_SIZE_4MB                  (4 * 1024 * 1024)
 #define PSRAM_SIZE_8MB                  (8 * 1024 * 1024)


### PR DESCRIPTION
The size table for this SPIRAM (IS6xWVS2M8ALL) is wrong. This PR adds the manufacturer identification and, based on that, chooses the right table size. For IS6xWVS2M8ALL, the size table starts at 8 Mib (1MB).