### PR TITLE
zephyr: esp32s3: fix PSRAM conditional build

### DIFF
--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -257,9 +257,11 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       ../../components/esp_psram/${CONFIG_SOC_SERIES}/esp_psram_impl_octal.c
       )
 
-    zephyr_sources_ifdef(CONFIG_SPIRAM_FETCH_INSTRUCTIONS
-      ../../components/esp_psram/mmu_psram_flash.c
-      )
+    if (CONFIG_SPIRAM_FETCH_INSTRUCTIONS OR CONFIG_SPIRAM_RODATA)
+      zephyr_sources(
+        ../../components/esp_psram/mmu_psram_flash.c
+        )
+    endif()
   endif()
 
   zephyr_sources_ifdef(


### PR DESCRIPTION
Fix conditional build in cmake to allow to select either CONFIG_SPIRAM_FETCH_INSTRUCTIONS or CONFIG_SPIRAM_RODATA.