### PR TITLE
include: fix compilation issues due to redefined symbols

### DIFF
--- a/components/bootloader_support/src/bootloader_utility.c
+++ b/components/bootloader_support/src/bootloader_utility.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp_attr.h"
 #include "esp_log.h"

--- a/components/bootloader_support/src/esp32/bootloader_sha.c
+++ b/components/bootloader_support/src/esp32/bootloader_sha.c
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp32/rom/sha.h"
 #include "soc/dport_reg.h"

--- a/components/bootloader_support/src/esp32c2/bootloader_sha.c
+++ b/components/bootloader_support/src/esp32c2/bootloader_sha.c
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp32c2/rom/sha.h"
 

--- a/components/bootloader_support/src/esp32c3/bootloader_sha.c
+++ b/components/bootloader_support/src/esp32c3/bootloader_sha.c
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp32c3/rom/sha.h"
 

--- a/components/bootloader_support/src/esp32c6/bootloader_ecdsa.c
+++ b/components/bootloader_support/src/esp32c6/bootloader_ecdsa.c
@@ -5,7 +5,7 @@
  */
 #include <stdbool.h>
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "rom/ecdsa.h"
 
 #define ROM_FUNC_TYPECAST  int(*)(const uint8_t*, const uint8_t*, int, const uint8_t*, uint8_t*)

--- a/components/bootloader_support/src/esp32c6/bootloader_sha.c
+++ b/components/bootloader_support/src/esp32c6/bootloader_sha.c
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp32c6/rom/sha.h"
 

--- a/components/bootloader_support/src/esp32h2/bootloader_sha.c
+++ b/components/bootloader_support/src/esp32h2/bootloader_sha.c
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp32h2/rom/sha.h"
 

--- a/components/bootloader_support/src/esp32s2/bootloader_sha.c
+++ b/components/bootloader_support/src/esp32s2/bootloader_sha.c
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp32s2/rom/sha.h"
 

--- a/components/bootloader_support/src/esp32s3/bootloader_sha.c
+++ b/components/bootloader_support/src/esp32s3/bootloader_sha.c
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp32s3/rom/sha.h"
 

--- a/components/bootloader_support/src/esp_image_format.c
+++ b/components/bootloader_support/src/esp_image_format.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <esp_cpu.h>
 #include <bootloader_utility.h>
 #include <bootloader_signature.h>

--- a/components/bootloader_support/src/idf/bootloader_sha.c
+++ b/components/bootloader_support/src/idf/bootloader_sha.c
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <mbedtls/sha256.h>
 
 bootloader_sha256_handle_t bootloader_sha256_start(void)

--- a/components/bootloader_support/src/secure_boot_v1/secure_boot_signatures_app.c
+++ b/components/bootloader_support/src/secure_boot_v1/secure_boot_signatures_app.c
@@ -18,7 +18,7 @@
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #ifdef CONFIG_SECURE_SIGNED_APPS_ECDSA_SCHEME
 static const char *TAG = "secure_boot_v1";

--- a/components/bootloader_support/src/secure_boot_v1/secure_boot_signatures_bootloader.c
+++ b/components/bootloader_support/src/secure_boot_v1/secure_boot_signatures_bootloader.c
@@ -16,7 +16,7 @@
 #include "esp32/rom/sha.h"
 #include "uECC_verify_antifault.h"
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <string.h>
 
 static const char *TAG = "secure_boot";

--- a/components/bootloader_support/src/secure_boot_v2/secure_boot_signatures_app.c
+++ b/components/bootloader_support/src/secure_boot_v2/secure_boot_signatures_app.c
@@ -18,7 +18,7 @@
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_secure_boot.h"
 #include "esp_ota_ops.h"
 #include "esp_efuse.h"

--- a/components/driver/spi/gpspi/spi_master.c
+++ b/components/driver/spi/gpspi/spi_master.c
@@ -111,7 +111,7 @@ We have two bits to control the interrupt:
 */
 
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_private/spi_common_internal.h"
 #include "driver/spi_master.h"
 #include "esp_clk_tree.h"

