### PR TITLE
hal: esp32h2: Fix UHCI symbols

### DIFF
--- a/components/hal/esp32h2/include/hal/uhci_ll.h
+++ b/components/hal/esp32h2/include/hal/uhci_ll.h
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include "hal/uhci_types.h"
 #include "soc/uhci_struct.h"
+#include "hal/misc.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/soc/esp32h2/include/soc/uhci_struct.h
+++ b/components/soc/esp32h2/include/soc/uhci_struct.h
@@ -363,7 +363,7 @@ typedef union {
         /** pkt_thrs : R/W; bitpos: [12:0]; default: 128;
          *  a
          */
-        uint32_t pkt_thrs:13;
+        uint32_t thrs:13;
         uint32_t reserved_13:19;
     };
     uint32_t val;


### PR DESCRIPTION
Fix UHCI symbols to allow enabling peripheral.