### PR TITLE
cmakelists: update Kconfig entry for no blobs build

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -369,13 +369,13 @@ if(CONFIG_SOC_SERIES_ESP32)
       )
 
     zephyr_sources_ifdef(
-      CONFIG_WIFI_BUILD_ONLY_MODE
+      CONFIG_BUILD_ONLY_NO_BLOBS
       ../port/wifi/wifi_stubs.c
       ../port/phy/phy_stubs.c
       )
 
     zephyr_link_libraries_ifndef(
-      CONFIG_WIFI_BUILD_ONLY_MODE
+      CONFIG_BUILD_ONLY_NO_BLOBS
       net80211
       core
       pp

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -318,13 +318,13 @@ if(CONFIG_SOC_SERIES_ESP32C2)
       )
 
     zephyr_sources_ifdef(
-      CONFIG_WIFI_BUILD_ONLY_MODE
+      CONFIG_BUILD_ONLY_NO_BLOBS
       ../port/wifi/wifi_stubs.c
       ../port/phy/phy_stubs.c
       )
 
     zephyr_link_libraries_ifndef(
-      CONFIG_WIFI_BUILD_ONLY_MODE
+      CONFIG_BUILD_ONLY_NO_BLOBS
       net80211
       core
       pp

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -367,13 +367,13 @@ if(CONFIG_SOC_SERIES_ESP32C3)
       )
 
     zephyr_sources_ifdef(
-      CONFIG_WIFI_BUILD_ONLY_MODE
+      CONFIG_BUILD_ONLY_NO_BLOBS
       ../port/wifi/wifi_stubs.c
       ../port/phy/phy_stubs.c
       )
 
     zephyr_link_libraries_ifndef(
-      CONFIG_WIFI_BUILD_ONLY_MODE
+      CONFIG_BUILD_ONLY_NO_BLOBS
       net80211
       core
       pp

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -321,13 +321,13 @@ if(CONFIG_SOC_SERIES_ESP32C6)
       )
 
     zephyr_sources_ifdef(
-      CONFIG_WIFI_BUILD_ONLY_MODE
+      CONFIG_BUILD_ONLY_NO_BLOBS
       ../port/wifi/wifi_stubs.c
       ../port/phy/phy_stubs.c
       )
 
     zephyr_link_libraries_ifndef(
-      CONFIG_WIFI_BUILD_ONLY_MODE
+      CONFIG_BUILD_ONLY_NO_BLOBS
       net80211
       core
       pp

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -576,13 +576,13 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     zephyr_link_libraries(mbedTLS)
 
     zephyr_sources_ifdef(
-      CONFIG_WIFI_BUILD_ONLY_MODE
+      CONFIG_BUILD_ONLY_NO_BLOBS
       ../port/wifi/wifi_stubs.c
       ../port/phy/phy_stubs.c
       )
 
     zephyr_link_libraries_ifndef(
-      CONFIG_WIFI_BUILD_ONLY_MODE
+      CONFIG_BUILD_ONLY_NO_BLOBS
       net80211
       core
       pp

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -406,13 +406,13 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       )
 
     zephyr_sources_ifdef(
-      CONFIG_WIFI_BUILD_ONLY_MODE
+      CONFIG_BUILD_ONLY_NO_BLOBS
       ../port/wifi/wifi_stubs.c
       ../port/phy/phy_stubs.c
       )
 
     zephyr_link_libraries_ifndef(
-      CONFIG_WIFI_BUILD_ONLY_MODE
+      CONFIG_BUILD_ONLY_NO_BLOBS
       net80211
       core
       pp


### PR DESCRIPTION
Unify Kconfig name so both Wi-Fi and BLE share the same configuration parameter.