### PR TITLE
zephyr: AMP targets include

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -108,6 +108,8 @@ if(CONFIG_SOC_SERIES_ESP32)
     ../../components/wpa_supplicant/src/utils
     ../../components/esp_coex/include
     ../../components/mbedtls/port/include
+
+     ../port/include/boot
     )
 
   zephyr_link_libraries(
@@ -258,7 +260,6 @@ if(CONFIG_SOC_SERIES_ESP32)
 
     zephyr_include_directories(
       ../../components/esp_rom/${CONFIG_SOC_SERIES}
-      ../port/include/boot
       )
 
     zephyr_sources(

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -109,6 +109,8 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     ../../components/wpa_supplicant/src/utils
     ../../components/wpa_supplicant/src/eap_peer
     ../../components/mbedtls/port/include
+
+    ../port/include/boot
     )
 
   zephyr_link_libraries(
@@ -290,7 +292,6 @@ if(CONFIG_SOC_SERIES_ESP32S3)
   if (CONFIG_MCUBOOT OR NOT CONFIG_BOOTLOADER_MCUBOOT)
     zephyr_include_directories(
       ../../components/esp_rom/${CONFIG_SOC_SERIES}
-      ../port/include/boot
       )
 
     zephyr_sources(


### PR DESCRIPTION
Add include path to expose bootloader headers for AMP SoCs.