### PR TITLE
espressif: mcuboot: get MCUBOOT_BOOT_MAX_ALIGN value from DT

### DIFF
--- a/components/soc/esp32s3/include/soc/system_reg.h
+++ b/components/soc/esp32s3/include/soc/system_reg.h
@@ -21,12 +21,23 @@ extern "C" {
 #endif
 
 #define SYSTEM_CORE_1_CONTROL_0_REG          (DR_REG_SYSTEM_BASE + 0x0)
+#ifndef CONFIG_MCUBOOT_ESPRESSIF
 /* SYSTEM_CONTROL_CORE_1_RESETTING : R/W ;bitpos:[2] ;default: 1'b1 ; */
 /*description: .*/
 #define SYSTEM_CONTROL_CORE_1_RESETTING    (BIT(2))
 #define SYSTEM_CONTROL_CORE_1_RESETTING_M  (BIT(2))
 #define SYSTEM_CONTROL_CORE_1_RESETTING_V  0x1
 #define SYSTEM_CONTROL_CORE_1_RESETTING_S  2
+#else
+/* NOTE: the original ESP-IDF version used by MCUboot Espressif still have
+ * the typo, thus the ifdef is needed */
+/* SYSTEM_CONTROL_CORE_1_RESETING : R/W ;bitpos:[2] ;default: 1'b1 ; */
+/*description: .*/
+#define SYSTEM_CONTROL_CORE_1_RESETING    (BIT(2))
+#define SYSTEM_CONTROL_CORE_1_RESETING_M  (BIT(2))
+#define SYSTEM_CONTROL_CORE_1_RESETING_V  0x1
+#define SYSTEM_CONTROL_CORE_1_RESETING_S  2
+#endif
 /* SYSTEM_CONTROL_CORE_1_CLKGATE_EN : R/W ;bitpos:[1] ;default: 1'b0 ; */
 /*description: .*/
 #define SYSTEM_CONTROL_CORE_1_CLKGATE_EN    (BIT(1))

--- a/zephyr/port/include/boot/mcuboot_config/mcuboot_config.h
+++ b/zephyr/port/include/boot/mcuboot_config/mcuboot_config.h
@@ -7,6 +7,8 @@
 #ifndef __MCUBOOT_CONFIG_H__
 #define __MCUBOOT_CONFIG_H__
 
+#include <zephyr/devicetree.h>
+
 /*
  * Signature types
  *
@@ -29,8 +31,13 @@
 #define MCUBOOT_SIGN_ED25519
 #endif
 
-#if defined(CONFIG_SECURE_FLASH_ENC_ENABLED)
-#define MCUBOOT_BOOT_MAX_ALIGN 32
+/* This mcuboot_config.h is used only by Zephyr builds, such as MCUboot
+ * Zephyr Port for ESP chips or a Zephyr application with MCUboot
+ * compatibilty (that builds the bootutil lib).
+ * In these cases, MCUBOOT_BOOT_MAX_ALIGN value must be taken from DT if
+ * the write-block-size is greater than 8 */
+#if DT_PROP(DT_CHOSEN(zephyr_flash), write_block_size) > 8
+#define MCUBOOT_BOOT_MAX_ALIGN DT_PROP(DT_CHOSEN(zephyr_flash), write_block_size)
 #endif
 
 /*


### PR DESCRIPTION
- Get MCUBOOT_BOOT_MAX_ALIGN value from DT - This change affects only MCUboot Zephyr Port for ESP chips or Zephyr application with MCUboot compatibilty (which builds the bootutil lib).

- Wrap typo fix with ifdef for MCUboot Espressif Port compatibility - The typo fix is not present on the original version of ESP-IDF used by MCUboot, thus the partial reverting of the fix.