### PR TITLE
hal: esp32h2: Add peripherals support

### DIFF
--- a/components/driver/gpio/rtc_io.c
+++ b/components/driver/gpio/rtc_io.c
@@ -173,6 +173,7 @@ esp_err_t rtc_gpio_hold_dis(gpio_num_t gpio_num)
     return ESP_OK;
 }
 
+#if SOC_RTCIO_HOLD_SUPPORTED && SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
 esp_err_t rtc_gpio_isolate(gpio_num_t gpio_num)
 {
     ESP_RETURN_ON_FALSE(rtc_gpio_is_valid_gpio(gpio_num), ESP_ERR_INVALID_ARG, RTCIO_TAG, "RTCIO number error");
@@ -182,6 +183,7 @@ esp_err_t rtc_gpio_isolate(gpio_num_t gpio_num)
 
     return ESP_OK;
 }
+#endif // SOC_RTCIO_HOLD_SUPPORTED && SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
 
 esp_err_t rtc_gpio_force_hold_en_all(void)
 {

--- a/components/hal/esp32h2/include/hal/clk_gate_ll.h
+++ b/components/hal/esp32h2/include/hal/clk_gate_ll.h
@@ -78,6 +78,8 @@ static inline uint32_t periph_ll_get_clk_en_mask(periph_module_t periph)
             return PCR_TSENS_CLK_EN;
         case PERIPH_REGDMA_MODULE:
             return PCR_REGDMA_CLK_EN;
+        case PERIPH_USB_DEVICE_MODULE:
+            return PCR_USB_DEVICE_CLK_EN;
         // case PERIPH_WIFI_MODULE:
         //     return PCR_WIFI_CLK_WIFI_EN_M;
         // case PERIPH_BT_MODULE:
@@ -178,6 +180,8 @@ static inline uint32_t periph_ll_get_rst_en_mask(periph_module_t periph, bool en
             return PCR_DS_RST_EN;
         case PERIPH_ECDSA_MODULE:
             return PCR_ECDSA_RST_EN;
+        case PERIPH_USB_DEVICE_MODULE:
+            return PCR_USB_DEVICE_RST_EN;
         // case PERIPH_RNG_MODULE:
         //     return PCR_WIFI_CLK_RNG_EN;
         // case PERIPH_WIFI_MODULE:
@@ -263,6 +267,8 @@ static uint32_t periph_ll_get_clk_en_reg(periph_module_t periph)
             return PCR_TSENS_CLK_CONF_REG;
         case PERIPH_REGDMA_MODULE:
             return PCR_REGDMA_CONF_REG;
+        case PERIPH_USB_DEVICE_MODULE:
+            return PCR_USB_DEVICE_CONF_REG;
         case PERIPH_RNG_MODULE:
             return LPPERI_CLK_EN_REG;
     default:
@@ -332,6 +338,8 @@ static uint32_t periph_ll_get_rst_en_reg(periph_module_t periph)
             return PCR_TSENS_CLK_CONF_REG;
         case PERIPH_REGDMA_MODULE:
             return PCR_REGDMA_CONF_REG;
+        case PERIPH_USB_DEVICE_MODULE:
+            return PCR_USB_DEVICE_CONF_REG;
     default:
         return 0;
     }

--- a/zephyr/esp32h2/CMakeLists.txt
+++ b/zephyr/esp32h2/CMakeLists.txt
@@ -264,6 +264,64 @@ if(CONFIG_SOC_SERIES_ESP32H2)
     ../../components/esp_hw_support/adc_share_hw_ctrl.c
     )
 
+  zephyr_sources_ifdef(
+    CONFIG_ESP32_SPIM
+    ../../components/hal/spi_hal.c
+    ../../components/hal/spi_hal_iram.c
+    ../../components/soc/lldesc.c
+    ../../components/hal/gdma_hal.c
+    )
+
+  zephyr_sources_ifdef(
+    CONFIG_DMA_ESP32
+    ../../components/soc/lldesc.c
+    ../../components/hal/gdma_hal.c
+    )
+
+  zephyr_sources_ifdef(
+    CONFIG_I2C_ESP32
+    ../../components/hal/i2c_hal_iram.c
+    ../../components/hal/i2c_hal.c
+    )
+
+  zephyr_sources_ifdef(
+    CONFIG_I2S_ESP32
+    ../../components/hal/i2s_hal.c
+    )
+
+  if (CONFIG_ADC_ESP32)
+    zephyr_include_directories(
+    ../../components/esp_adc/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_adc/include
+    ../../components/esp_adc/interface
+    )
+
+    zephyr_sources(
+    ../../components/hal/adc_hal.c
+    ../../components/hal/adc_hal_common.c
+    ../../components/hal/adc_oneshot_hal.c
+    ../../components/hal/rtc_io_hal.c
+    ../../components/driver/gpio/rtc_io.c
+    ../../components/esp_adc/adc_cali.c
+    ../../components/esp_adc/adc_cali_curve_fitting.c
+    ../../components/esp_adc/${CONFIG_SOC_SERIES}/curve_fitting_coefficients.c
+    ../../components/soc/${CONFIG_SOC_SERIES}/adc_periph.c
+    ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_rtc_calib.c
+    )
+  endif()
+
+  zephyr_sources_ifdef(
+    CONFIG_PWM_LED_ESP32
+    ../../components/soc/${CONFIG_SOC_SERIES}/ledc_periph.c
+    ../../components/hal/ledc_hal_iram.c
+    ../../components/hal/ledc_hal.c
+    )
+
+  zephyr_sources_ifdef(
+    CONFIG_PCNT_ESP32
+    ../../components/hal/pcnt_hal.c
+    )
+
   zephyr_link_libraries_ifdef(CONFIG_NEWLIB_LIBC c)
 
 endif()