--- a/components/driver/spi/sdspi/sdspi_host.c
+++ b/components/driver/spi/sdspi/sdspi_host.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_log.h"
 #include "esp_heap_caps.h"
 #include "driver/gpio.h"

--- a/components/driver/uart/uart.c
+++ b/components/driver/uart/uart.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_types.h"
 #include "esp_attr.h"
 #include "esp_intr_alloc.h"

--- a/components/efuse/esp32/esp_efuse_utility.c
+++ b/components/efuse/esp32/esp_efuse_utility.c
@@ -11,7 +11,7 @@
 #include "esp_log.h"
 #include "assert.h"
 #include "sdkconfig.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 static const char *TAG = "efuse";
 

--- a/components/efuse/esp32c2/esp_efuse_utility.c
+++ b/components/efuse/esp32c2/esp_efuse_utility.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_log.h"
 #include "assert.h"

--- a/components/efuse/esp32c3/esp_efuse_utility.c
+++ b/components/efuse/esp32c3/esp_efuse_utility.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_log.h"
 #include "assert.h"

--- a/components/efuse/esp32c6/esp_efuse_utility.c
+++ b/components/efuse/esp32c6/esp_efuse_utility.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_log.h"
 #include "assert.h"

--- a/components/efuse/esp32h2/esp_efuse_utility.c
+++ b/components/efuse/esp32h2/esp_efuse_utility.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_log.h"
 #include "assert.h"

--- a/components/efuse/esp32s2/esp_efuse_utility.c
+++ b/components/efuse/esp32s2/esp_efuse_utility.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_log.h"
 #include "assert.h"

--- a/components/efuse/esp32s3/esp_efuse_utility.c
+++ b/components/efuse/esp32s3/esp_efuse_utility.c
@@ -10,7 +10,7 @@
 #include "esp_log.h"
 #include "assert.h"
 #include "sdkconfig.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 static const char *TAG = "efuse";
 

--- a/components/efuse/src/esp_efuse_utility.c
+++ b/components/efuse/src/esp_efuse_utility.c
@@ -11,7 +11,7 @@
 #include "esp_rom_sys.h"
 #include "assert.h"
 #include "sdkconfig.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 static const char *TAG = "efuse";
 

--- a/components/esp_app_format/esp_app_desc.c
+++ b/components/esp_app_format/esp_app_desc.c
@@ -5,7 +5,7 @@
  */
 
 #include <assert.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_app_desc.h"
 #include "esp_attr.h"
 #include "sdkconfig.h"

--- a/components/esp_hw_support/dma/esp_async_memcpy.c
+++ b/components/esp_hw_support/dma/esp_async_memcpy.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "hal/dma_types.h"

--- a/components/esp_hw_support/esp_clk.c
+++ b/components/esp_hw_support/esp_clk.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include <zephyr/kernel.h>
 

--- a/components/esp_hw_support/hw_random.c
+++ b/components/esp_hw_support/hw_random.c
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_attr.h"
 #include "esp_cpu.h"
 #include "soc/wdev_reg.h"

--- a/components/esp_hw_support/port/esp32c6/pmu_sleep.c
+++ b/components/esp_hw_support/port/esp32c6/pmu_sleep.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <esp_types.h>
 #include "sdkconfig.h"
 #include "esp_err.h"

--- a/components/esp_hw_support/port/esp32h2/pmu_sleep.c
+++ b/components/esp_hw_support/port/esp32h2/pmu_sleep.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <esp_types.h>
 #include "sdkconfig.h"
 #include "esp_err.h"

--- a/components/esp_hw_support/port/esp32s3/mspi_timing_config.c
+++ b/components/esp_hw_support/port/esp32s3/mspi_timing_config.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "string.h"
 #include "esp_attr.h"

--- a/components/esp_hw_support/port/esp32s3/rtc_init.c
+++ b/components/esp_hw_support/port/esp32s3/rtc_init.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdint.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/soc.h"
 #include "soc/rtc.h"
 #include "soc/rtc_cntl_reg.h"

