### PR TITLE
Add file needed when moving code and data from FLASH to PSRAM

### DIFF
--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -167,6 +167,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     zephyr_compile_definitions(CONFIG_SPIRAM)
     zephyr_sources(
       ../../components/esp_psram/esp_psram.c
+      ../../components/esp_psram/mmu_psram_flash.c
       ../../components/esp_hw_support/esp_memory_utils.c
       ../../components/esp_psram/${CONFIG_SOC_SERIES}/esp_psram_impl_quad.c
       ../../components/esp_hw_support/esp_gpio_reserve.c

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -234,6 +234,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     zephyr_compile_definitions(CONFIG_SPIRAM)
     zephyr_sources(
       ../../components/esp_psram/esp_psram.c
+      ../../components/esp_psram/mmu_psram_flash.c
       ../../components/esp_hw_support/esp_memory_utils.c
       ../../components/esp_hw_support/esp_gpio_reserve.c
       )


### PR DESCRIPTION
This PR adds the mmu_psram_flash.c to CMakeLists.txt for ESP32-S2 and ESP32-S3 needed when CONFIG_SPIRAM_FETCH_INSTRUCTIONS and CONFIG_SPIRAM_RODATA are enabled.