### PR TITLE
soc: esp32c2: Add i2c support

### DIFF
--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -295,6 +295,12 @@ if(CONFIG_SOC_SERIES_ESP32C2)
     )
 
   zephyr_sources_ifdef(
+    CONFIG_I2C_ESP32
+    ../../components/hal/i2c_hal_iram.c
+    ../../components/hal/i2c_hal.c
+    )
+
+  zephyr_sources_ifdef(
     CONFIG_PWM_LED_ESP32
     ../../components/hal/ledc_hal_iram.c
     ../../components/hal/ledc_hal.c

--- a/zephyr/port/pincfgs/esp32c2.yml
+++ b/zephyr/port/pincfgs/esp32c2.yml
@@ -89,3 +89,13 @@ ledc:
   ch5:
     sigo: ledc_ls_sig_out5
     gpio: [[0, 10], [18, 20]]
+
+i2c0:
+  sda:
+    sigi: i2cext0_sda_in
+    sigo: i2cext0_sda_out
+    gpio: [[0, 10], [18, 20]]
+  scl:
+    sigi: i2cext0_scl_in
+    sigo: i2cext0_scl_out
+    gpio: [[0, 10], [18, 20]]


### PR DESCRIPTION
Add pinctrl config and HAL files for i2c support.