--- a/components/esp_hw_support/port/linux/esp_random.c
+++ b/components/esp_hw_support/port/linux/esp_random.c
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <assert.h>
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp_log.h"
 

--- a/components/esp_hw_support/sleep_cpu.c
+++ b/components/esp_hw_support/sleep_cpu.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include <sys/lock.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp_attr.h"
 #include "esp_check.h"

--- a/components/esp_hw_support/sleep_gpio.c
+++ b/components/esp_hw_support/sleep_gpio.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <sys/lock.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp_attr.h"
 #include "esp_sleep.h"

--- a/components/esp_hw_support/sleep_modem.c
+++ b/components/esp_hw_support/sleep_modem.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <sys/lock.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp_log.h"
 #include "esp_attr.h"

--- a/components/esp_hw_support/sleep_modes.c
+++ b/components/esp_hw_support/sleep_modes.c
@@ -10,7 +10,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <sys/lock.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp_attr.h"
 #include "esp_memory_utils.h"

--- a/components/esp_hw_support/sleep_retention.c
+++ b/components/esp_hw_support/sleep_retention.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <zephyr/kernel.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp_err.h"
 #include "esp_attr.h"

--- a/components/esp_hw_support/sleep_wake_stub.c
+++ b/components/esp_hw_support/sleep_wake_stub.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <sys/lock.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp_attr.h"
 #include "esp_sleep.h"

--- a/components/esp_mm/cache_esp32.c
+++ b/components/esp_mm/cache_esp32.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <inttypes.h>
 #include "sdkconfig.h"
 #include "rom/cache.h"

--- a/components/esp_mm/esp_cache.c
+++ b/components/esp_mm/esp_cache.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <inttypes.h>
 #include "sdkconfig.h"
 #include "esp_check.h"

--- a/components/esp_mm/esp_mmu_map.c
+++ b/components/esp_mm/esp_mmu_map.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <sys/queue.h>
 #include <inttypes.h>
 #include "sdkconfig.h"

--- a/components/esp_netif/vfs_l2tap/esp_vfs_l2tap.c
+++ b/components/esp_netif/vfs_l2tap/esp_vfs_l2tap.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdatomic.h>
 #include <sys/fcntl.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <sys/queue.h>
 #include "arpa/inet.h" // for ntohs, etc.
 #include "errno.h"

--- a/components/esp_pm/pm_impl.c
+++ b/components/esp_pm/pm_impl.c
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <stdint.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp_attr.h"
 #include "esp_err.h"

--- a/components/esp_psram/esp_psram.c
+++ b/components/esp_psram/esp_psram.c
@@ -11,7 +11,7 @@
  *
  * When we add more types of external RAM memory, this can be made into a more intelligent dispatcher.
  *----------------------------------------------------------------------------------------------------*/
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_attr.h"
 #include "esp_err.h"

--- a/components/esp_psram/include/esp_private/mmu_psram_flash.h
+++ b/components/esp_psram/include/esp_private/mmu_psram_flash.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_err.h"
 #include "sdkconfig.h"
 

--- a/components/esp_psram/mmu_psram_flash.c
+++ b/components/esp_psram/mmu_psram_flash.c
@@ -16,7 +16,7 @@
  *    APIs in 2 will be refactored when MMU driver is ready
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_log.h"
 #include "esp_attr.h"

--- a/components/esp_system/port/soc/esp32c2/clk.c
+++ b/components/esp_system/port/soc/esp32c2/clk.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 #include <sys/cdefs.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_attr.h"
 #include "esp_log.h"

--- a/components/esp_system/port/soc/esp32c3/clk.c
+++ b/components/esp_system/port/soc/esp32c3/clk.c
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <sys/cdefs.h>
 // #include <sys/time.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_attr.h"
 #include "esp_log.h"

--- a/components/esp_system/port/soc/esp32c6/clk.c
+++ b/components/esp_system/port/soc/esp32c6/clk.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 #include <sys/cdefs.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_attr.h"
 #include "esp_log.h"

--- a/components/esp_system/port/soc/esp32h2/clk.c
+++ b/components/esp_system/port/soc/esp32h2/clk.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 #include <sys/cdefs.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_attr.h"
 #include "esp_log.h"

