### PR TITLE
drivers: bluetooth: add stubs to allow CI testing without blobs

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -364,12 +364,6 @@ if(CONFIG_SOC_SERIES_ESP32)
       ../../components/esp_phy/src/phy_common.c
       )
 
-    zephyr_sources_ifdef(
-      CONFIG_BUILD_ONLY_NO_BLOBS
-      ../port/wifi/wifi_stubs.c
-      ../port/phy/phy_stubs.c
-      )
-
     zephyr_link_libraries_ifndef(
       CONFIG_BUILD_ONLY_NO_BLOBS
       net80211
@@ -380,16 +374,23 @@ if(CONFIG_SOC_SERIES_ESP32)
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
       gcc
         -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32
-    )
-
+      )
   endif()
 
   ## BT definitions
   if (CONFIG_BT)
+
     zephyr_sources(src/bt/esp_bt_adapter.c)
     zephyr_compile_definitions(CONFIG_BT_ENABLED)
 
-    zephyr_link_libraries(
+    zephyr_sources_ifdef(
+      CONFIG_BUILD_ONLY_NO_BLOBS
+      ../port/bluetooth/bt_stubs.c
+      ../port/phy/phy_stubs.c
+      )
+
+    zephyr_link_libraries_ifndef(
+      CONFIG_BUILD_ONLY_NO_BLOBS
       ## ble
       btdm_app
         -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32
@@ -399,6 +400,12 @@ if(CONFIG_SOC_SERIES_ESP32)
 
   ## WIFI definitions
   if (CONFIG_WIFI_ESP32)
+
+    zephyr_sources_ifdef(
+      CONFIG_BUILD_ONLY_NO_BLOBS
+      ../port/wifi/wifi_stubs.c
+      ../port/phy/phy_stubs.c
+      )
 
     set(WPA_SUPPLICANT_COMPONENT_DIR "../../components/wpa_supplicant")
     #TODO: Additional WPA supplicant feature like Enterprise mode etc. are yet to be supported.

--- a/zephyr/esp32/include/bt/esp_bt.h
+++ b/zephyr/esp32/include/bt/esp_bt.h
@@ -483,6 +483,8 @@ typedef struct esp_vhci_host_callback {
     int (*notify_host_recv)(uint8_t *data, uint16_t len);   /*!< Callback to notify the Host that the Controller has a packet to send */
 } esp_vhci_host_callback_t;
 
+typedef void (*workitem_handler_t)(void *arg);
+
 /**
  * @brief Check whether the Controller is ready to receive the packet
  *

--- a/zephyr/esp32/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32/src/bt/esp_bt_adapter.c
@@ -170,8 +170,6 @@ struct osi_funcs_t {
 	uint32_t _magic;
 };
 
-typedef void (*workitem_handler_t)(void *arg);
-
 /* OSI */
 extern int btdm_osi_funcs_register(void *osi_funcs);
 /* Initialise and De-initialise */

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -367,12 +367,6 @@ if(CONFIG_SOC_SERIES_ESP32C3)
       ../../components/efuse/src/efuse_controller/keys/with_key_purposes/esp_efuse_api_key.c
       )
 
-    zephyr_sources_ifdef(
-      CONFIG_BUILD_ONLY_NO_BLOBS
-      ../port/wifi/wifi_stubs.c
-      ../port/phy/phy_stubs.c
-      )
-
     zephyr_link_libraries_ifndef(
       CONFIG_BUILD_ONLY_NO_BLOBS
       net80211
@@ -388,10 +382,18 @@ if(CONFIG_SOC_SERIES_ESP32C3)
 
   ## BT definitions
   if (CONFIG_BT)
+
     zephyr_sources(src/bt/esp_bt_adapter.c)
     zephyr_compile_definitions(CONFIG_BT_ENABLED)
 
-    zephyr_link_libraries(
+    zephyr_sources_ifdef(
+      CONFIG_BUILD_ONLY_NO_BLOBS
+      ../port/bluetooth/bt_stubs.c
+      ../port/phy/phy_stubs.c
+      )
+
+    zephyr_link_libraries_ifndef(
+      CONFIG_BUILD_ONLY_NO_BLOBS
       ## ble
       btbb
       btdm_app
@@ -401,6 +403,12 @@ if(CONFIG_SOC_SERIES_ESP32C3)
 
   ## WIFI definitions
   if (CONFIG_WIFI_ESP32)
+
+    zephyr_sources_ifdef(
+      CONFIG_BUILD_ONLY_NO_BLOBS
+      ../port/wifi/wifi_stubs.c
+      ../port/phy/phy_stubs.c
+      )
 
     zephyr_sources(
       ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_rtc_calib.c

--- a/zephyr/esp32c3/include/bt/esp_bt.h
+++ b/zephyr/esp32c3/include/bt/esp_bt.h
@@ -85,12 +85,21 @@ enum {
     ESP_BT_COEX_PHY_CODED_TX_RX_TIME_LIMIT_FORCE_ENABLE,         /*!< Always Enable the limit */
 };
 
+/* vendor dependent signals to be posted to controller task */
+typedef enum {
+    BTDM_VND_OL_SIG_WAKEUP_TMR = 0,
+    BTDM_VND_OL_SIG_NUM,
+} btdm_vnd_ol_sig_t;
+
 #define ESP_BT_HCI_TL_STATUS_OK            (0)   /*!< HCI_TL Tx/Rx operation status OK */
 
 /**
  * @brief callback function for HCI Transport Layer send/receive operations
  */
 typedef void (* esp_bt_hci_tl_callback_t) (void *arg, uint8_t status);
+
+/* prototype of function to handle vendor dependent signals */
+typedef void (* btdm_vnd_ol_task_func_t)(void *param);
 
 #ifdef CONFIG_BT_ENABLED
 

--- a/zephyr/esp32c3/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32c3/src/bt/esp_bt_adapter.c
@@ -92,14 +92,6 @@ typedef union {
 
 #define BLE_PWR_HDL_INVL 0xFFFF
 
-typedef enum {
-	BTDM_VND_OL_SIG_WAKEUP_TMR = 0,
-	BTDM_VND_OL_SIG_NUM,
-} btdm_vnd_ol_sig_t;
-
-/* prototype of function to handle vendor dependent signals */
-typedef void (* btdm_vnd_ol_task_func_t)(void *param);
-
 typedef void (* irq_handler_t)(const void *param);
 
 /* VHCI function interface */
@@ -235,7 +227,7 @@ extern int btdm_hci_tl_io_event_post(int event);
 /* VHCI */
 extern bool API_vhci_host_check_send_available(void);
 extern void API_vhci_host_send_packet(uint8_t *data, uint16_t len);
-extern int API_vhci_host_register_callback(const vhci_host_callback_t *callback);
+extern int API_vhci_host_register_callback(const esp_vhci_host_callback_t *callback);
 /* TX power */
 extern int ble_txpwr_set(int power_type, int power_level);
 extern int ble_txpwr_get(int power_type);
@@ -1013,7 +1005,7 @@ esp_err_t esp_vhci_host_register_callback(const esp_vhci_host_callback_t *callba
 		return ESP_FAIL;
 	}
 
-	return API_vhci_host_register_callback((const vhci_host_callback_t *)callback) == 0 ? ESP_OK : ESP_FAIL;
+	return API_vhci_host_register_callback((const esp_vhci_host_callback_t *)callback) == 0 ? ESP_OK : ESP_FAIL;
 }
 
 

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -400,12 +400,6 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       ../../components/efuse/src/efuse_controller/keys/with_key_purposes/esp_efuse_api_key.c
       )
 
-    zephyr_sources_ifdef(
-      CONFIG_BUILD_ONLY_NO_BLOBS
-      ../port/wifi/wifi_stubs.c
-      ../port/phy/phy_stubs.c
-      )
-
     zephyr_link_libraries_ifndef(
       CONFIG_BUILD_ONLY_NO_BLOBS
       net80211
@@ -420,10 +414,18 @@ if(CONFIG_SOC_SERIES_ESP32S3)
 
   ## BT definitions
   if (CONFIG_BT)
+
     zephyr_sources(src/bt/esp_bt_adapter.c)
     zephyr_compile_definitions(CONFIG_BT_ENABLED)
 
-    zephyr_link_libraries(
+    zephyr_sources_ifdef(
+      CONFIG_BUILD_ONLY_NO_BLOBS
+      ../port/bluetooth/bt_stubs.c
+      ../port/phy/phy_stubs.c
+      )
+
+    zephyr_link_libraries_ifndef(
+      CONFIG_BUILD_ONLY_NO_BLOBS
       ## ble
       btbb
       btdm_app
@@ -433,6 +435,12 @@ if(CONFIG_SOC_SERIES_ESP32S3)
 
     ## WIFI definitions
   if (CONFIG_WIFI_ESP32)
+
+    zephyr_sources_ifdef(
+      CONFIG_BUILD_ONLY_NO_BLOBS
+      ../port/wifi/wifi_stubs.c
+      ../port/phy/phy_stubs.c
+      )
 
     set(WPA_SUPPLICANT_COMPONENT_DIR "../../components/wpa_supplicant")
     #TODO: Additional WPA supplicant feature like Enterprise mode etc. are yet to be supported.

--- a/zephyr/esp32s3/include/bt/esp_bt.h
+++ b/zephyr/esp32s3/include/bt/esp_bt.h
@@ -85,12 +85,21 @@ enum {
     ESP_BT_COEX_PHY_CODED_TX_RX_TIME_LIMIT_FORCE_ENABLE,         /*!< Always Enable the limit */
 };
 
+/* vendor dependent signals to be posted to controller task */
+typedef enum {
+    BTDM_VND_OL_SIG_WAKEUP_TMR = 0,
+    BTDM_VND_OL_SIG_NUM,
+} btdm_vnd_ol_sig_t;
+
 #define ESP_BT_HCI_TL_STATUS_OK            (0)   /*!< HCI_TL Tx/Rx operation status OK */
 
 /**
  * @brief callback function for HCI Transport Layer send/receive operations
  */
 typedef void (* esp_bt_hci_tl_callback_t) (void *arg, uint8_t status);
+
+/* prototype of function to handle vendor dependent signals */
+typedef void (* btdm_vnd_ol_task_func_t)(void *param);
 
 #ifdef CONFIG_BT_ENABLED
 

--- a/zephyr/esp32s3/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32s3/src/bt/esp_bt_adapter.c
@@ -92,14 +92,6 @@ typedef union {
 
 #define BLE_PWR_HDL_INVL 0xFFFF
 
-typedef enum {
-	BTDM_VND_OL_SIG_WAKEUP_TMR = 0,
-	BTDM_VND_OL_SIG_NUM,
-} btdm_vnd_ol_sig_t;
-
-/* prototype of function to handle vendor dependent signals */
-typedef void (* btdm_vnd_ol_task_func_t)(void *param);
-
 /* VHCI function interface */
 typedef struct vhci_host_callback {
 	/* callback used to notify that the host can send packet to controller */
@@ -235,7 +227,7 @@ extern int btdm_hci_tl_io_event_post(int event);
 /* VHCI */
 extern bool API_vhci_host_check_send_available(void);
 extern void API_vhci_host_send_packet(uint8_t *data, uint16_t len);
-extern int API_vhci_host_register_callback(const vhci_host_callback_t *callback);
+extern int API_vhci_host_register_callback(const esp_vhci_host_callback_t *callback);
 /* TX power */
 extern int ble_txpwr_set(int power_type, int power_level);
 extern int ble_txpwr_get(int power_type);
@@ -1007,7 +999,7 @@ esp_err_t esp_vhci_host_register_callback(const esp_vhci_host_callback_t *callba
 		return ESP_FAIL;
 	}
 
-	return API_vhci_host_register_callback((const vhci_host_callback_t *)callback) == 0 ? ESP_OK : ESP_FAIL;
+	return API_vhci_host_register_callback((const esp_vhci_host_callback_t *)callback) == 0 ? ESP_OK : ESP_FAIL;
 }
 
 

--- a/zephyr/port/bluetooth/bt_stubs.c
+++ b/zephyr/port/bluetooth/bt_stubs.c
@@ -1,0 +1,165 @@
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "esp_err.h"
+#include "esp_bt.h"
+
+int btdm_osi_funcs_register(void *osi_funcs)
+{
+	return ESP_OK;
+}
+
+int btdm_controller_init(uint32_t config_mask, esp_bt_controller_config_t *config_opts)
+{
+	return ESP_OK;
+}
+
+void btdm_controller_deinit(void)
+{
+	// No-op
+}
+
+int btdm_controller_enable(esp_bt_mode_t mode)
+{
+	return ESP_OK;
+}
+
+void btdm_controller_disable(void)
+{
+	// No-op
+}
+
+uint8_t btdm_controller_get_mode(void)
+{
+	return 0;
+}
+
+const char *btdm_controller_get_compile_version(void)
+{
+	return "dummy_version";
+}
+
+void btdm_rf_bb_init_phase2(void)
+{
+	// No-op
+}
+
+#ifdef CONFIG_SOC_SERIES_ESP32
+int btdm_dispatch_work_to_controller(workitem_handler_t callback, void *arg, bool blocking)
+{
+	return ESP_OK;
+}
+#endif
+
+void btdm_controller_enable_sleep(bool enable)
+{
+	// No-op
+}
+
+void btdm_controller_set_sleep_mode(uint8_t mode)
+{
+	// No-op
+}
+
+uint8_t btdm_controller_get_sleep_mode(void)
+{
+	return 0;
+}
+
+bool btdm_power_state_active(void)
+{
+	return true;
+}
+
+void btdm_wakeup_request(void)
+{
+	// No-op
+}
+
+void btdm_in_wakeup_requesting_set(bool in_wakeup_requesting)
+{
+	// No-op
+}
+
+#ifndef CONFIG_SOC_SERIES_ESP32
+
+int btdm_vnd_offload_task_register(btdm_vnd_ol_sig_t sig, btdm_vnd_ol_task_func_t func)
+{
+	return ESP_OK;
+}
+
+int btdm_vnd_offload_task_deregister(btdm_vnd_ol_sig_t sig)
+{
+	return ESP_OK;
+}
+
+int r_btdm_vnd_offload_post(btdm_vnd_ol_sig_t sig, void *param)
+{
+	return ESP_OK;
+}
+
+#endif /* CONFIG_SOC_SERIES_ESP32 */
+uint8_t btdm_sleep_clock_sync(void)
+{
+	return 0;
+}
+
+bool btdm_lpclk_select_src(uint32_t sel)
+{
+	return true;
+}
+
+bool btdm_lpclk_set_div(uint32_t div)
+{
+	return true;
+}
+
+int btdm_hci_tl_io_event_post(int event)
+{
+	return ESP_OK;
+}
+
+bool API_vhci_host_check_send_available(void)
+{
+	return true;
+}
+
+void API_vhci_host_send_packet(uint8_t *data, uint16_t len)
+{
+	// No-op
+}
+
+int API_vhci_host_register_callback(const esp_vhci_host_callback_t *callback)
+{
+	return ESP_OK;
+}
+
+void coex_pti_v2(void)
+{
+	// No-op
+}
+
+void sdk_config_set_bt_pll_track_enable(bool enable)
+{
+	// No-op
+}
+
+void sdk_config_set_uart_flow_ctrl_enable(bool enable)
+{
+	// No-op
+}
+
+void config_bt_funcs_reset(void)
+{
+	// No-op
+}
+
+void config_ble_funcs_reset(void)
+{
+	// No-op
+}
+
+void config_btdm_funcs_reset(void)
+{
+	// No-op
+}


### PR DESCRIPTION
Add all bluetooth stubs in order to allow building without blobs.