### PR TITLE
monitor: fix output error when exiting

### DIFF
--- a/tools/idf_monitor/idf_monitor_base/console_reader.py
+++ b/tools/idf_monitor/idf_monitor_base/console_reader.py
@@ -94,4 +94,8 @@ class ConsoleReader(StoppableThread):
             # Note: This would throw exception in testing mode when the stdin is connected to PTY.
             import fcntl
             import termios
-            fcntl.ioctl(self.console.fd, termios.TIOCSTI, b'\0')
+            try:
+                fcntl.ioctl(self.console.fd, termios.TIOCSTI, b'\0')
+            except OSError:
+                # ignore I/O errors when injecting the “unblock” byte
+                pass


### PR DESCRIPTION
When CTRL+C is pressed, terminal should be closed without spilling out any error. This fixes it.