### PR TITLE
esp_restart: add proper shutdown handlers

### DIFF
--- a/zephyr/common/esp_restart.c
+++ b/zephyr/common/esp_restart.c
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include "esp_system.h"
+#include "esp_private/system_internal.h"
+#include <stdint.h>
+#include "esp_cpu.h"
+#include "soc/soc.h"
+#include "soc/soc_caps.h"
+#include "esp_private/rtc_clk.h"
+#include "esp_private/panic_internal.h"
+#include "esp_private/system_internal.h"
+#include "esp_private/spi_flash_os.h"
+#include "esp_rom_uart.h"
+#include "esp_rom_sys.h"
+#include "sdkconfig.h"
+
+#if CONFIG_ESP_SYSTEM_MEMPROT_FEATURE
+#if CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/memprot.h"
+#else
+#include "esp_memprot.h"
+#endif
+#endif
+
+#define SHUTDOWN_HANDLERS_NO 5
+
+static shutdown_handler_t shutdown_handlers[SHUTDOWN_HANDLERS_NO];
+
+esp_err_t esp_register_shutdown_handler(shutdown_handler_t handler)
+{
+	for (int i = 0; i < SHUTDOWN_HANDLERS_NO; i++) {
+		if (shutdown_handlers[i] == handler) {
+			return ESP_ERR_INVALID_STATE;
+		} else if (shutdown_handlers[i] == NULL) {
+			shutdown_handlers[i] = handler;
+			return ESP_OK;
+		}
+	}
+	return ESP_ERR_NO_MEM;
+}
+
+esp_err_t esp_unregister_shutdown_handler(shutdown_handler_t handler)
+{
+	for (int i = 0; i < SHUTDOWN_HANDLERS_NO; i++) {
+		if (shutdown_handlers[i] == handler) {
+			shutdown_handlers[i] = NULL;
+			return ESP_OK;
+		}
+	}
+	return ESP_ERR_INVALID_STATE;
+}
+
+void IRAM_ATTR esp_restart_noos_dig(void)
+{
+	/* In case any of the calls below results in re-enabling of interrupts
+	 * (for example, by entering a critical section), disable all the
+	 * interrupts (e.g. from watchdogs) here.
+	 */
+#ifdef CONFIG_IDF_TARGET_ARCH_RISCV
+	rv_utils_intr_global_disable();
+#else
+	xt_ints_off(0xFFFFFFFF);
+#endif
+
+	/* make sure all the panic handler output is sent from UART FIFO */
+	if (CONFIG_ESP_CONSOLE_UART_NUM >= 0) {
+		esp_rom_uart_tx_wait_idle(CONFIG_ESP_CONSOLE_UART_NUM);
+	}
+
+#if SOC_MEMSPI_CLOCK_IS_INDEPENDENT
+	spi_flash_set_clock_src(MSPI_CLK_SRC_ROM_DEFAULT);
+#endif
+
+	/* switch to XTAL (otherwise we will keep running from the PLL) */
+	rtc_clk_cpu_set_to_default_config();
+
+	/* esp_restart_noos_dig() will generates a core reset, which does not reset the
+	 * registers of the RTC domain, so the CPU's stall state remains after the reset,
+	 * we need to release them here
+	 */
+#if !CONFIG_FREERTOS_UNICORE
+	int core_id = esp_cpu_get_core_id();
+	for (uint32_t i = 0; i < SOC_CPU_CORES_NUM; i++) {
+		if (i != core_id) {
+			esp_cpu_unstall(i);
+		}
+	}
+#endif
+	esp_rom_software_reset_system();
+	while (true) {
+		;
+	}
+}
+
+void esp_restart(void)
+{
+	for (int i = SHUTDOWN_HANDLERS_NO - 1; i >= 0; i--) {
+		if (shutdown_handlers[i]) {
+			shutdown_handlers[i]();
+		}
+	}
+
+	k_sched_lock();
+
+	bool digital_reset_needed = false;
+#if CONFIG_ESP_SYSTEM_MEMPROT_FEATURE
+#if CONFIG_IDF_TARGET_ESP32S2
+	if (esp_memprot_is_intr_ena_any() || esp_memprot_is_locked_any()) {
+		digital_reset_needed = true;
+	}
+#else
+	bool is_on = false;
+	if (esp_mprot_is_intr_ena_any(&is_on) != ESP_OK || is_on) {
+		digital_reset_needed = true;
+	} else if (esp_mprot_is_conf_locked_any(&is_on) != ESP_OK || is_on) {
+		digital_reset_needed = true;
+	}
+#endif
+#endif
+	if (digital_reset_needed) {
+		esp_restart_noos_dig();
+	}
+	esp_restart_noos();
+}

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -347,6 +347,7 @@ if(CONFIG_SOC_SERIES_ESP32)
     ../port/bootloader/bootloader_flash.c
 
     ../common/flash_init.c
