### PR TITLE
esp32s3: fix missing SPIRAM octal 80 MHz source

### DIFF
--- a/zephyr/common/flash_init.c
+++ b/zephyr/common/flash_init.c
@@ -8,6 +8,9 @@
 
 #include <stdbool.h>
 #include <bootloader_flash_priv.h>
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+#include <bootloader_flash_config.h>
+#endif
 #include <esp_flash_internal.h>
 #include <esp_private/mspi_timing_tuning.h>
 #include <esp_private/esp_mmu_map_private.h>
@@ -53,6 +56,16 @@ void esp_flash_config(void)
 	spi_flash_init_chip_state();
 
 	esp_mspi_pin_init();
+
+	/*
+	 * Re-apply CS timing after spi_flash_init_chip_state() may have
+	 * switched flash to OPI mode.  The simple bootloader sets CS timing
+	 * for non-octal; OPI flash needs larger hold/setup values.
+	 * With MCUboot, the bootloader already configures CS timing.
+	 */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+	bootloader_flash_cs_timing_config();
+#endif
 
 	/*
 	 * Flash timing tuning must run right after spi_flash_init_chip_state()

--- a/zephyr/common/flash_init.c
+++ b/zephyr/common/flash_init.c
@@ -8,9 +8,7 @@
 
 #include <stdbool.h>
 #include <bootloader_flash_priv.h>
-#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
 #include <bootloader_flash_config.h>
-#endif
 #include <esp_flash_internal.h>
 #include <esp_private/mspi_timing_tuning.h>
 #include <esp_private/esp_mmu_map_private.h>
@@ -57,15 +55,7 @@ void esp_flash_config(void)
 
 	esp_mspi_pin_init();
 
-	/*
-	 * Re-apply CS timing after spi_flash_init_chip_state() may have
-	 * switched flash to OPI mode.  The simple bootloader sets CS timing
-	 * for non-octal; OPI flash needs larger hold/setup values.
-	 * With MCUboot, the bootloader already configures CS timing.
-	 */
-#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
 	bootloader_flash_cs_timing_config();