--- a/components/esp_system/port/soc/esp32s2/clk.c
+++ b/components/esp_system/port/soc/esp32s2/clk.c
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <sys/cdefs.h>
 // #include <sys/time.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_attr.h"
 #include "esp_log.h"

--- a/components/esp_system/port/soc/esp32s3/clk.c
+++ b/components/esp_system/port/soc/esp32s3/clk.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 #include <sys/cdefs.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_attr.h"
 #include "esp_log.h"

--- a/components/esp_system/port/usb_console.c
+++ b/components/esp_system/port/usb_console.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/components/esp_timer/src/esp_timer.c
+++ b/components/esp_timer/src/esp_timer.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <string.h>
 #include "soc/soc.h"
 #include "esp_types.h"

--- a/components/esp_timer/src/esp_timer_impl_systimer.c
+++ b/components/esp_timer/src/esp_timer_impl_systimer.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_timer_impl.h"
 #include "esp_err.h"

--- a/components/hal/adc_hal.c
+++ b/components/hal/adc_hal.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "hal/adc_hal.h"
 #include "hal/assert.h"

--- a/components/hal/adc_hal_common.c
+++ b/components/hal/adc_hal_common.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "soc/soc_caps.h"
 #include "hal/adc_hal_common.h"

--- a/components/hal/adc_oneshot_hal.c
+++ b/components/hal/adc_oneshot_hal.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "soc/soc_caps.h"
 #include "hal/adc_oneshot_hal.h"

--- a/components/hal/cache_hal.c
+++ b/components/hal/cache_hal.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <stdint.h>
 #include "sdkconfig.h"
 #include "esp_err.h"

--- a/components/hal/efuse_hal.c
+++ b/components/hal/efuse_hal.c
@@ -5,7 +5,7 @@
  */
 
 #include "sdkconfig.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/soc_caps.h"
 #include "hal/efuse_ll.h"
 #include "hal/assert.h"

--- a/components/hal/esp32/efuse_hal.c
+++ b/components/hal/esp32/efuse_hal.c
@@ -5,7 +5,7 @@
  */
 
 #include "sdkconfig.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/soc_caps.h"
 #include "hal/efuse_ll.h"
 #include "hal/assert.h"

--- a/components/hal/esp32/include/hal/spi_flash_ll.h
+++ b/components/hal/esp32/include/hal/spi_flash_ll.h
@@ -19,7 +19,7 @@
 #include "soc/spi_struct.h"
 #include "hal/spi_types.h"
 #include "hal/spi_flash_types.h"
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 #include "hal/misc.h"

--- a/components/hal/esp32c2/efuse_hal.c
+++ b/components/hal/esp32c2/efuse_hal.c
@@ -5,7 +5,7 @@
  */
 
 #include "sdkconfig.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/soc_caps.h"
 #include "hal/assert.h"
 #include "hal/efuse_hal.h"

--- a/components/hal/esp32c2/include/hal/gpspi_flash_ll.h
+++ b/components/hal/esp32c2/include/hal/gpspi_flash_ll.h
@@ -19,7 +19,7 @@
 #include "hal/spi_types.h"
 #include "hal/spi_flash_types.h"
 #include "hal/misc.h"
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 

--- a/components/hal/esp32c2/include/hal/spimem_flash_ll.h
+++ b/components/hal/esp32c2/include/hal/spimem_flash_ll.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <stdlib.h>
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 

--- a/components/hal/esp32c3/efuse_hal.c
+++ b/components/hal/esp32c3/efuse_hal.c
@@ -5,7 +5,7 @@
  */
 
 #include "sdkconfig.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/soc_caps.h"
 #include "hal/assert.h"
 #include "hal/efuse_hal.h"

--- a/components/hal/esp32c3/include/hal/gpspi_flash_ll.h
+++ b/components/hal/esp32c3/include/hal/gpspi_flash_ll.h
@@ -19,7 +19,7 @@
 #include "soc/spi_struct.h"
 #include "hal/spi_types.h"
 #include "hal/spi_flash_types.h"
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 #include "hal/misc.h"

