### PR TITLE
west: tools.py: fix espressif monitor command for sysbuild

### DIFF
--- a/west/tools.py
+++ b/west/tools.py
@@ -65,27 +65,6 @@ def get_esp_serial_port(module_path):
         return None
 
 
-def get_build_dir(path, die_if_none=True):
-    # Get the build directory for the given argument list and environment.
-
-    guess = config.get('build', 'guess-dir', fallback='never')
-    guess = guess == 'runners'
-    dir = find_build_dir(path, guess)
-
-    if dir and is_zephyr_build(dir):
-        return dir
-    elif die_if_none:
-        msg = 'could not find build directory and '
-        if dir:
-            msg = msg + 'neither {} nor {} are zephyr build directories.'
-        else:
-            msg = msg + ('{} is not a build directory and the default build '
-                         'directory cannot be determined. ')
-        log.die(msg.format(os.getcwd(), dir))
-    else:
-        return None
-
-
 def parse_runners_yaml():
     def runners_yaml_path(build_dir):
         ret = Path(build_dir) / 'zephyr' / 'runners.yaml'
@@ -111,13 +90,12 @@ def parse_runners_yaml():
     global build_elf_path
     global baud_rate
 
-    build_dir = get_build_dir(None)
+    build_dir = find_build_dir(None, True)
     domain = load_domains(build_dir).get_default_domain()
 
     # build dir differs when sysbuild is used
-    if domain.name != 'app':
-        build_dir = Path(build_dir) / domain.name
-        build_dir = get_build_dir(build_dir)
+    if domain.build_dir:
+        build_dir = domain.build_dir
 
     yaml_path = runners_yaml_path(build_dir)
     runners_yaml = load_runners_yaml(yaml_path)


### PR DESCRIPTION
Runing `west espressif monitor` failed when the app was built with `--sysbuild`.

Using `domain.build_dir` to get path for app built with sysbuild now.

Function `get_build_dir` (copied from zephyr repo) is removed because it is not needed here.