### PR TITLE
wifi: esp32: fix build failure with CONFIG_WIFI_LOG_LEVEL_DBG=y

### DIFF
--- a/components/esp_wifi/esp32c2/esp_adapter.c
+++ b/components/esp_wifi/esp32c2/esp_adapter.c
@@ -679,7 +679,8 @@ static void esp_phy_disable_wrapper(void)
 static void esp_log_writev_wrapper(uint32_t level, const char *tag, const char *format, va_list args)
 {
 #if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
-    esp_log_writev((esp_log_level_t)level, tag, format, args);
+    esp_rom_printf("%s: ", tag);
+    esp_rom_vprintf(format, args);
 #endif
 }
 
@@ -688,7 +689,8 @@ static void esp_log_write_wrapper(uint32_t level, const char *tag, const char *f
 #if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
     va_list list;
     va_start(list, format);
-    esp_log_writev((esp_log_level_t)level, tag, format, list);
+    esp_rom_printf("%s: ", tag);
+    esp_rom_vprintf(format, list);
     va_end(list);
 #endif
 }

--- a/components/esp_wifi/esp32c3/esp_adapter.c
+++ b/components/esp_wifi/esp32c3/esp_adapter.c
@@ -608,7 +608,8 @@ int32_t nvs_erase_key(uint32_t handle, const char *key)
 static void esp_log_writev_wrapper(uint32_t level, const char *tag, const char *format, va_list args)
 {
 #if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
-    esp_log_writev((esp_log_level_t)level, tag, format, args);
+    esp_rom_printf("%s: ", tag);
+    esp_rom_vprintf(format, args);
 #endif
 }
 
@@ -617,7 +618,8 @@ static void esp_log_write_wrapper(uint32_t level, const char *tag, const char *f
 #if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
     va_list list;
     va_start(list, format);
-    esp_log_writev((esp_log_level_t)level, tag, format, list);
+    esp_rom_printf("%s: ", tag);
+    esp_rom_vprintf(format, list);
     va_end(list);
 #endif
 }

--- a/components/esp_wifi/esp32c5/esp_adapter.c
+++ b/components/esp_wifi/esp32c5/esp_adapter.c
@@ -601,7 +601,8 @@ int32_t nvs_erase_key(uint32_t handle, const char *key)
 static void esp_log_writev_wrapper(uint32_t level, const char *tag, const char *format, va_list args)
 {
 #if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
-    esp_log_writev((esp_log_level_t)level, tag, format, args);
+    esp_rom_printf("%s: ", tag);
+    esp_rom_vprintf(format, args);
 #endif
 }
 
@@ -610,7 +611,8 @@ static void esp_log_write_wrapper(uint32_t level, const char *tag, const char *f
 #if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
     va_list list;
     va_start(list, format);
-    esp_log_writev((esp_log_level_t)level, tag, format, list);
+    esp_rom_printf("%s: ", tag);
+    esp_rom_vprintf(format, list);
     va_end(list);
 #endif
 }

--- a/components/esp_wifi/esp32c6/esp_adapter.c
+++ b/components/esp_wifi/esp32c6/esp_adapter.c
@@ -601,7 +601,8 @@ int32_t nvs_erase_key(uint32_t handle, const char *key)
 static void esp_log_writev_wrapper(uint32_t level, const char *tag, const char *format, va_list args)
 {
 #if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
-    esp_log_writev((esp_log_level_t)level, tag, format, args);
+    esp_rom_printf("%s: ", tag);
+    esp_rom_vprintf(format, args);
 #endif
 }
 
@@ -610,7 +611,8 @@ static void esp_log_write_wrapper(uint32_t level, const char *tag, const char *f
 #if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
     va_list list;
     va_start(list, format);
-    esp_log_writev((esp_log_level_t)level, tag, format, list);
+    esp_rom_printf("%s: ", tag);
+    esp_rom_vprintf(format, list);
     va_end(list);
 #endif
 }


### PR DESCRIPTION
esp32c2, esp32c3, esp32c5, and esp32c6 variants of esp_adapter.c called esp_log_writev() in esp_log_writev_wrapper() and esp_log_write_wrapper(), but this function is not available in the Zephyr HAL shim.

Replace the calls with esp_rom_printf()/esp_rom_vprintf() which are already declared via the existing esp_rom_sys.h include and are available on all ESP32 variants.

Fixes zephyrproject-rtos/zephyr#106322