### PR TITLE
wifi: revert to use interrupt allocator

### DIFF
--- a/zephyr/esp32/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32/src/wifi/esp_wifi_adapter.c
@@ -405,9 +405,7 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-	irq_disable(n);
-	irq_connect_dynamic(n, 0, f, arg, 0);
-	irq_enable(n);
+	esp_intr_alloc(n, 0, f, arg, NULL);
 }
 
 static void intr_on(unsigned int mask)

--- a/zephyr/esp32c2/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32c2/src/wifi/esp_wifi_adapter.c
@@ -443,9 +443,10 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-	irq_disable(n);
-	irq_connect_dynamic(n, 0, f, arg, 0);
-	irq_enable(n);
+	ARG_UNUSED(n);
+
+	esp_intr_alloc(0, 0, f, arg, NULL);
+	esp_intr_alloc(2, 0, f, arg, NULL);
 }
 
 static void enable_intr_wrapper(unsigned int mask)

--- a/zephyr/esp32c3/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32c3/src/wifi/esp_wifi_adapter.c
@@ -443,9 +443,10 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-	irq_disable(n);
-	irq_connect_dynamic(n, 0, f, arg, 0);
-	irq_enable(n);
+	ARG_UNUSED(n);
+
+	esp_intr_alloc(0, 0, f, arg, NULL);
+	esp_intr_alloc(2, 0, f, arg, NULL);
 }
 
 static void enable_intr_wrapper(unsigned int mask)

--- a/zephyr/esp32c6/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32c6/src/wifi/esp_wifi_adapter.c
@@ -447,9 +447,10 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-	irq_disable(n);
-	irq_connect_dynamic(n, 0, f, arg, 0);
-	irq_enable(n);
+	ARG_UNUSED(n);
+
+	esp_intr_alloc(0, 0, f, arg, NULL);
+	esp_intr_alloc(2, 0, f, arg, NULL);
 }
 
 static void enable_intr_wrapper(unsigned int mask)

--- a/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
@@ -406,9 +406,10 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-	irq_disable(n);
-	irq_connect_dynamic(n, 0, f, arg, 0);
-	irq_enable(n);
+	ARG_UNUSED(n);
+
+	esp_intr_alloc(0, 0, f, arg, NULL);
+	esp_intr_alloc(2, 0, f, arg, NULL);
 }
 
 static void intr_on(unsigned int mask)

--- a/zephyr/esp32s3/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32s3/src/wifi/esp_wifi_adapter.c
@@ -152,9 +152,10 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-	irq_disable(n);
-	irq_connect_dynamic(n, 0, f, arg, 0);
-	irq_enable(n);
+	ARG_UNUSED(n);
+
+	esp_intr_alloc(0, 0, f, arg, NULL);
+	esp_intr_alloc(2, 0, f, arg, NULL);
 }
 
 static void intr_on(unsigned int mask)


### PR DESCRIPTION
Make sure ISR call uses interrupt allocator API to control slots properly.