### PR TITLE
zephyr: esptool requirements

### DIFF
--- a/zephyr/requirements.txt
+++ b/zephyr/requirements.txt
@@ -1,1 +1,1 @@
-esptool>=5.0.1
+esptool>=5.0.2


### PR DESCRIPTION
Move the esptool requirements to use esptool 5.0.2, which comes with an importand bugfixes that affect the image loading.