+    ../common/esp_restart.c
 
     src/stubs.c
     src/soc_random.c

--- a/zephyr/esp32/src/bt/esp_bt_adapter.c
+++ b/zephyr/esp32/src/bt/esp_bt_adapter.c
@@ -31,7 +31,7 @@
 #include "private/esp_coexist_internal.h"
 #include "esp_timer.h"
 #include "esp_heap_adapter.h"
-
+#include "esp_system.h"
 #include "esp_rom_sys.h"
 
 #include <zephyr/logging/log.h>
@@ -1254,6 +1254,10 @@ esp_err_t esp_bt_controller_enable(esp_bt_mode_t mode)
 	}
 
 	btdm_controller_status = ESP_BT_CONTROLLER_STATUS_ENABLED;
+	ret = esp_register_shutdown_handler(bt_shutdown);
+	if (ret != ESP_OK) {
+		LOG_WRN("Register shutdown handler failed, ret = 0x%x", ret);
+	}
 
 	/* set default TX power level */
 	esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_DEFAULT, ESP32_RADIO_TXP_DEFAULT);
@@ -1284,7 +1288,7 @@ esp_err_t esp_bt_controller_disable(void)
 
 	esp_phy_disable(PHY_MODEM_BT);
 	btdm_controller_status = ESP_BT_CONTROLLER_STATUS_INITED;
-	bt_shutdown();
+	esp_unregister_shutdown_handler(bt_shutdown);
 
 	return ESP_OK;
 }

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -268,6 +268,7 @@ if(CONFIG_SOC_SERIES_ESP32C2)
     ../port/bootloader/bootloader_flash.c
 
     ../common/flash_init.c
+    ../common/esp_restart.c
 
     src/stubs.c
     src/soc_random.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -347,6 +347,7 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     ../port/bootloader/bootloader_flash.c
 
     ../common/flash_init.c
+    ../common/esp_restart.c
 
     src/stubs.c
     src/soc_random.c

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -285,6 +285,7 @@ if(CONFIG_SOC_SERIES_ESP32C6)
     ../port/bootloader/bootloader_flash.c
 
     ../common/flash_init.c
+    ../common/esp_restart.c
 
     src/stubs.c
     src/soc_random.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -358,6 +358,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     ../port/bootloader/bootloader_flash.c
 
     ../common/flash_init.c
+    ../common/esp_restart.c
 
     src/stubs.c
     src/soc_random.c

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -377,6 +377,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     ../port/bootloader/bootloader_flash.c
 
     ../common/flash_init.c
+    ../common/esp_restart.c
 
     src/stubs.c
     src/soc_random.c

--- a/zephyr/port/wifi/wifi_init.c
+++ b/zephyr/port/wifi/wifi_init.c
@@ -25,6 +25,7 @@
 #include "esp_phy_init.h"
 #include "esp_private/phy.h"
 #include "private/esp_modem_wrapper.h"
+#include "esp_system.h"
 
 #ifdef CONFIG_ESP_WIFI_NAN_ENABLE
 #include "apps_private/wifi_apps_private.h"
@@ -322,6 +323,11 @@ esp_err_t esp_wifi_init(const wifi_init_config_t *config)
 #ifdef CONFIG_ESP_WIFI_NAN_ENABLE
     esp_nan_app_init();
 #endif
+
+    result = esp_register_shutdown_handler((shutdown_handler_t)esp_wifi_stop);
+    if (result != ESP_OK && result != ESP_ERR_INVALID_STATE) {
+        LOG_ERR("Failed to init wifi (0x%x)", result);
+    }
 
     s_wifi_inited = true;
 


### PR DESCRIPTION
This creates a common esp_restart call to be used across the system and also implements the shutdown handler, needed for Wi-Fi, BLE and esp_timer(TBD).