--- a/components/hal/esp32c3/include/hal/spimem_flash_ll.h
+++ b/components/hal/esp32c3/include/hal/spimem_flash_ll.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <stdlib.h>
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 

--- a/components/hal/esp32c6/efuse_hal.c
+++ b/components/hal/esp32c6/efuse_hal.c
@@ -5,7 +5,7 @@
  */
 
 #include "sdkconfig.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/soc_caps.h"
 #include "hal/assert.h"
 #include "hal/efuse_hal.h"

--- a/components/hal/esp32c6/include/hal/gpspi_flash_ll.h
+++ b/components/hal/esp32c6/include/hal/gpspi_flash_ll.h
@@ -19,7 +19,7 @@
 #include "soc/spi_struct.h"
 #include "hal/spi_types.h"
 #include "hal/spi_flash_types.h"
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 #include "hal/misc.h"

--- a/components/hal/esp32c6/include/hal/spimem_flash_ll.h
+++ b/components/hal/esp32c6/include/hal/spimem_flash_ll.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <stdlib.h>
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 

--- a/components/hal/esp32h2/efuse_hal.c
+++ b/components/hal/esp32h2/efuse_hal.c
@@ -5,7 +5,7 @@
  */
 
 #include "sdkconfig.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/soc_caps.h"
 #include "hal/assert.h"
 #include "hal/efuse_hal.h"

--- a/components/hal/esp32h2/include/hal/gpspi_flash_ll.h
+++ b/components/hal/esp32h2/include/hal/gpspi_flash_ll.h
@@ -19,7 +19,7 @@
 #include "soc/spi_struct.h"
 #include "hal/spi_types.h"
 #include "hal/spi_flash_types.h"
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 #include "hal/misc.h"

--- a/components/hal/esp32h2/include/hal/spimem_flash_ll.h
+++ b/components/hal/esp32h2/include/hal/spimem_flash_ll.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <stdlib.h>
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 

--- a/components/hal/esp32s2/efuse_hal.c
+++ b/components/hal/esp32s2/efuse_hal.c
@@ -5,7 +5,7 @@
  */
 
 #include "sdkconfig.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/soc_caps.h"
 #include "hal/assert.h"
 #include "hal/efuse_hal.h"

--- a/components/hal/esp32s2/include/hal/gpspi_flash_ll.h
+++ b/components/hal/esp32s2/include/hal/gpspi_flash_ll.h
@@ -19,7 +19,7 @@
 #include "soc/spi_struct.h"
 #include "hal/spi_types.h"
 #include "hal/spi_flash_types.h"
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 #include "hal/misc.h"

--- a/components/hal/esp32s2/include/hal/spimem_flash_ll.h
+++ b/components/hal/esp32s2/include/hal/spimem_flash_ll.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <stdlib.h>
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 

--- a/components/hal/esp32s3/efuse_hal.c
+++ b/components/hal/esp32s3/efuse_hal.c
@@ -5,7 +5,7 @@
  */
 
 #include "sdkconfig.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/soc_caps.h"
 #include "hal/assert.h"
 #include "hal/efuse_hal.h"

--- a/components/hal/esp32s3/include/hal/gpspi_flash_ll.h
+++ b/components/hal/esp32s3/include/hal/gpspi_flash_ll.h
@@ -19,7 +19,7 @@
 #include "soc/spi_struct.h"
 #include "hal/spi_types.h"
 #include "hal/spi_flash_types.h"
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 #include "hal/misc.h"

--- a/components/hal/esp32s3/include/hal/mspi_timing_tuning_ll.h
+++ b/components/hal/esp32s3/include/hal/mspi_timing_tuning_ll.h
@@ -14,7 +14,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_bit_defs.h"
 #include "hal/assert.h"
 #include "soc/soc.h"

--- a/components/hal/esp32s3/include/hal/spimem_flash_ll.h
+++ b/components/hal/esp32s3/include/hal/spimem_flash_ll.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <stdlib.h>
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <string.h>
 

