### PR TITLE
esp32: fix interrupt allocator descriptor checks

### DIFF
--- a/components/esp_hw_support/port/esp32/esp_cpu_intr.c
+++ b/components/esp_hw_support/port/esp32/esp_cpu_intr.c
@@ -49,11 +49,11 @@ typedef struct {
 
 /**
  * @brief Reserve the interrupts on the core where Bluetooth will run.
- * The macro CONFIG_BTDM_CTRL_PINNED_TO_CORE is only defined if Bluetooth controller is enabled.
+ * The macro CONFIG_ESP32_BT_CTLR_PINNED_TO_CORE is only defined if Bluetooth controller is enabled.
  * It is set to the core where it will run.
  */
-#ifdef CONFIG_BTDM_CTRL_PINNED_TO_CORE
-    #if CONFIG_BTDM_CTRL_PINNED_TO_CORE == 0
+#ifdef CONFIG_ESP32_BT_CTLR_PINNED_TO_CORE
+    #if CONFIG_ESP32_BT_CTLR_PINNED_TO_CORE == 0
         /* Interrupt 1 is used by Bluetooth UART HCI, check code above */
         #define CORE_0_INTERRUPT_1  STATE_INTERRUPT_1
         #define CORE_1_INTERRUPT_1  0
@@ -69,7 +69,7 @@ typedef struct {
         /* Interrupt 25 may be used by Bluetooth BR/EDR and BLE controller */
         #define CORE_0_INTERRUPT_25 STATE_INTERRUPT_25
         #define CORE_1_INTERRUPT_25 0
-    #elif CONFIG_BTDM_CTRL_PINNED_TO_CORE == 1
+    #elif CONFIG_ESP32_BT_CTLR_PINNED_TO_CORE == 1
         /* Interrupt 1 is used by Bluetooth UART HCI, check code above */
         #define CORE_0_INTERRUPT_1  0
         #define CORE_1_INTERRUPT_1  STATE_INTERRUPT_1

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -5,7 +5,7 @@ if(CONFIG_SOC_SERIES_ESP32)
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
 
-  zephyr_compile_definitions(CONFIG_ESP_SYSTEM_CHECK_INT_LEVEL_5)
+  zephyr_compile_definitions(CONFIG_ESP_SYSTEM_CHECK_INT_LEVEL_4)
 
   if(CONFIG_MCUBOOT)
     zephyr_compile_options(-fdump-rtl-expand)


### PR DESCRIPTION
Make sure to use proper BLE core kconfig entry to update ESP32 interrupt table descriptor.