### PR TITLE
adc: update code to remove VLA from source

### DIFF
--- a/components/esp_adc/esp32/adc_cali_line_fitting.c
+++ b/components/esp_adc/esp32/adc_cali_line_fitting.c
@@ -207,7 +207,7 @@ esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config
 
 err:
     if (scheme) {
-        free(scheme);
+        heap_caps_free(scheme);
     }
     return ret;
 }
@@ -231,10 +231,10 @@ esp_err_t adc_cali_delete_scheme_line_fitting(adc_cali_handle_t handle)
 {
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid argument: null pointer");
 
-    free(handle->ctx);
+    heap_caps_free(handle->ctx);
     handle->ctx = NULL;
 
-    free(handle);
+    heap_caps_free(handle);
     handle = NULL;
 
     return ESP_OK;

--- a/components/esp_adc/esp32c2/adc_cali_line_fitting.c
+++ b/components/esp_adc/esp32c2/adc_cali_line_fitting.c
@@ -89,7 +89,7 @@ esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config
 
 err:
     if (scheme) {
-        free(scheme);
+        heap_caps_free(scheme);
     }
     return ret;
 }
@@ -98,10 +98,10 @@ esp_err_t adc_cali_delete_scheme_line_fitting(adc_cali_handle_t handle)
 {
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid argument: null pointer");
 
-    free(handle->ctx);
+    heap_caps_free(handle->ctx);
     handle->ctx = NULL;
 
-    free(handle);
+    heap_caps_free(handle);
     handle = NULL;
 
     return ESP_OK;

--- a/components/esp_adc/esp32s2/adc_cali_line_fitting.c
+++ b/components/esp_adc/esp32s2/adc_cali_line_fitting.c
@@ -124,7 +124,7 @@ esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config
 
 err:
     if (scheme) {
-        free(scheme);
+        heap_caps_free(scheme);
     }
     return ret;
 }
@@ -133,10 +133,10 @@ esp_err_t adc_cali_delete_scheme_line_fitting(adc_cali_handle_t handle)
 {
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid argument: null pointer");
 
-    free(handle->ctx);
+    heap_caps_free(handle->ctx);
     handle->ctx = NULL;
 
-    free(handle);
+    heap_caps_free(handle);
     handle = NULL;
 
     return ESP_OK;


### PR DESCRIPTION
Update hal_espressif to fix ADC source code with VLA, which is not C90 standard. To keep it up with Zephyr as is, update the necessary code and optimize the it.