### PR TITLE
esp_clk: remove sys/lock.h leftover

### DIFF
--- a/components/esp_hw_support/esp_clk.c
+++ b/components/esp_hw_support/esp_clk.c
@@ -7,7 +7,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/param.h>
-#include <sys/lock.h>
 
 #include <zephyr/kernel.h>
 


### PR DESCRIPTION
Remove unused header file.