--- a/zephyr/port/pincfgs/esp32h2.yml
+++ b/zephyr/port/pincfgs/esp32h2.yml
@@ -40,3 +40,217 @@ uart1:
   dsr:
     sigi: u1dsr_in
     gpio: [[0, 5], [8, 14], [22, 27]]
+
+spim2:
+  miso:
+    sigi: fspiq_in
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  mosi:
+    sigo: fspid_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  sclk:
+    sigo: fspiclk_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  csel:
+    sigo: fspics0_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  csel1:
+    sigo: fspics1_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  csel2:
+    sigo: fspics2_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  csel3:
+    sigo: fspics3_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  csel4:
+    sigo: fspics4_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  csel5:
+    sigo: fspics5_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+
+i2c0:
+  sda:
+    sigi: i2cext0_sda_in
+    sigo: i2cext0_sda_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  scl:
+    sigi: i2cext0_scl_in
+    sigo: i2cext0_scl_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+
+i2c1:
+  sda:
+    sigi: i2cext1_sda_in
+    sigo: i2cext1_sda_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  scl:
+    sigi: i2cext1_scl_in
+    sigo: i2cext1_scl_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+
+i2s:
+  mclk:
+    sigi: i2s_mclk_in
+    sigo: i2s_mclk_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  i_bck:
+    sigi: i2si_bck_in
+    sigo: i2si_bck_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  i_ws:
+    sigi: i2si_ws_in
+    sigo: i2si_ws_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  i_sd:
+    sigi: i2si_sd_in
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  o_bck:
+    sigi: i2so_bck_in
+    sigo: i2so_bck_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  o_ws:
+    sigi: i2so_ws_in
+    sigo: i2so_ws_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  o_sd:
+    sigo: i2so_sd_out
+    gpio: [[0, 5], [8, 14], [22, 27]]
+
+ledc:
+  ch0:
+    sigo: ledc_ls_sig_out0
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch1:
+    sigo: ledc_ls_sig_out1
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch2:
+    sigo: ledc_ls_sig_out2
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch3:
+    sigo: ledc_ls_sig_out3
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch4:
+    sigo: ledc_ls_sig_out4
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch5:
+    sigo: ledc_ls_sig_out5
+    gpio: [[0, 5], [8, 14], [22, 27]]
+
+mcpwm0:
+  out0a:
+    sigo: pwm0_out0a
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  out0b:
+    sigo: pwm0_out0b
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  out1a:
+    sigo: pwm0_out1a
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  out1b:
+    sigo: pwm0_out1b
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  out2a:
+    sigo: pwm0_out2a
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  out2b:
+    sigo: pwm0_out2b
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  sync0:
+    sigi: pwm0_sync0_in
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  sync1:
+    sigi: pwm0_sync1_in
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  sync2:
+    sigi: pwm0_sync2_in
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  fault0:
+    sigi: pwm0_f0_in
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  fault1:
+    sigi: pwm0_f1_in
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  fault2:
+    sigi: pwm0_f2_in
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  cap0:
+    sigi: pwm0_cap0_in
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  cap1:
+    sigi: pwm0_cap1_in
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  cap2:
+    sigi: pwm0_cap2_in
+    gpio: [[0, 5], [8, 14], [22, 27]]
+
+twai:
+  rx:
+    sigi: twai_rx
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  tx:
+    sigo: twai_tx
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  clkout:
+    sigo: twai_clkout
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  bus_off:
+    sigo: twai_bus_off_on
+    gpio: [[0, 5], [8, 14], [22, 27]]
+
+pcnt0:
+  ch0sig:
+    sigi: pcnt_sig_ch0_in0
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch0ctrl:
+    sigi: pcnt_ctrl_ch0_in0
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch1sig:
+    sigi: pcnt_sig_ch1_in0
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch1ctrl:
+    sigi: pcnt_ctrl_ch1_in0
+    gpio: [[0, 5], [8, 14], [22, 27]]
+
+pcnt1:
+  ch0sig:
+    sigi: pcnt_sig_ch0_in1
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch0ctrl:
+    sigi: pcnt_ctrl_ch0_in1
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch1sig:
+    sigi: pcnt_sig_ch1_in1
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch1ctrl:
+    sigi: pcnt_ctrl_ch1_in1
+    gpio: [[0, 5], [8, 14], [22, 27]]
+
+pcnt2:
+  ch0sig:
+    sigi: pcnt_sig_ch0_in2
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch0ctrl:
+    sigi: pcnt_ctrl_ch0_in2
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch1sig:
+    sigi: pcnt_sig_ch1_in2
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch1ctrl:
+    sigi: pcnt_ctrl_ch1_in2
+    gpio: [[0, 5], [8, 14], [22, 27]]
+
+pcnt3:
+  ch0sig:
+    sigi: pcnt_sig_ch0_in3
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch0ctrl:
+    sigi: pcnt_ctrl_ch0_in3
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch1sig:
+    sigi: pcnt_sig_ch1_in3
+    gpio: [[0, 5], [8, 14], [22, 27]]
+  ch1ctrl:
+    sigi: pcnt_ctrl_ch1_in3
+    gpio: [[0, 5], [8, 14], [22, 27]]


### PR DESCRIPTION
Add HAL files and pinctrl for the following peripherals:

- ADC
- I2C
- I2S
- LEDC PWM
- MCPWM
- PCNT
- SPI
- GDMA
- TWAI
- USB serial