### PR TITLE
components: ieee802154: Add ESP32 kconfig prefix

### DIFF
--- a/components/ieee802154/driver/esp_ieee802154_ack.c
+++ b/components/ieee802154/driver/esp_ieee802154_ack.c
@@ -27,7 +27,7 @@ static IRAM_ATTR bool ieee802154_addr_in_pending_table(const uint8_t *addr, bool
 {
     bool ret = false;
     if (is_short) {
-        for (uint8_t index = 0; index < CONFIG_IEEE802154_PENDING_TABLE_SIZE; index++) {
+        for (uint8_t index = 0; index < CONFIG_IEEE802154_ESP32_PENDING_TABLE_SIZE; index++) {
             if (BIT_IST(ieee802154_pending_table.short_addr_mask, index) &&
                     memcmp(addr, ieee802154_pending_table.short_addr[index], IEEE802154_FRAME_SHORT_ADDR_SIZE) == 0) {
                 ret = true;
@@ -35,7 +35,7 @@ static IRAM_ATTR bool ieee802154_addr_in_pending_table(const uint8_t *addr, bool
             }
         }
     } else {
-        for (uint8_t index = 0; index < CONFIG_IEEE802154_PENDING_TABLE_SIZE; index++) {
+        for (uint8_t index = 0; index < CONFIG_IEEE802154_ESP32_PENDING_TABLE_SIZE; index++) {
             if (BIT_IST(ieee802154_pending_table.ext_addr_mask, index) &&
                     memcmp(addr, ieee802154_pending_table.ext_addr[index], IEEE802154_FRAME_EXT_ADDR_SIZE) == 0) {
                 ret = true;
@@ -51,7 +51,7 @@ esp_err_t ieee802154_add_pending_addr(const uint8_t *addr, bool is_short)
     esp_err_t ret = ESP_FAIL;
     int8_t first_empty_index = -1;
     if (is_short) {
-        for (uint8_t index = 0; index < CONFIG_IEEE802154_PENDING_TABLE_SIZE; index++) {
+        for (uint8_t index = 0; index < CONFIG_IEEE802154_ESP32_PENDING_TABLE_SIZE; index++) {
             if (!BIT_IST(ieee802154_pending_table.short_addr_mask, index)) {
                 // record the first empty index
                 first_empty_index = (first_empty_index == -1 ? index : first_empty_index);
@@ -67,7 +67,7 @@ esp_err_t ieee802154_add_pending_addr(const uint8_t *addr, bool is_short)
             ret = ESP_OK;
         }
     } else {
-        for (uint8_t index = 0; index < CONFIG_IEEE802154_PENDING_TABLE_SIZE; index++) {
+        for (uint8_t index = 0; index < CONFIG_IEEE802154_ESP32_PENDING_TABLE_SIZE; index++) {
             if (!BIT_IST(ieee802154_pending_table.ext_addr_mask, index)) {
                 first_empty_index = (first_empty_index == -1 ? index : first_empty_index);
             } else if (memcmp(addr, ieee802154_pending_table.ext_addr[index], IEEE802154_FRAME_EXT_ADDR_SIZE) == 0) {
@@ -90,7 +90,7 @@ esp_err_t ieee802154_clear_pending_addr(const uint8_t *addr, bool is_short)
     esp_err_t ret = ESP_FAIL;
     // Consider this function may be called in ISR, only clear the mask bits for finishing the process quickly.
     if (is_short) {
-        for (uint8_t index = 0; index < CONFIG_IEEE802154_PENDING_TABLE_SIZE; index++) {
+        for (uint8_t index = 0; index < CONFIG_IEEE802154_ESP32_PENDING_TABLE_SIZE; index++) {
             if (BIT_IST(ieee802154_pending_table.short_addr_mask, index) &&
                     memcmp(addr, ieee802154_pending_table.short_addr[index], IEEE802154_FRAME_SHORT_ADDR_SIZE) == 0) {
                 BIT_CLR(ieee802154_pending_table.short_addr_mask, index);
@@ -99,7 +99,7 @@ esp_err_t ieee802154_clear_pending_addr(const uint8_t *addr, bool is_short)
             }
         }
     } else {
-        for (uint8_t index = 0; index < CONFIG_IEEE802154_PENDING_TABLE_SIZE; index++) {
+        for (uint8_t index = 0; index < CONFIG_IEEE802154_ESP32_PENDING_TABLE_SIZE; index++) {
             if (BIT_IST(ieee802154_pending_table.ext_addr_mask, index) &&
                     memcmp(addr, ieee802154_pending_table.ext_addr[index], IEEE802154_FRAME_EXT_ADDR_SIZE) == 0) {
                 BIT_CLR(ieee802154_pending_table.ext_addr_mask, index);

--- a/components/ieee802154/driver/esp_ieee802154_debug.c
+++ b/components/ieee802154/driver/esp_ieee802154_debug.c
@@ -10,10 +10,10 @@
 #include "esp_ieee802154_util.h"
 #include "esp_log.h"
 
-#if CONFIG_IEEE802154_DEBUG
+#if CONFIG_IEEE802154_ESP32_DEBUG
 ieee802154_probe_info_t g_ieee802154_probe;
 
-#if CONFIG_IEEE802154_RECORD_EVENT
+#if CONFIG_IEEE802154_ESP32_RECORD_EVENT
 static char *ieee802154_get_event_string(ieee802154_ll_event_t events)
 {
     char *event_string = "";
@@ -60,9 +60,9 @@ static char *ieee802154_get_event_string(ieee802154_ll_event_t events)
     }
     return event_string;
 }
-#endif // CONFIG_IEEE802154_RECORD_EVENT
+#endif // CONFIG_IEEE802154_ESP32_RECORD_EVENT
 
-#if CONFIG_IEEE802154_RECORD_STATE || CONFIG_IEEE802154_RECORD_EVENT
+#if CONFIG_IEEE802154_ESP32_RECORD_STATE || CONFIG_IEEE802154_ESP32_RECORD_EVENT
 static char *ieee802154_state_string[] = {
     "DISABLE",
     "IDLE",
@@ -77,9 +77,9 @@ static char *ieee802154_state_string[] = {
     "ED",
     "CCA",
 };
-#endif // CONFIG_IEEE802154_RECORD_STATE
+#endif // CONFIG_IEEE802154_ESP32_RECORD_STATE
 
-#if CONFIG_IEEE802154_RECORD_CMD
+#if CONFIG_IEEE802154_ESP32_RECORD_CMD
 static char *ieee802154_get_cmd_string(ieee802154_ll_cmd_t cmd)
 {
     char *cmd_string = "";
@@ -123,9 +123,9 @@ static char *ieee802154_get_cmd_string(ieee802154_ll_cmd_t cmd)
     }
     return cmd_string;
 }
-#endif // CONFIG_IEEE802154_RECORD_CMD
+#endif // CONFIG_IEEE802154_ESP32_RECORD_CMD
 
-#if CONFIG_IEEE802154_RECORD_EVENT || CONFIG_IEEE802154_RECORD_ABORT
+#if CONFIG_IEEE802154_ESP32_RECORD_EVENT || CONFIG_IEEE802154_ESP32_RECORD_ABORT
 static char *ieee80154_rx_abort_reason_string[] = {
     "RSVD",                                         //   = 0,
     "RX_STOP",                                      //   = 1,
@@ -169,12 +169,12 @@ static char *ieee80154_tx_abort_reason_string[] = {
     "CCA_BUSY",                                     //   = 25,
 };
 
-#endif // CONFIG_IEEE802154_RECORD_EVENT
+#endif // CONFIG_IEEE802154_ESP32_RECORD_EVENT
 
-#if CONFIG_IEEE802154_ASSERT
+#if CONFIG_IEEE802154_ESP32_ASSERT
 void ieee802154_assert_print(void)
 {
-#if CONFIG_IEEE802154_RECORD_EVENT
+#if CONFIG_IEEE802154_ESP32_RECORD_EVENT
     ESP_EARLY_LOGW(IEEE802154_TAG, "Print the record event, current event index: %d", g_ieee802154_probe.event_index);
     for (uint8_t i = 0; i < IEEE802154_ASSERT_RECORD_EVENT_SIZE; i++) {
         char event_log[200] = { 0 };
@@ -193,9 +193,9 @@ void ieee802154_assert_print(void)
         ESP_EARLY_LOGW(IEEE802154_TAG, "%s %s", event_log, abort_log);
     }
     ESP_EARLY_LOGW(IEEE802154_TAG,"Print the record event done.");
-#endif // CONFIG_IEEE802154_RECORD_EVENT
+#endif // CONFIG_IEEE802154_ESP32_RECORD_EVENT
 
-#if CONFIG_IEEE802154_RECORD_STATE
+#if CONFIG_IEEE802154_ESP32_RECORD_STATE
     ESP_EARLY_LOGW(IEEE802154_TAG, "Print the record state, current state index: %d", g_ieee802154_probe.state_index);
     for (uint8_t i = 0; i < IEEE802154_ASSERT_RECORD_STATE_SIZE; i++) {
         ESP_EARLY_LOGW(IEEE802154_TAG, "index %2d: line:%5s, state:%10s, timestamp: %lld",
@@ -204,9 +204,9 @@ void ieee802154_assert_print(void)
             g_ieee802154_probe.state[i].timestamp);
     }
     ESP_EARLY_LOGW(IEEE802154_TAG,"Print the record state done.");
-#endif // CONFIG_IEEE802154_RECORD_STATE
+#endif // CONFIG_IEEE802154_ESP32_RECORD_STATE
 
-#if CONFIG_IEEE802154_RECORD_CMD
+#if CONFIG_IEEE802154_ESP32_RECORD_CMD
     ESP_EARLY_LOGW(IEEE802154_TAG, "Print the record cmd, current cmd index: %d", g_ieee802154_probe.cmd_index);
     for (uint8_t i = 0; i < IEEE802154_ASSERT_RECORD_CMD_SIZE; i++) {
         ESP_EARLY_LOGW(IEEE802154_TAG, "index %2d: line:%5s, cmd:%10s, timestamp: %lld",
@@ -215,9 +215,9 @@ void ieee802154_assert_print(void)
             g_ieee802154_probe.cmd[i].timestamp);
     }
     ESP_EARLY_LOGW(IEEE802154_TAG,"Print the record cmd done.");
-#endif // CONFIG_IEEE802154_RECORD_CMD
+#endif // CONFIG_IEEE802154_ESP32_RECORD_CMD
 
-#if CONFIG_IEEE802154_RECORD_ABORT
+#if CONFIG_IEEE802154_ESP32_RECORD_ABORT
     ESP_EARLY_LOGW(IEEE802154_TAG, "Print the record abort, current abort index: %d", g_ieee802154_probe.abort_index);
     for (uint8_t i = 0; i < IEEE802154_ASSERT_RECORD_ABORT_SIZE; i++) {
         if (g_ieee802154_probe.abort[i].is_tx_abort) {
@@ -233,11 +233,11 @@ void ieee802154_assert_print(void)
         }
     }
     ESP_EARLY_LOGW(IEEE802154_TAG,"Print the record abort done.");
-#endif // CONFIG_IEEE802154_RECORD_ABORT
+#endif // CONFIG_IEEE802154_ESP32_RECORD_ABORT
 }
-#endif // CONFIG_IEEE802154_ASSERT
+#endif // CONFIG_IEEE802154_ESP32_ASSERT
 
-#if CONFIG_IEEE802154_TXRX_STATISTIC
+#if CONFIG_IEEE802154_ESP32_TXRX_STATISTIC
 static ieee802154_txrx_statistic_t s_ieee802154_txrx_statistic;
 
 void ieee802154_txrx_statistic_clear(void)
@@ -368,6 +368,6 @@ void ieee802154_txrx_statistic_print(void)
     ESP_LOGW(IEEE802154_TAG, "+--------------------+-----------------------------------+--------------------------------------------------+");
 }
 
-#endif // CONFIG_IEEE802154_TXRX_STATISTIC
+#endif // CONFIG_IEEE802154_ESP32_TXRX_STATISTIC
 
-#endif // CONFIG_IEEE802154_DEBUG
+#endif // CONFIG_IEEE802154_ESP32_DEBUG

--- a/components/ieee802154/driver/esp_ieee802154_pib.c
+++ b/components/ieee802154/driver/esp_ieee802154_pib.c
@@ -38,8 +38,8 @@ void ieee802154_pib_init(void)
     s_ieee802154_pib.promiscuous = true;
     s_ieee802154_pib.rx_when_idle = false;
     s_ieee802154_pib.channel = 11;
-    s_ieee802154_pib.cca_threshold = CONFIG_IEEE802154_CCA_THRESHOLD;
-    s_ieee802154_pib.cca_mode = CONFIG_IEEE802154_CCA_MODE;
+    s_ieee802154_pib.cca_threshold = CONFIG_IEEE802154_ESP32_CCA_THRESHOLD;
+    s_ieee802154_pib.cca_mode = CONFIG_IEEE802154_ESP32_CCA_MODE;
     s_ieee802154_pib.txpower = IEEE802154_TXPOWER_VALUE_MAX;
 
     set_pending();

--- a/components/ieee802154/driver/esp_ieee802154_util.c
+++ b/components/ieee802154/driver/esp_ieee802154_util.c
@@ -21,7 +21,7 @@ uint8_t ieee802154_channel_to_freq(uint8_t channel)
     return (channel - 11) * 5 + 3;
 }
 
-#if !CONFIG_IEEE802154_TEST && (CONFIG_ESP_COEX_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE)
+#if !CONFIG_IEEE802154_ESP32_TEST && (CONFIG_ESP_COEX_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE)
 void ieee802154_set_txrx_pti(ieee802154_txrx_scene_t txrx_scene)
 {
 
@@ -42,7 +42,7 @@ void ieee802154_set_txrx_pti(ieee802154_txrx_scene_t txrx_scene)
         break;
     }
 }
-#endif // !CONFIG_IEEE802154_TEST && CONFIG_ESP_COEX_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
+#endif // !CONFIG_IEEE802154_ESP32_TEST && CONFIG_ESP_COEX_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
 
 // TZ-97: implement these two functions using ETM common interface
 void ieee802154_etm_channel_clear(uint32_t channel)

--- a/components/ieee802154/esp_ieee802154.c
+++ b/components/ieee802154/esp_ieee802154.c
@@ -128,7 +128,7 @@ esp_err_t esp_ieee802154_set_coordinator(bool enable)
     return ESP_OK;
 }
 
-#if CONFIG_IEEE802154_MULTI_PAN_ENABLE
+#if CONFIG_IEEE802154_ESP32_MULTI_PAN_ENABLE
 
 uint16_t esp_ieee802154_get_multipan_panid(esp_ieee802154_multipan_index_t index)
 {
@@ -218,7 +218,7 @@ esp_err_t esp_ieee802154_set_extended_address(const uint8_t *ext_addr)
     return ESP_OK;
 }
 
-#endif // CONFIG_IEEE802154_MULTI_PAN_ENABLE
+#endif // CONFIG_IEEE802154_ESP32_MULTI_PAN_ENABLE
 
 esp_ieee802154_pending_mode_t esp_ieee802154_get_pending_mode(void)
 {
@@ -405,7 +405,7 @@ __attribute__((weak)) void esp_ieee802154_timer1_done(void)
 
 }
 
-#if CONFIG_IEEE802154_TXRX_STATISTIC
+#if CONFIG_IEEE802154_ESP32_TXRX_STATISTIC
 void esp_ieee802154_txrx_statistic_clear(void)
 {
     ieee802154_txrx_statistic_clear();
@@ -415,4 +415,4 @@ void esp_ieee802154_txrx_statistic_print(void)
 {
     ieee802154_txrx_statistic_print();
 }
-#endif // CONFIG_IEEE802154_TXRX_STATISTIC
+#endif // CONFIG_IEEE802154_ESP32_TXRX_STATISTIC

--- a/components/ieee802154/include/esp_ieee802154.h
+++ b/components/ieee802154/include/esp_ieee802154.h
@@ -608,7 +608,7 @@ esp_err_t esp_ieee802154_enh_ack_generator(uint8_t *frame, esp_ieee802154_frame_
 /**
  * The configurable definitions via Kconfig
  */
-#if CONFIG_IEEE802154_TXRX_STATISTIC
+#if CONFIG_IEEE802154_ESP32_TXRX_STATISTIC
 
 /**
  * @brief  Clear the current IEEE802.15.4 statistic.
@@ -621,7 +621,7 @@ void esp_ieee802154_txrx_statistic_clear(void);
  *
  */
 void esp_ieee802154_txrx_statistic_print(void);
-#endif // CONFIG_IEEE802154_TXRX_STATISTIC
+#endif // CONFIG_IEEE802154_ESP32_TXRX_STATISTIC
 
 #ifdef __cplusplus
 }

--- a/components/ieee802154/private_include/esp_ieee802154_ack.h
+++ b/components/ieee802154/private_include/esp_ieee802154_ack.h
@@ -21,10 +21,10 @@ extern "C" {
  */
 
 #define IEEE802154_PENDING_TABLE_MASK_BITS (8)
-#define IEEE802154_PENDING_TABLE_MASK_SIZE (((CONFIG_IEEE802154_PENDING_TABLE_SIZE - 1) / IEEE802154_PENDING_TABLE_MASK_BITS) + 1)
+#define IEEE802154_PENDING_TABLE_MASK_SIZE (((CONFIG_IEEE802154_ESP32_PENDING_TABLE_SIZE - 1) / IEEE802154_PENDING_TABLE_MASK_BITS) + 1)
 typedef struct {
-    uint8_t short_addr[CONFIG_IEEE802154_PENDING_TABLE_SIZE][IEEE802154_FRAME_SHORT_ADDR_SIZE]; /*!< Short address table */
-    uint8_t ext_addr[CONFIG_IEEE802154_PENDING_TABLE_SIZE][IEEE802154_FRAME_EXT_ADDR_SIZE];     /*!< Extend address table */
+    uint8_t short_addr[CONFIG_IEEE802154_ESP32_PENDING_TABLE_SIZE][IEEE802154_FRAME_SHORT_ADDR_SIZE]; /*!< Short address table */
+    uint8_t ext_addr[CONFIG_IEEE802154_ESP32_PENDING_TABLE_SIZE][IEEE802154_FRAME_EXT_ADDR_SIZE];     /*!< Extend address table */
     uint8_t short_addr_mask[IEEE802154_PENDING_TABLE_MASK_SIZE];                                /*!< The mask which the index of short address table is used */
     uint8_t ext_addr_mask[IEEE802154_PENDING_TABLE_MASK_SIZE];                                  /*!< The mask which the index of extended address table is used */
 } ieee802154_pending_table_t;

--- a/components/ieee802154/private_include/esp_ieee802154_dev.h
+++ b/components/ieee802154/private_include/esp_ieee802154_dev.h
@@ -238,7 +238,7 @@ extern void esp_ieee802154_receive_failed(uint16_t error);
  */
 extern void esp_ieee802154_ed_failed(uint16_t error);
 
-#if CONFIG_IEEE802154_TEST
+#if CONFIG_IEEE802154_ESP32_TEST
 #define IEEE802154_STATIC
 #define IEEE802154_INLINE
 extern void esp_ieee802154_timer0_done(void);
@@ -246,7 +246,7 @@ extern void esp_ieee802154_timer1_done(void);
 #else
 #define IEEE802154_STATIC  static
 #define IEEE802154_INLINE  inline
-#endif // CONFIG_IEEE802154_TEST
+#endif // CONFIG_IEEE802154_ESP32_TEST
 #define IEEE802154_NOINLINE __attribute__((noinline))
 
 #ifdef __cplusplus

--- a/components/ieee802154/private_include/esp_ieee802154_util.h
+++ b/components/ieee802154/private_include/esp_ieee802154_util.h
@@ -32,8 +32,8 @@ extern "C" {
             IEEE802154_TXRX_STATISTIC(a); \
             } while(0)
 
-#if CONFIG_IEEE802154_RECORD_EVENT
-#define IEEE802154_ASSERT_RECORD_EVENT_SIZE CONFIG_IEEE802154_RECORD_EVENT_SIZE
+#if CONFIG_IEEE802154_ESP32_RECORD_EVENT
+#define IEEE802154_ASSERT_RECORD_EVENT_SIZE CONFIG_IEEE802154_ESP32_RECORD_EVENT_SIZE
 #define IEEE802154_RECORD_EVENT(a) do { \
             g_ieee802154_probe.event[g_ieee802154_probe.event_index].event = a; \
             g_ieee802154_probe.event[g_ieee802154_probe.event_index].state = ieee802154_get_state(); \
@@ -63,10 +63,10 @@ typedef struct {
 } ieee802154_event_info_t;
 #else
 #define IEEE802154_RECORD_EVENT(a)
-#endif // CONFIG_IEEE802154_RECORD_EVENT
+#endif // CONFIG_IEEE802154_ESP32_RECORD_EVENT
 
-#if CONFIG_IEEE802154_RECORD_STATE
-#define IEEE802154_ASSERT_RECORD_STATE_SIZE CONFIG_IEEE802154_RECORD_STATE_SIZE
+#if CONFIG_IEEE802154_ESP32_RECORD_STATE
+#define IEEE802154_ASSERT_RECORD_STATE_SIZE CONFIG_IEEE802154_ESP32_RECORD_STATE_SIZE
 #define ieee802154_set_state(a) do { s_ieee802154_state = a; \
             sprintf(g_ieee802154_probe.state[g_ieee802154_probe.state_index].line_str, "%d", __LINE__); \
             g_ieee802154_probe.state[g_ieee802154_probe.state_index].timestamp = esp_timer_get_time(); \
@@ -85,10 +85,10 @@ typedef struct {
 } ieee802154_state_info_t;
 #else
 #define ieee802154_set_state(state) (s_ieee802154_state = state)
-#endif // CONFIG_IEEE802154_RECORD_STATE
+#endif // CONFIG_IEEE802154_ESP32_RECORD_STATE
 
-#if CONFIG_IEEE802154_RECORD_CMD
-#define IEEE802154_ASSERT_RECORD_CMD_SIZE CONFIG_IEEE802154_RECORD_CMD_SIZE
+#if CONFIG_IEEE802154_ESP32_RECORD_CMD
+#define IEEE802154_ASSERT_RECORD_CMD_SIZE CONFIG_IEEE802154_ESP32_RECORD_CMD_SIZE
 #define ieee802154_set_cmd(a) do { ieee802154_ll_set_cmd(a); \
             sprintf(g_ieee802154_probe.cmd[g_ieee802154_probe.cmd_index].line_str, "%d", __LINE__); \
             g_ieee802154_probe.cmd[g_ieee802154_probe.cmd_index].timestamp = esp_timer_get_time(); \
@@ -107,10 +107,10 @@ typedef struct {
 } ieee802154_cmd_info_t;
 #else
 #define ieee802154_set_cmd(cmd) ieee802154_ll_set_cmd(cmd)
-#endif //CONFIG_IEEE802154_RECORD_CMD
+#endif //CONFIG_IEEE802154_ESP32_RECORD_CMD
 
-#if CONFIG_IEEE802154_RECORD_ABORT
-#define IEEE802154_ASSERT_RECORD_ABORT_SIZE CONFIG_IEEE802154_RECORD_ABORT_SIZE
+#if CONFIG_IEEE802154_ESP32_RECORD_ABORT
+#define IEEE802154_ASSERT_RECORD_ABORT_SIZE CONFIG_IEEE802154_ESP32_RECORD_ABORT_SIZE
 #define ieee802154_record_abort(a) do { \
             if (a == IEEE802154_EVENT_RX_ABORT) { \
                 g_ieee802154_probe.abort[g_ieee802154_probe.abort_index].abort_reason.rx \
@@ -142,33 +142,33 @@ typedef struct {
 } ieee802154_abort_info_t;
 #else
 #define ieee802154_record_abort(a)
-#endif // CONFIG_IEEE802154_RECORD_ABORT
+#endif // CONFIG_IEEE802154_ESP32_RECORD_ABORT
 
 /**
  * @brief The table of recording IEEE802154 information.
  */
 typedef struct {
-#if CONFIG_IEEE802154_RECORD_EVENT
+#if CONFIG_IEEE802154_ESP32_RECORD_EVENT
     ieee802154_event_info_t event[IEEE802154_ASSERT_RECORD_EVENT_SIZE]; /*!< record radio event */
     uint8_t event_index;                                                /*!< the index of event */
-#endif // CONFIG_IEEE802154_RECORD_EVENT
-#if CONFIG_IEEE802154_RECORD_STATE
+#endif // CONFIG_IEEE802154_ESP32_RECORD_EVENT
+#if CONFIG_IEEE802154_ESP32_RECORD_STATE
     ieee802154_state_info_t state[IEEE802154_ASSERT_RECORD_STATE_SIZE]; /*!< record radio state */
     uint8_t state_index;                                                /*!< the index of state */
-#endif // CONFIG_IEEE802154_RECORD_STATE
-#if CONFIG_IEEE802154_RECORD_CMD
+#endif // CONFIG_IEEE802154_ESP32_RECORD_STATE
+#if CONFIG_IEEE802154_ESP32_RECORD_CMD
     ieee802154_cmd_info_t cmd[IEEE802154_ASSERT_RECORD_CMD_SIZE];       /*!< record radio command */
     uint8_t cmd_index;                                                  /*!< the index of command */
-#endif // CONFIG_IEEE802154_RECORD_CMD
-#if CONFIG_IEEE802154_RECORD_ABORT
+#endif // CONFIG_IEEE802154_ESP32_RECORD_CMD
+#if CONFIG_IEEE802154_ESP32_RECORD_ABORT
     ieee802154_abort_info_t abort[IEEE802154_ASSERT_RECORD_ABORT_SIZE]; /*!< record radio abort */
     uint8_t abort_index;                                                  /*!< the index of abort */
-#endif // CONFIG_IEEE802154_RECORD_ABORT
+#endif // CONFIG_IEEE802154_ESP32_RECORD_ABORT
 } ieee802154_probe_info_t;
 
 extern ieee802154_probe_info_t g_ieee802154_probe;
 
-#if CONFIG_IEEE802154_ASSERT
+#if CONFIG_IEEE802154_ESP32_ASSERT
 /**
  * @brief  This function print rich information, which is useful for debug.
  *         Only can be used when `IEEE802154_ASSERT` is enabled.
@@ -181,11 +181,11 @@ void ieee802154_assert_print(void);
                                         assert(a); \
                                     } \
                                 } while (0)
-#else // CONFIG_IEEE802154_ASSERT
+#else // CONFIG_IEEE802154_ESP32_ASSERT
 #define IEEE802154_ASSERT(a) assert(a)
-#endif // CONFIG_IEEE802154_ASSERT
+#endif // CONFIG_IEEE802154_ESP32_ASSERT
 
-#if CONFIG_IEEE802154_TXRX_STATISTIC
+#if CONFIG_IEEE802154_ESP32_TXRX_STATISTIC
 typedef struct ieee802154_txrx_statistic{
     struct {
         uint64_t nums;
@@ -247,7 +247,7 @@ void ieee802154_tx_break_coex_nums_update(void);
 #define IEEE802154_TX_DEFERRED_NUMS_UPDATE()
 #define IEEE802154_TXRX_STATISTIC_CLEAR()
 #define IEEE802154_TX_BREAK_COEX_NUMS_UPDATE()
-#endif // CONFIG_IEEE802154_TXRX_STATISTIC
+#endif // CONFIG_IEEE802154_ESP32_TXRX_STATISTIC
 
 // TODO: replace etm code using common interface
 
@@ -265,7 +265,7 @@ typedef enum {
     IEEE802154_SCENE_RX_AT,     /*!< IEEE802154 radio coexistence scene RX AT */
 } ieee802154_txrx_scene_t;
 
-#if !CONFIG_IEEE802154_TEST && (CONFIG_ESP_COEX_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE)
+#if !CONFIG_IEEE802154_ESP32_TEST && (CONFIG_ESP_COEX_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE)
 
 /**
  * @brief  Set the IEEE802154 radio coexistence scene during transmitting or receiving.
@@ -281,7 +281,7 @@ void ieee802154_set_txrx_pti(ieee802154_txrx_scene_t txrx_scene);
 
 #define IEEE802154_SET_TXRX_PTI(txrx_scene)
 
-#endif // !CONFIG_IEEE802154_TEST && CONFIG_ESP_COEX_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
+#endif // !CONFIG_IEEE802154_ESP32_TEST && CONFIG_ESP_COEX_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
 
 /**
  * @brief  Convert the frequency to the index of channel.


### PR DESCRIPTION
Adding the `ESP32` prefix in all IEEE802154 configs to conform with Zephyr where multiple vendors has its own IEEE802154 configurations.