--- a/components/hal/mmu_hal.c
+++ b/components/hal/mmu_hal.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include "sdkconfig.h"

--- a/components/hal/systimer_hal.c
+++ b/components/hal/systimer_hal.c
@@ -5,7 +5,7 @@
  */
 
 #include <stddef.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/soc_caps.h"
 #include "hal/systimer_hal.h"
 #include "hal/systimer_ll.h"

--- a/components/heap/heap_caps.c
+++ b/components/heap/heap_caps.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stdio.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_attr.h"
 #include "esp_heap_caps.h"
 #include "multi_heap.h"

--- a/components/heap/multi_heap_poisoning.c
+++ b/components/heap/multi_heap_poisoning.c
@@ -10,7 +10,7 @@
 #include <string.h>
 #include <stddef.h>
 #include <stdio.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <multi_heap.h>
 #include "multi_heap_internal.h"
 

--- a/components/mbedtls/port/dynamic/esp_ssl_cli.c
+++ b/components/mbedtls/port/dynamic/esp_ssl_cli.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include "esp_mbedtls_dynamic_impl.h"
 

--- a/components/mbedtls/port/dynamic/esp_ssl_srv.c
+++ b/components/mbedtls/port/dynamic/esp_ssl_srv.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_mbedtls_dynamic_impl.h"
 
 int __real_mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl);

--- a/components/mbedtls/port/dynamic/esp_ssl_tls.c
+++ b/components/mbedtls/port/dynamic/esp_ssl_tls.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "mbedtls/error.h"
 #include "esp_mbedtls_dynamic_impl.h"
 

--- a/components/mbedtls/port/esp32/bignum.c
+++ b/components/mbedtls/port/esp32/bignum.c
@@ -13,7 +13,7 @@
 #include "esp_private/periph_ctrl.h"
 #include <mbedtls/bignum.h>
 #include "bignum_impl.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <sys/lock.h>
 
 static _lock_t mpi_lock;

--- a/components/mbedtls/port/esp32c3/bignum.c
+++ b/components/mbedtls/port/esp32c3/bignum.c
@@ -9,7 +9,7 @@
  * SPDX-FileContributor: 2016-2022 Espressif Systems (Shanghai) CO LTD
  */
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/hwcrypto_periph.h"
 #include "esp_private/periph_ctrl.h"
 #include "mbedtls/bignum.h"

--- a/components/mbedtls/port/esp32c6/bignum.c
+++ b/components/mbedtls/port/esp32c6/bignum.c
@@ -9,7 +9,7 @@
  * SPDX-FileContributor: 2023 Espressif Systems (Shanghai) CO LTD
  */
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/hwcrypto_periph.h"
 #include "esp_private/periph_ctrl.h"
 #include "mbedtls/bignum.h"

--- a/components/mbedtls/port/esp32h2/bignum.c
+++ b/components/mbedtls/port/esp32h2/bignum.c
@@ -9,7 +9,7 @@
  * SPDX-FileContributor: 2023 Espressif Systems (Shanghai) CO LTD
  */
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "soc/hwcrypto_periph.h"
 #include "esp_private/periph_ctrl.h"
 #include "mbedtls/bignum.h"

--- a/components/mbedtls/port/esp32s2/bignum.c
+++ b/components/mbedtls/port/esp32s2/bignum.c
@@ -14,7 +14,7 @@
 #include "bignum_impl.h"
 #include "soc/dport_reg.h"
 #include "soc/periph_defs.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_crypto_lock.h"
 
 size_t esp_mpi_hardware_words(size_t words)

--- a/components/mbedtls/port/esp32s3/bignum.c
+++ b/components/mbedtls/port/esp32s3/bignum.c
@@ -15,7 +15,7 @@
 #include "soc/dport_reg.h"
 #include "soc/system_reg.h"
 #include "soc/periph_defs.h"
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_crypto_lock.h"
 
 size_t esp_mpi_hardware_words(size_t words)

