### PR TITLE
soc: esp32c2: Fix clock macros

### DIFF
--- a/components/soc/esp32c2/include/soc/soc.h
+++ b/components/soc/esp32c2/include/soc/soc.h
@@ -147,8 +147,7 @@
 #define  EFUSE_CLK_FREQ_ROM                          ( 20*1000000)
 #define  CPU_CLK_FREQ_MHZ_BTLD                       (80)           // The cpu clock frequency (in MHz) to set at 2nd stage bootloader system clock configuration
 #define  CPU_CLK_FREQ                                APB_CLK_FREQ
-#define  APB_CLK_FREQ                                ( 40*1000000 )
-#define  SCLK_CLK_FREQ                               ( 60*1000000 )
+#define  APB_CLK_FREQ                                ( CONFIG_XTAL_FREQ * 1000000 )
 #define  MODEM_REQUIRED_MIN_APB_CLK_FREQ             ( 80*1000000 )
 #define  REF_CLK_FREQ                                ( 1000000 )
 #define  UART_CLK_FREQ                               APB_CLK_FREQ


### PR DESCRIPTION
Fix clock macros for compatibility with new HAL update.