### PR TITLE
SPIRAM option for Wi-Fi adapter

### DIFF
--- a/zephyr/esp32s3/src/coex/esp_coex_adapter.c
+++ b/zephyr/esp32s3/src/coex/esp_coex_adapter.c
@@ -125,7 +125,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void * IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-	return wifi_malloc(size);
+	return k_malloc(size);
 }
 
 uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)


### PR DESCRIPTION
Use SPIRAM option when allocating Wi-Fi buffers.