### PR TITLE
flash: use esp_rom_flash prefix instead bootloader

### DIFF
--- a/components/bootloader_support/bootloader_flash/include/bootloader_flash_priv.h
+++ b/components/bootloader_support/bootloader_flash/include/bootloader_flash_priv.h
@@ -90,7 +90,7 @@ uint32_t bootloader_mmap_get_free_pages(void);
 const void *bootloader_mmap(uint32_t src_addr, uint32_t size);
 
 /* use ROM functions to mmap */
-const void *bootloader_mmap_rom(uint32_t src_addr, uint32_t size);
+const void *esp_rom_flash_mmap(uint32_t src_addr, uint32_t size);
 
 /**
  * @brief Unmap a previously mapped region of flash
@@ -100,7 +100,7 @@ const void *bootloader_mmap_rom(uint32_t src_addr, uint32_t size);
 void bootloader_munmap(const void *mapping);
 
 /* use ROM functions to unmmap */
-void bootloader_munmap_rom(const void *mapping);
+void esp_rom_flash_mmap(const void *mapping);
 
 /**
  * @brief  Read data from Flash.
@@ -120,7 +120,7 @@ void bootloader_munmap_rom(const void *mapping);
 esp_err_t bootloader_flash_read(size_t src_addr, void *dest, size_t size, bool allow_decrypt);
 
 /* use ROM functions to flash read */
-esp_err_t bootloader_flash_read_rom(size_t src_addr, void *dest, size_t size, bool allow_decrypt);
+esp_err_t esp_rom_flash_read(size_t src_addr, void *dest, size_t size, bool allow_decrypt);
 
 /**
  * @brief  Write data to Flash.
@@ -140,7 +140,7 @@ esp_err_t bootloader_flash_read_rom(size_t src_addr, void *dest, size_t size, bo
 esp_err_t bootloader_flash_write(size_t dest_addr, void *src, size_t size, bool write_encrypted);
 
 /* use ROM functions to flash write */
-esp_err_t bootloader_flash_write_rom(size_t dest_addr, void *src, size_t size, bool write_encrypted);
+esp_err_t esp_rom_flash_write(size_t dest_addr, void *src, size_t size, bool write_encrypted);
 
 /**
  * @brief  Erase the Flash sector.
@@ -152,7 +152,7 @@ esp_err_t bootloader_flash_write_rom(size_t dest_addr, void *src, size_t size, b
 esp_err_t bootloader_flash_erase_sector(size_t sector);
 
 /* use ROM functions to flash erase */
-esp_err_t bootloader_flash_erase_sector_rom(size_t sector);
+esp_err_t esp_rom_flash_erase_sector(size_t sector);
 
 /**
  * @brief  Erase the Flash range.
@@ -165,7 +165,7 @@ esp_err_t bootloader_flash_erase_sector_rom(size_t sector);
 esp_err_t bootloader_flash_erase_range(uint32_t start_addr, uint32_t size);
 
 /* use ROM functions to flash range read */
-esp_err_t bootloader_flash_erase_range_rom(uint32_t start_addr, uint32_t size);
+esp_err_t esp_rom_flash_erase_range(uint32_t start_addr, uint32_t size);
 
 /**
  * @brief Execute a user command on the flash

--- a/zephyr/common/soc_init.c
+++ b/zephyr/common/soc_init.c
@@ -46,7 +46,7 @@ void print_banner(void)
 int read_bootloader_header(void)
 {
 	/* load bootloader image header */
