### PR TITLE
mcuboot: assert: solve assert conflit

### DIFF
--- a/zephyr/port/boot/esp_image_loader.c
+++ b/zephyr/port/boot/esp_image_loader.c
@@ -187,9 +187,3 @@ void start_cpu1_image(int image_index, int slot, unsigned int hdr_offset)
     appcpu_start(entry_addr);
 }
 #endif
-
-void mcuboot_assert_handler(const char *file, int line, const char *func)
-{
-    ets_printf("ASSERTION FAIL @ %s:%d in function %s\n", file, line, func);
-    abort();
-}

--- a/zephyr/port/include/boot/mcuboot_config/mcuboot_assert.h
+++ b/zephyr/port/include/boot/mcuboot_config/mcuboot_assert.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-extern void mcuboot_assert_handler(const char *file, int line, const char *func);
+#include <stdlib.h>
 
 #ifdef assert
 #undef assert
@@ -14,6 +14,7 @@ extern void mcuboot_assert_handler(const char *file, int line, const char *func)
 #define assert(arg)                                                 \
     do {                                                            \
         if (!(arg)) {                                               \
-            mcuboot_assert_handler(__FILE__, __LINE__, __func__);   \
+            ets_printf("ASSERTION FAIL @ %s:%d in function %s\n", __FILE__, __LINE__, __func__); \
+            abort();                                                \
         }                                                           \
     } while(0)


### PR DESCRIPTION
When MCUBoot is used with ASSERT, build fails
due to missing mcuboot_assert_handler() call.

Current implementation conflicts with the way esp_image_loader.c is used. esp_image_loader.c should not handle mcuboot assertion as it is used for other means.