### PR TITLE
esp32: fix naming of BT modem sleep orig config

### DIFF
--- a/zephyr/esp32/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32/src/bt/esp_bt_adapter.c
@@ -389,10 +389,10 @@ static DRAM_ATTR uint32_t btdm_lpcycle_us = 0;
 /* number of fractional bit for btdm_lpcycle_us */
 static DRAM_ATTR uint8_t btdm_lpcycle_us_frac = 0;
 
-#if CONFIG_BTDM_MODEM_SLEEP_MODE_ORIG
+#if CONFIG_BTDM_CTRL_MODEM_SLEEP_MODE_ORIG
 // used low power clock
 static DRAM_ATTR uint8_t btdm_lpclk_sel;
-#endif /* #ifdef CONFIG_BTDM_MODEM_SLEEP_MODE_ORIG */
+#endif /* #ifdef CONFIG_BTDM_CTRL_MODEM_SLEEP_MODE_ORIG */
 
 static DRAM_ATTR struct k_sem *s_wakeup_req_sem = NULL;
 
@@ -1098,7 +1098,7 @@ esp_err_t esp_bt_controller_init(esp_bt_controller_config_t *cfg)
 	btdm_lpcycle_us_frac = RTC_CLK_CAL_FRACT;
 	btdm_lpcycle_us = 2 << (btdm_lpcycle_us_frac);
 
-#if CONFIG_BTDM_MODEM_SLEEP_MODE_ORIG
+#if CONFIG_BTDM_CTRL_MODEM_SLEEP_MODE_ORIG
 
 	btdm_lpclk_sel = BTDM_LPCLK_SEL_XTAL; // set default value
 #if CONFIG_BTDM_LPCLK_SEL_EXT_32K_XTAL


### PR DESCRIPTION
It seems like the naming of the config for BTDM modem sleep orig mode has changed name in esp-idf. In the latest doc (5.2.3) it is referred to as `CONFIG_BTDM_CTRL_MODEM_SLEEP_MODE_ORIG`, https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/kconfig.html#config-btdm-ctrl-modem-sleep-mode. I can find references to `CONFIG_BTDM_MODEM_SLEEP_MODE_ORIG` in 3.1, https://docs.espressif.com/projects/esp-idf/en/release-v3.1/api-reference/kconfig.html.

Furthermore, this has (now) an actual effect on modem mode. In a simple BLE sample where we advertise, the power consumption is reduced by over 50 % (from 70 to sub 30 mA on 3V).