-	if (bootloader_flash_read_rom(FIXED_PARTITION_OFFSET(boot_partition), &bootloader_image_hdr,
+	if (esp_rom_flash_read(FIXED_PARTITION_OFFSET(boot_partition), &bootloader_image_hdr,
 				      sizeof(esp_image_header_t), true) != 0) {
 		ESP_EARLY_LOGE(TAG, "failed to load bootloader image header!");
 		return -EIO;

--- a/zephyr/port/boot/esp_image_loader.c
+++ b/zephyr/port/boot/esp_image_loader.c
@@ -62,13 +62,13 @@
 static int load_segment(const struct flash_area *fap, uint32_t data_addr,
                         uint32_t data_len, uint32_t load_addr)
 {
-    const uint32_t *data = (const uint32_t *)bootloader_mmap_rom((fap->fa_off + data_addr), data_len);
+    const uint32_t *data = (const uint32_t *)esp_rom_flash_mmap((fap->fa_off + data_addr), data_len);
     if (!data) {
         BOOT_LOG_ERR("%s: Bootloader mmap failed", __func__);
         return -1;
     }
     memcpy((void *)load_addr, data, data_len);
-    bootloader_munmap_rom(data);
+    esp_rom_flash_mmap(data);
     return 0;
 }
 
@@ -88,11 +88,11 @@ void esp_app_image_load(int image_index, int slot,
     BOOT_LOG_INF("Loading image %d - slot %d from flash, area id: %d",
     image_index, slot, area_id);
 
-    const uint32_t *data = (const uint32_t *)bootloader_mmap_rom((fap->fa_off + hdr_offset),
+    const uint32_t *data = (const uint32_t *)esp_rom_flash_mmap((fap->fa_off + hdr_offset),
                                                              sizeof(esp_image_load_header_t));
     esp_image_load_header_t load_header = {0};
     memcpy((void *)&load_header, data, sizeof(esp_image_load_header_t));
-    bootloader_munmap_rom(data);
+    esp_rom_flash_mmap(data);
 
     if (load_header.header_magic != ESP_LOAD_HEADER_MAGIC) {
         BOOT_LOG_ERR("Load header magic verification failed. Aborting");

--- a/zephyr/port/bootloader/bootloader_flash.c
+++ b/zephyr/port/bootloader/bootloader_flash.c
@@ -151,7 +151,7 @@ static bool mapped;
 // Current bootloader mapping (ab)used for bootloader_read()
 static uint32_t current_read_mapping = UINT32_MAX;
 
-uint32_t bootloader_mmap_get_free_pages_rom(void)
+uint32_t esp_rom_flash_mmap_get_free_pages(void)
 {
     /**
      * Allow mapping up to 50 of the 51 available MMU blocks (last one used for reads)
@@ -160,7 +160,7 @@ uint32_t bootloader_mmap_get_free_pages_rom(void)
     return MMU_FREE_PAGES;
 }
 
-const void *bootloader_mmap_rom(uint32_t src_paddr, uint32_t size)
+const void *esp_rom_flash_mmap(uint32_t src_paddr, uint32_t size)
 {
     if (mapped) {
         ESP_EARLY_LOGE(TAG, "tried to bootloader_mmap twice");
@@ -231,7 +231,7 @@ const void *bootloader_mmap_rom(uint32_t src_paddr, uint32_t size)
     return (void *)(MMU_BLOCK0_VADDR + (src_paddr - src_paddr_aligned));
 }
 
-void bootloader_munmap_rom(const void *mapping)
+void esp_rom_flash_mmap(const void *mapping)
 {
     if (mapped)  {
 #if CONFIG_IDF_TARGET_ESP32
@@ -331,7 +331,7 @@ static esp_err_t bootloader_flash_read_allow_decrypt(size_t src_addr, void *dest
     return ESP_OK;
 }
 
-esp_err_t bootloader_flash_read_rom(size_t src_addr, void *dest, size_t size, bool allow_decrypt)
+esp_err_t esp_rom_flash_read(size_t src_addr, void *dest, size_t size, bool allow_decrypt)
 {
     if (src_addr & 3) {
         ESP_EARLY_LOGE(TAG, "bootloader_flash_read src_addr 0x%x not 4-byte aligned", src_addr);
@@ -353,7 +353,7 @@ esp_err_t bootloader_flash_read_rom(size_t src_addr, void *dest, size_t size, bo
     }
 }
 
-esp_err_t bootloader_flash_write_rom(size_t dest_addr, void *src, size_t size, bool write_encrypted)
+esp_err_t esp_rom_flash_write(size_t dest_addr, void *src, size_t size, bool write_encrypted)
 {
     esp_err_t err;
     size_t alignment = write_encrypted ? 32 : 4;
@@ -382,12 +382,12 @@ esp_err_t bootloader_flash_write_rom(size_t dest_addr, void *src, size_t size, b
     }
 }
 
-esp_err_t bootloader_flash_erase_sector_rom(size_t sector)
+esp_err_t esp_rom_flash_erase_sector(size_t sector)
 {
     return spi_to_esp_err(esp_rom_spiflash_erase_sector(sector));
 }
 
-esp_err_t bootloader_flash_erase_range_rom(uint32_t start_addr, uint32_t size)
+esp_err_t esp_rom_flash_erase_range(uint32_t start_addr, uint32_t size)
 {
     if (start_addr % FLASH_SECTOR_SIZE != 0) {
         return ESP_ERR_INVALID_ARG;


### PR DESCRIPTION
Changes bootloader calls related to flash access
to reflect its real usage.