### PR TITLE
mspi: Zephyr sources for MSPI driver

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -175,6 +175,13 @@ if(CONFIG_SOC_SERIES_ESP32)
     )
 
   zephyr_sources_ifdef(
+    CONFIG_MSPI_ESP32
+    ../../components/hal/spi_hal.c
+    ../../components/hal/spi_hal_iram.c
+    ../../components/soc/lldesc.c
+    )
+
+  zephyr_sources_ifdef(
     CONFIG_I2C_ESP32
     ../../components/hal/i2c_hal_iram.c
     ../../components/hal/i2c_hal.c

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -142,6 +142,14 @@ if(CONFIG_SOC_SERIES_ESP32C2)
     ../../components/hal/gdma_hal.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_MSPI_ESP32
+    ../../components/hal/spi_hal.c
+    ../../components/hal/spi_hal_iram.c
+    ../../components/soc/lldesc.c
+    ../../components/hal/gdma_hal.c
+    )
+
   if(CONFIG_SOC_FLASH_ESP32 OR NOT CONFIG_BOOTLOADER_MCUBOOT)
     zephyr_sources(
     ../../components/bootloader_support/src/flash_encrypt.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -145,6 +145,14 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     ../../components/hal/gdma_hal.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_MSPI_ESP32
+    ../../components/hal/spi_hal.c
+    ../../components/hal/spi_hal_iram.c
+    ../../components/soc/lldesc.c
+    ../../components/hal/gdma_hal.c
+    )
+
     if(CONFIG_SOC_FLASH_ESP32 OR NOT CONFIG_BOOTLOADER_MCUBOOT)
     zephyr_sources(
     ../../components/spi_flash/flash_ops.c

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -148,6 +148,14 @@ if(CONFIG_SOC_SERIES_ESP32C6)
     ../../components/hal/gdma_hal.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_MSPI_ESP32
+    ../../components/hal/spi_hal.c
+    ../../components/hal/spi_hal_iram.c
+    ../../components/soc/lldesc.c
+    ../../components/hal/gdma_hal.c
+    )
+
   if(CONFIG_SOC_FLASH_ESP32 OR NOT CONFIG_BOOTLOADER_MCUBOOT)
     zephyr_sources(
     ../../components/esp_mm/esp_mmu_map.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -166,6 +166,13 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     ../../components/soc/lldesc.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_MSPI_ESP32
+    ../../components/hal/spi_hal.c
+    ../../components/hal/spi_hal_iram.c
+    ../../components/soc/lldesc.c
+    )
+
   if (CONFIG_ESP_SPIRAM)
     zephyr_compile_definitions(CONFIG_SPIRAM)
     zephyr_sources(

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -173,6 +173,14 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     )
 
   zephyr_sources_ifdef(
+    CONFIG_MSPI_ESP32
+    ../../components/hal/spi_hal.c
+    ../../components/hal/spi_hal_iram.c
+    ../../components/soc/lldesc.c
+    ../../components/hal/gdma_hal.c
+    )
+
+  zephyr_sources_ifdef(
     CONFIG_COUNTER_TMR_ESP32
     ../../components/hal/timer_hal.c
   )


### PR DESCRIPTION
Source files added for new MSPI driver to support [PR #94140](https://github.com/zephyrproject-rtos/zephyr/pull/94140) to Zephyr Project.