### PR TITLE
hal: riscv: Fix noniram enable/disable

### DIFF
--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -220,6 +220,7 @@ if(CONFIG_SOC_SERIES_ESP32C2)
     ../../components/esp_hw_support/mac_addr.c
     ../../components/esp_hw_support/periph_ctrl.c
     ../../components/esp_hw_support/regi2c_ctrl.c
+    ../../components/esp_hw_support/rtc_module.c
     ../../components/esp_hw_support/sleep_modes.c
     ../../components/esp_hw_support/sar_periph_ctrl_common.c
     ../../components/esp_hw_support/port/esp_clk_tree_common.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -284,6 +284,7 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     ../../components/esp_hw_support/hw_random.c
     ../../components/esp_hw_support/mac_addr.c
     ../../components/esp_hw_support/periph_ctrl.c
+    ../../components/esp_hw_support/rtc_module.c
     ../../components/esp_hw_support/regi2c_ctrl.c
     ../../components/esp_hw_support/sar_periph_ctrl_common.c
     ../../components/esp_hw_support/sleep_modes.c

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -240,6 +240,7 @@ if(CONFIG_SOC_SERIES_ESP32C6)
     ../../components/esp_hw_support/mac_addr.c
     ../../components/esp_hw_support/modem_clock.c
     ../../components/esp_hw_support/periph_ctrl.c
+    ../../components/esp_hw_support/rtc_module.c
     ../../components/esp_hw_support/regi2c_ctrl.c
     ../../components/esp_hw_support/sar_periph_ctrl_common.c
     ../../components/esp_hw_support/sleep_modes.c

--- a/zephyr/esp32h2/CMakeLists.txt
+++ b/zephyr/esp32h2/CMakeLists.txt
@@ -189,6 +189,7 @@ if(CONFIG_SOC_SERIES_ESP32H2)
     ../../components/esp_hw_support/mac_addr.c
     ../../components/esp_hw_support/modem_clock.c
     ../../components/esp_hw_support/periph_ctrl.c
+    ../../components/esp_hw_support/rtc_module.c
     ../../components/esp_hw_support/regi2c_ctrl.c
     ../../components/esp_hw_support/sar_periph_ctrl_common.c
     ../../components/esp_hw_support/sleep_modes.c

--- a/zephyr/port/host_flash/cache_utils.c
+++ b/zephyr/port/host_flash/cache_utils.c
@@ -77,10 +77,8 @@ void spi_flash_op_unlock(void)
 void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu(void)
 {
 	s_intr_saved_state = irq_lock();
-#if !defined(CONFIG_SOC_SERIES_ESP32C2) && !defined(CONFIG_SOC_SERIES_ESP32C3) &&                  \
-	!defined(CONFIG_SOC_SERIES_ESP32C6) && !defined(CONFIG_SOC_SERIES_ESP32H2)
+
 	esp_intr_noniram_disable();
-#endif
 
 #if !defined(CONFIG_SOC_SERIES_ESP32C2) && !defined(CONFIG_SOC_SERIES_ESP32C3) &&                  \
 	!defined(CONFIG_SOC_SERIES_ESP32C6) && !defined(CONFIG_SOC_SERIES_ESP32H2)
@@ -111,10 +109,8 @@ void IRAM_ATTR spi_flash_enable_interrupts_caches_and_other_cpu(void)
 	spi_flash_restore_cache(other_cpu, s_flash_op_cache_state[other_cpu]);
 #endif
 
-#if !defined(CONFIG_SOC_SERIES_ESP32C2) && !defined(CONFIG_SOC_SERIES_ESP32C3) &&                  \
-	!defined(CONFIG_SOC_SERIES_ESP32C6) && !defined(CONFIG_SOC_SERIES_ESP32H2)
 	esp_intr_noniram_enable();
-#endif
+
 	irq_unlock(s_intr_saved_state);
 }
 


### PR DESCRIPTION
Until recently, RISC-V SoCs were using a custom interrupt controller driver on Zephyr, which didn't implement esp_intr_noniram_enable() and esp_intr_noniram_disable() functions. Now that all SoCs share the same interrupt controller driver, these functions can be called for RISC-V chips.