### PR TITLE
wifi: fix internal malloc wrappers reference

### DIFF
--- a/zephyr/esp32/src/coex/esp_coex_adapter.c
+++ b/zephyr/esp32/src/coex/esp_coex_adapter.c
@@ -126,7 +126,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-	return wifi_malloc(size);
+	return k_malloc(size);
 }
 
 static int32_t IRAM_ATTR esp_coex_internal_semphr_take_from_isr_wrapper(void *semphr, void *hptw)

--- a/zephyr/esp32/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32/src/wifi/esp_wifi_adapter.c
@@ -355,12 +355,12 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-	return wifi_calloc(n, size);
+	return k_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-	return wifi_calloc(1, size);
+	return k_calloc(1, size);
 }
 
 uint32_t uxQueueMessagesWaiting(void *queue)

--- a/zephyr/esp32c2/src/coex/esp_coex_adapter.c
+++ b/zephyr/esp32c2/src/coex/esp_coex_adapter.c
@@ -122,7 +122,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-	return wifi_malloc(size);
+	return k_malloc(size);
 }
 
 uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)

--- a/zephyr/esp32c2/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32c2/src/wifi/esp_wifi_adapter.c
@@ -374,12 +374,12 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-	return wifi_calloc(n, size);
+	return k_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-	return wifi_calloc(1, size);
+	return k_calloc(1, size);
 }
 
 uint32_t uxQueueMessagesWaiting(void *queue)

--- a/zephyr/esp32c3/src/coex/esp_coex_adapter.c
+++ b/zephyr/esp32c3/src/coex/esp_coex_adapter.c
@@ -127,7 +127,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-	return wifi_malloc(size);
+	return k_malloc(size);
 }
 
 uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)

--- a/zephyr/esp32c3/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32c3/src/wifi/esp_wifi_adapter.c
@@ -374,12 +374,12 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-	return wifi_calloc(n, size);
+	return k_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-	return wifi_calloc(1, size);
+	return k_calloc(1, size);
 }
 
 uint32_t uxQueueMessagesWaiting(void *queue)

--- a/zephyr/esp32c6/src/coex/esp_coex_adapter.c
+++ b/zephyr/esp32c6/src/coex/esp_coex_adapter.c
@@ -127,7 +127,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-	return wifi_malloc(size);
+	return k_malloc(size);
 }
 
 uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)

--- a/zephyr/esp32c6/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32c6/src/wifi/esp_wifi_adapter.c
@@ -378,12 +378,12 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-	return wifi_calloc(n, size);
+	return k_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-	return wifi_calloc(1, size);
+	return k_calloc(1, size);
 }
 
 uint32_t uxQueueMessagesWaiting(void *queue)

--- a/zephyr/esp32s2/src/coex/esp_coex_adapter.c
+++ b/zephyr/esp32s2/src/coex/esp_coex_adapter.c
@@ -168,7 +168,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-	return wifi_malloc(size);
+	return k_malloc(size);
 }
 
 uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)

--- a/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
+++ b/zephyr/esp32s2/src/wifi/esp_wifi_adapter.c
@@ -356,12 +356,12 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-	return wifi_calloc(n, size);
+	return k_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-	return wifi_calloc(1, size);
+	return k_calloc(1, size);
 }
 
 uint32_t uxQueueMessagesWaiting(void *queue)


### PR DESCRIPTION
Wi-Fi adapter internal wrappers must allocate buffers from the main heap (internal RAM) and never from SPIRAM.

This change updates all adapter files to make consistent approach.

Fix https://github.com/zephyrproject-rtos/zephyr/issues/92823