### PR TITLE
esp32s3: psram:  add sources to suport code relocation

### DIFF
--- a/components/esp_psram/mmu_psram_flash.c
+++ b/components/esp_psram/mmu_psram_flash.c
@@ -172,7 +172,8 @@ void instruction_flash_page_info_init(uint32_t psram_start_physical_page)
     instr_end_page = instr_start_page + instr_page_cnt - 1;
     instr_flash2spiram_offs = instr_start_page - psram_start_physical_page;
     instruction_in_spiram = 1;
-    ESP_DRAM_LOGV("mmu_psram", "Instructions from flash page%d copy to SPIRAM page%d, Offset: %d", instr_start_page, psram_start_physical_page, instr_flash2spiram_offs);
+    ESP_DRAM_LOGV("mmu_psram", "Instructions in flash pages %d..%d copy to SPIRAM page %d, Offset: %d",
+		    instr_start_page, instr_end_page, psram_start_physical_page, instr_flash2spiram_offs);
 }
 
 uint32_t esp_spiram_instruction_access_enabled(void)

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -241,6 +241,9 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       ../../components/esp_psram/${CONFIG_SOC_SERIES}/esp_psram_impl_octal.c
       )
 
+    zephyr_sources_ifdef(CONFIG_SPIRAM_FETCH_INSTRUCTIONS
+      ../../components/esp_psram/mmu_psram_flash.c
+      )
   endif()
 
   zephyr_sources_ifdef(

--- a/zephyr/port/include/esp_heap_adapter.h
+++ b/zephyr/port/include/esp_heap_adapter.h
@@ -20,6 +20,41 @@
 #define os_wpa_calloc_func(_nmemb, _size) k_calloc(_nmemb, _size)
 #define os_wpa_free_func(_mem)            k_free(_mem)
 
+#elif defined(CONFIG_ESP_WIFI_WIFI_SPIRAM)
+
+#define esp_wifi_malloc_func(_size)                                                               \
+		shared_multi_heap_aligned_alloc(SMH_REG_ATTR_EXTERNAL, 16, _size)
+#define esp_wifi_calloc_func(_nmemb, _size)                                                       \
+	{                                                                                         \
+		void *p;                                                                          \
+		p = shared_multi_heap_aligned_alloc(SMH_REG_ATTR_EXTERNAL, 16, _nmemb * _size);   \
+		if (p) {                                                                          \
+			memset(p, 0, _nmemb * _size);                                             \
+		}                                                                                 \
+		return p;                                                                         \
+	}
+#define esp_wifi_free_func(_mem) shared_multi_heap_free(_mem)
+
+#define os_wpa_malloc_func(_size) shared_multi_heap_aligned_alloc(SMH_REG_ATTR_EXTERNAL, 16, _size)
+#define os_wpa_realloc_func(_ptr, _size)                                                          \
+	{	void *p;                                                                          \
+		if (_ptr) {                                                                       \
+			shared_multi_heap_free(_ptr);                                             \
+		}                                                                                 \
+		p = shared_multi_heap_aligned_alloc(SMH_REG_ATTR_EXTERNAL, 16, _size);            \
+		return p;                                                                         \
+	}
+#define os_wpa_calloc_func(_nmemb, _size)                                                         \
+	{                                                                                         \
+		void *p;                                                                          \
+		p = shared_multi_heap_aligned_alloc(SMH_REG_ATTR_EXTERNAL, 16, _nmemb * _size);   \
+		if (p) {                                                                          \
+			memset(p, 0, _nmemb * _size);                                             \
+		}                                                                                 \
+		return p;                                                                         \
+	}
+#define os_wpa_free_func(_mem) shared_multi_heap_free(_mem)
+
 #else
 
 #define esp_wifi_malloc_func(_size)         malloc(_size)


### PR DESCRIPTION
Allow to use PSRAM code relocation on ESP32-S3.