--- a/components/mbedtls/port/esp_bignum.c
+++ b/components/mbedtls/port/esp_bignum.c
@@ -14,7 +14,7 @@
 #include <limits.h>
 #include <assert.h>
 #include <stdlib.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "esp_system.h"
 #include "esp_log.h"

--- a/components/newlib/assert.c
+++ b/components/newlib/assert.c
@@ -5,7 +5,7 @@
  */
 
 #include <string.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "esp_system.h"
 #include "spi_flash_mmap.h"
 #include "soc/soc_memory_layout.h"

--- a/components/newlib/poll.c
+++ b/components/newlib/poll.c
@@ -8,7 +8,7 @@
 #include <sys/poll.h>
 #include <sys/select.h>
 #include <sys/errno.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 int poll(struct pollfd *fds, nfds_t nfds, int timeout)
 {

--- a/components/newlib/random.c
+++ b/components/newlib/random.c
@@ -5,7 +5,7 @@
  */
 
 #include <sys/random.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <assert.h>
 #include <errno.h>
 #include <string.h>

--- a/components/newlib/realpath.c
+++ b/components/newlib/realpath.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 /* realpath logic:
  * 1. prepend CWD (/)

--- a/components/riscv/include/riscv/csr.h
+++ b/components/riscv/include/riscv/csr.h
@@ -34,7 +34,7 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include "encoding.h"
 #include "esp_assert.h"
 

--- a/components/spi_flash/esp_flash_api.c
+++ b/components/spi_flash/esp_flash_api.c
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 #include <string.h>
 
 #include <zephyr/kernel.h>

--- a/components/spi_flash/flash_ops.c
+++ b/components/spi_flash/flash_ops.c
@@ -8,7 +8,7 @@
 #include <assert.h>
 #include <string.h>
 #include <stdio.h>
-#include <sys/param.h>  // For MIN/MAX(a, b)
+#include <zephyr/sys/util.h>
 
 #include <zephyr/kernel.h>
 #include <soc/soc.h>

--- a/components/spi_flash/spi_flash_chip_gd.c
+++ b/components/spi_flash/spi_flash_chip_gd.c
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include "esp_log.h"
 #include "spi_flash_chip_generic.h"
 #include "spi_flash_chip_gd.h"

--- a/components/spi_flash/spi_flash_chip_generic.c
+++ b/components/spi_flash/spi_flash_chip_generic.c
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include "spi_flash_chip_generic.h"
 #include "spi_flash_defs.h"
 #include "hal/spi_flash_encrypt_hal.h"

--- a/components/spi_flash/spi_flash_chip_mxic_opi.c
+++ b/components/spi_flash/spi_flash_chip_mxic_opi.c
@@ -9,7 +9,7 @@
 #include "spi_flash_defs.h"
 #include "esp_log.h"
 #include "string.h"
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include "hal/spi_flash_hal.h"
 
 #define CMD_OPI_FLASH_MXIC(cmd)              ((((~(cmd) & 0xff) << 8)) | ((cmd) & 0xff))

--- a/components/spi_flash/spi_flash_chip_winbond.c
+++ b/components/spi_flash/spi_flash_chip_winbond.c
@@ -14,7 +14,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <sys/param.h> // For MIN/MAX
+#include <zephyr/sys/util.h>
 #include "esp_log.h"
 #include "spi_flash_chip_generic.h"
 #include "spi_flash_defs.h"

--- a/components/spi_flash/spi_flash_os_func_app.c
+++ b/components/spi_flash/spi_flash_os_func_app.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdarg.h>
-#include <sys/param.h>  //For max/min
+#include <zephyr/sys/util.h>  //For max/min
 #include "esp_attr.h"
 #include "esp_private/system_internal.h"
 #include "esp_flash.h"

--- a/zephyr/esp32s3/src/soc_flash_init.c
+++ b/zephyr/esp32s3/src/soc_flash_init.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <sys/param.h>
+#include <zephyr/sys/util.h>
 
 #include "flash_init.h"
 #include "soc_flash_init.h"


### PR DESCRIPTION
Use Zephyr's MIN/MAX defines from <zephyr/sys/util.h> instead.

Fixes #97074