### PR TITLE
flash: skip failing if flash size won't match

### DIFF
--- a/components/spi_flash/esp_flash_spi_init.c
+++ b/components/spi_flash/esp_flash_spi_init.c
@@ -394,11 +394,12 @@ esp_err_t esp_flash_init_default_chip(void)
 #ifdef CONFIG_BOOTLOADER_MCUBOOT
     if (default_chip.size < legacy_chip->chip_size) {
         ESP_EARLY_LOGE(TAG, "Detected size(%dk) smaller than the size in the binary image header(%dk). Probe failed.", default_chip.size/1024, legacy_chip->chip_size/1024);
-        return ESP_ERR_FLASH_SIZE_NOT_MATCH;
+        /* do not fail if size does not match */
     }
 #endif
     if (default_chip.size > legacy_chip->chip_size) {
         ESP_EARLY_LOGW(TAG, "Detected size(%dk) larger than the size in the binary image header(%dk). Using the size in the binary image header.", default_chip.size/1024, legacy_chip->chip_size/1024);
+        /* do not fail if size does not match */
     }
     // Set chip->size equal to ROM flash size(also equal to the size in binary image header), which means the available size that can be used
     default_chip.size = legacy_chip->chip_size;


### PR DESCRIPTION
There are scenarios that flash size in binary file is different from the configured. Let only the warning message and skip failing.