### PR TITLE
pinctrl: esp32c6: Add i2c config to pinctrl generation yml

### DIFF
--- a/zephyr/port/pincfgs/esp32c6.yml
+++ b/zephyr/port/pincfgs/esp32c6.yml
@@ -141,3 +141,13 @@ mcpwm0:
   cap2:
     sigi: pwm0_cap2_in
     gpio: [[0, 23]]
+
+i2c0:
+  sda:
+    sigi: i2cext0_sda_in
+    sigo: i2cext0_sda_out
+    gpio: [[0, 23]]
+  scl:
+    sigi: i2cext0_scl_in
+    sigo: i2cext0_scl_out
+    gpio: [[0, 23]]


### PR DESCRIPTION
Add i2c config to pinctrl generation yml to avoid regression (i2c already integrated).