### PR TITLE
github: add codeowners to improve review cycle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This file assigns all users below as reviewers
+* @LucasTambor @marekmatej @raffarost @sylvioalves @wmrsouza


### PR DESCRIPTION
Add team as codeowners.