### PR TITLE
zephyr: port: add missing bootloader_wdt_feed

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -276,6 +276,7 @@ if(CONFIG_SOC_SERIES_ESP32)
     zephyr_sources_ifdef(
       CONFIG_MCUBOOT
       ../port/boot/esp_image_loader.c
+      ../port/boot/bootloader_wdt.c
       )
   endif()
 

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -183,6 +183,7 @@ if(CONFIG_SOC_SERIES_ESP32C2)
   if (CONFIG_MCUBOOT)
     zephyr_sources(
         ../port/boot/esp_image_loader.c
+        ../port/boot/bootloader_wdt.c
         )
   endif()
 

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -274,6 +274,7 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     zephyr_sources_ifdef(
       CONFIG_MCUBOOT
       ../port/boot/esp_image_loader.c
+      ../port/boot/bootloader_wdt.c
       )
   endif()
 

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -197,6 +197,7 @@ if(CONFIG_SOC_SERIES_ESP32C6)
 
     zephyr_sources(
         ../port/boot/esp_image_loader.c
+        ../port/boot/bootloader_wdt.c
         )
   endif()
 

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -279,6 +279,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     zephyr_sources_ifdef(
       CONFIG_MCUBOOT
       ../port/boot/esp_image_loader.c
+      ../port/boot/bootloader_wdt.c
       )
   endif()
 

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -310,6 +310,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     zephyr_sources_ifdef(
       CONFIG_MCUBOOT
       ../port/boot/esp_image_loader.c
+      ../port/boot/bootloader_wdt.c
       )
   endif()
 

--- a/zephyr/port/boot/bootloader_wdt.c
+++ b/zephyr/port/boot/bootloader_wdt.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Arif Balik <arifbalik@outlook.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <bootloader_wdt.h>
+#include <hal/wdt_hal.h>
+#include "soc/rtc.h"
+
+void bootloader_wdt_feed(void)
+{
+	wdt_hal_context_t rtc_wdt_ctx = RWDT_HAL_CONTEXT_DEFAULT();
+	wdt_hal_write_protect_disable(&rtc_wdt_ctx);
+	wdt_hal_feed(&rtc_wdt_ctx);
+	wdt_hal_write_protect_enable(&rtc_wdt_ctx);
+}


### PR DESCRIPTION
mcuboot requires this function and it is present in the espressif port of the mcuboot bootloader. Also we already have the header file https://github.com/zephyrproject-rtos/hal_espressif/blob/zephyr/zephyr/port/include/boot/bootloader_wdt.h

https://github.com/mcu-tools/mcuboot/blob/main/boot/espressif/hal/src/bootloader_wdt.c