-#endif
 
 	/*
 	 * Flash timing tuning must run right after spi_flash_init_chip_state()

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -237,7 +237,6 @@ if(CONFIG_SOC_SERIES_ESP32)
       ../../components/esp_psram/${CONFIG_SOC_SERIES}/esp_psram_impl_quad.c
       ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/cache_sram_mmu.c
       ../../components/esp_psram/${CONFIG_SOC_SERIES}/esp_psram_extram_cache.c
-      ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
       )
   endif()
 
@@ -282,7 +281,6 @@ if(CONFIG_SOC_SERIES_ESP32)
       ../../components/esp_hw_support/sleep_uart.c
       ../../components/esp_hw_support/clk_utils.c
       ../../components/esp_hal_touch_sens/touch_sens_hal.c
-      ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
       )
   endif()
 
@@ -346,6 +344,7 @@ if(CONFIG_SOC_SERIES_ESP32)
   endif()
 
   zephyr_sources(
+    ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
     ../../components/bootloader_support/src/bootloader_efuse.c
     ../../components/esp_driver_gpio/src/rtc_io.c
     ../../components/esp_hal_clock/${CONFIG_SOC_SERIES}/clk_tree_hal.c

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -235,6 +235,7 @@ if(CONFIG_SOC_SERIES_ESP32C2)
   endif()
 
   zephyr_sources(
+    ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
     ../../components/esp_driver_gpio/src/rtc_io.c
     ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/temperature_sensor_periph.c
     ../../components/esp_hal_ana_conv/temperature_sensor_hal.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -308,6 +308,7 @@ if(CONFIG_SOC_SERIES_ESP32C3)
   endif()
 
   zephyr_sources(
+    ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
     ../../components/esp_driver_gpio/src/rtc_io.c
     ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/temperature_sensor_periph.c
     ../../components/esp_hal_ana_conv/temperature_sensor_hal.c

--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -314,6 +314,7 @@ if(CONFIG_SOC_SERIES_ESP32C5)
   endif()
 
   zephyr_sources_ifdef(CONFIG_SOC_ESP32C5_HPCORE
+    ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
     ../../components/esp_driver_gpio/src/rtc_io.c
     ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/temperature_sensor_periph.c
     ../../components/esp_hal_ana_conv/temperature_sensor_hal.c

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -290,6 +290,7 @@ if(CONFIG_SOC_SERIES_ESP32C6)
   endif()
 
   zephyr_sources_ifdef(CONFIG_SOC_ESP32C6_HPCORE
+    ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
     ../../components/esp_driver_gpio/src/rtc_io.c
     ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/temperature_sensor_periph.c
     ../../components/esp_hal_ana_conv/temperature_sensor_hal.c

--- a/zephyr/esp32h2/CMakeLists.txt
+++ b/zephyr/esp32h2/CMakeLists.txt
@@ -218,6 +218,7 @@ if(CONFIG_SOC_SERIES_ESP32H2)
   endif()
 
   zephyr_sources_ifdef(CONFIG_SOC_ESP32H2
+    ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
     ../../components/esp_driver_gpio/src/rtc_io.c
     ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/temperature_sensor_periph.c
     ../../components/esp_hal_ana_conv/temperature_sensor_hal.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -341,6 +341,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     ../../components/esp_hw_support/adc_share_hw_ctrl.c
     ../../components/esp_hw_support/clk_ctrl_os.c
     ../../components/esp_hw_support/cpu.c
+    ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
     ../../components/esp_hw_support/esp_clk.c
     ../../components/esp_hw_support/esp_memory_utils.c
     ../../components/esp_hw_support/hw_random.c

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -405,6 +405,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     ../../components/esp_hw_support/mac_addr.c
     ../../components/esp_hw_support/mspi/mspi_timing_tuning/mspi_timing_tuning.c
     ../../components/esp_hw_support/mspi/mspi_timing_tuning/port/${CONFIG_SOC_SERIES}/mspi_timing_config.c
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/port/${CONFIG_SOC_SERIES}/mspi_timing_by_mspi_delay.c
     ../../components/esp_hw_support/periph_ctrl.c
     ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/cpu_region_protect.c
     ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/esp_clk_tree.c

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -376,7 +376,6 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       ../../components/bootloader_support/src/bootloader_clock_init.c
       ../../components/esp_hal_security/mpu_hal.c
       ../../components/bootloader_support/bootloader_flash/src/flash_qio_mode.c
-      ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
       ../common/console_init.c
       ../common/soc_init.c
       )
@@ -387,6 +386,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
   endif()
 
   zephyr_sources(
+    ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
     ../../components/esp_driver_gpio/src/rtc_io.c
     ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/temperature_sensor_periph.c
     ../../components/esp_hal_ana_conv/temperature_sensor_hal.c

--- a/zephyr/esp32s3/src/soc_init.c
+++ b/zephyr/esp32s3/src/soc_init.c
@@ -152,6 +152,18 @@ void bootloader_clock_configure(void)
 	rtc_clk_xtal_freq_update(CONFIG_XTAL_FREQ);
 	rtc_clk_apb_freq_update(CONFIG_XTAL_FREQ * MHZ(1));
 
+	/*
+	 * Switch CPU to PLL so that flash and PSRAM MSPI timing
+	 * tuning works correctly. The MSPI core clock is derived
+	 * from PLL (480 MHz) and must be active before any timing
+	 * tuning runs.
+	 */
+	rtc_cpu_freq_config_t pll_cfg;
+
+	if (rtc_clk_cpu_freq_mhz_to_config(CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ, &pll_cfg)) {
+		rtc_clk_cpu_freq_set_config(&pll_cfg);
+	}
+
 	REG_WRITE(RTC_CNTL_INT_ENA_REG, 0);
 	REG_WRITE(RTC_CNTL_INT_CLR_REG, UINT32_MAX);
 }


### PR DESCRIPTION
Add the missing source file to the build, enable PLL in bootloader_clock_configure before flash/PSRAM init, and call bootloader_flash_cs_timing_config() after flash mode detection.