### PR TITLE
hal: esp32c6: Fix sleep routine

### DIFF
--- a/components/esp_hw_support/sleep_modes.c
+++ b/components/esp_hw_support/sleep_modes.c
@@ -522,11 +522,11 @@ static void IRAM_ATTR resume_timers(uint32_t pd_flags) {
 // [refactor-todo] provide target logic for body of uart functions below
 static void IRAM_ATTR flush_uarts(void)
 {
-    for (int i = 0; i < SOC_UART_NUM; ++i) {
+    for (int i = 0; i < SOC_UART_HP_NUM; ++i) {
 #ifdef CONFIG_IDF_TARGET_ESP32
         esp_rom_uart_tx_wait_idle(i);
 #else
-        if (periph_ll_periph_enabled(PERIPH_UART0_MODULE + i)) {
+        if (uart_ll_is_enabled(i)) {
             esp_rom_uart_tx_wait_idle(i);
         }
 #endif
@@ -541,9 +541,9 @@ static uint32_t s_suspended_uarts_bmap = 0;
 static IRAM_ATTR void suspend_uarts(void)
 {
     s_suspended_uarts_bmap = 0;
-    for (int i = 0; i < SOC_UART_NUM; ++i) {
+    for (int i = 0; i < SOC_UART_HP_NUM; ++i) {
 #ifndef CONFIG_IDF_TARGET_ESP32
-        if (!periph_ll_periph_enabled(PERIPH_UART0_MODULE + i)) {
+        if (!uart_ll_is_enabled(i)) {
             continue;
         }
 #endif
@@ -562,7 +562,7 @@ static IRAM_ATTR void suspend_uarts(void)
 
 static void IRAM_ATTR resume_uarts(void)
 {
-    for (int i = 0; i < SOC_UART_NUM; ++i) {
+    for (int i = 0; i < SOC_UART_HP_NUM; ++i) {
         if (s_suspended_uarts_bmap & 0x1) {
             uart_ll_force_xon(i);
         }


### PR DESCRIPTION
Fix sleep routine for ESP32-C6 after regression when updating HAL to v.5.1.c (PR #335).