### PR TITLE
pinctrl: esp32c6: Add i2s pins config

### DIFF
--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -300,6 +300,11 @@ if(CONFIG_SOC_SERIES_ESP32C6)
     )
 
   zephyr_sources_ifdef(
+    CONFIG_I2S_ESP32
+    ../../components/hal/i2s_hal.c
+    )
+
+  zephyr_sources_ifdef(
     CONFIG_COUNTER_TMR_ESP32
     ../../components/hal/timer_hal.c
     )

--- a/zephyr/port/pincfgs/esp32c6.yml
+++ b/zephyr/port/pincfgs/esp32c6.yml
@@ -152,6 +152,34 @@ i2c0:
     sigo: i2cext0_scl_out
     gpio: [[0, 23]]
 
+i2s:
+  mclk:
+    sigi: i2s_mclk_in
+    sigo: i2s_mclk_out
+    gpio: [[0, 23]]
+  i_bck:
+    sigi: i2si_bck_in
+    sigo: i2si_bck_out
+    gpio: [[0, 23]]
+  i_ws:
+    sigi: i2si_ws_in
+    sigo: i2si_ws_out
+    gpio: [[0, 23]]
+  i_sd:
+    sigi: i2si_sd_in
+    gpio: [[0, 23]]
+  o_bck:
+    sigi: i2so_bck_in
+    sigo: i2so_bck_out
+    gpio: [[0, 23]]
+  o_ws:
+    sigi: i2so_ws_in
+    sigo: i2so_ws_out
+    gpio: [[0, 23]]
+  o_sd:
+    sigo: i2so_sd_out
+    gpio: [[0, 23]]
+
 twai0:
   rx:
     sigi: twai0_rx


### PR DESCRIPTION
Add pinctrl config for ESP32-C6.