### PR TITLE
critical_section: make esp_os_spinlock_t nest-safe and smp-ready

### DIFF
--- a/components/bt/controller/esp32/bt.c
+++ b/components/bt/controller/esp32/bt.c
@@ -26,6 +26,7 @@
 #include "esp_log.h"
 #include "esp_private/esp_clk.h"
 #include "esp_private/periph_ctrl.h"
+#include "esp_private/critical_section.h"
 #include "soc/rtc.h"
 #include "soc/soc_memory_layout.h"
 #include "soc/dport_reg.h"
@@ -409,8 +410,7 @@ static DRAM_ATTR struct osi_funcs_t *osi_funcs_p;
 static DRAM_ATTR int64_t s_time_phy_rf_just_enabled = 0;
 static DRAM_ATTR esp_bt_controller_status_t btdm_controller_status = ESP_BT_CONTROLLER_STATUS_IDLE;
 
-static unsigned int global_int_lock;
-static unsigned int global_nested_counter = 0;
+static esp_os_spinlock_t global_int_lock = ESP_OS_SPINLOCK_INIT;
 
 // BT library uses a single task
 K_THREAD_STACK_DEFINE(bt_stack, CONFIG_ESP32_BT_CONTROLLER_STACK_SIZE);
@@ -507,18 +507,12 @@ static void IRAM_ATTR interrupt_hlevel_restore(void)
 
 static void IRAM_ATTR interrupt_l3_disable(void)
 {
-    if (global_nested_counter == 0) {
-        global_int_lock = irq_lock();
-    }
-    global_nested_counter++;
+    esp_os_enter_critical(&global_int_lock);
 }
 
 static void IRAM_ATTR interrupt_l3_restore(void)
 {
-    global_nested_counter--;
-    if (global_nested_counter == 0) {
-        irq_unlock(global_int_lock);
-    }
+    esp_os_exit_critical(&global_int_lock);
 }
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)

--- a/components/bt/controller/esp32c3/bt.c
+++ b/components/bt/controller/esp32c3/bt.c
@@ -32,6 +32,7 @@
 #include "esp_timer.h"
 #include "esp_rom_sys.h"
 #include "esp_rom_gpio.h"
+#include "esp_private/critical_section.h"
 
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
@@ -478,8 +479,7 @@ static DRAM_ATTR struct osi_funcs_t *osi_funcs_p;
 /* Static variable declare */
 static DRAM_ATTR esp_bt_controller_status_t btdm_controller_status = ESP_BT_CONTROLLER_STATUS_IDLE;
 
-static DRAM_ATTR unsigned int global_int_mux;
-static DRAM_ATTR unsigned int global_nested_counter = 0;
+static DRAM_ATTR esp_os_spinlock_t global_int_mux = ESP_OS_SPINLOCK_INIT;
 
 // low power control struct
 static DRAM_ATTR btdm_lpcntl_t s_lp_cntl;
@@ -880,18 +880,12 @@ static int interrupt_disable_wrapper(void *handle)
 
 static void IRAM_ATTR global_interrupt_disable(void)
 {
-    if (global_nested_counter == 0) {
-        global_int_mux = irq_lock();
-    }
-    global_nested_counter++;
+    esp_os_enter_critical(&global_int_mux);
 }
 
 static void IRAM_ATTR global_interrupt_restore(void)
 {
-    global_nested_counter--;
-    if (global_nested_counter == 0) {
-        irq_unlock(global_int_mux);
-    }
+    esp_os_exit_critical(&global_int_mux);
 }
 
 static void IRAM_ATTR task_yield_wrapper(void)

--- a/components/bt/porting/npl/zephyr/src/npl_os_zephyr.c
+++ b/components/bt/porting/npl/zephyr/src/npl_os_zephyr.c
@@ -17,8 +17,9 @@
 #include "os/os_mempool.h"
 #include "esp_bt.h"
 #include "bt_osi_mem.h"
+#include "esp_private/critical_section.h"
 
-static unsigned int ble_port_lock_key;
+static esp_os_spinlock_t ble_port_lock = ESP_OS_SPINLOCK_INIT;
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(esp32_ble_npl, CONFIG_LOG_DEFAULT_LEVEL);
@@ -584,35 +585,33 @@ void IRAM_ATTR npl_zephyr_time_delay(ble_npl_time_t ticks)
     k_sleep(K_TICKS(ticks));
 }
 
-uint8_t hw_critical_state_status = 0;
-
 uint32_t IRAM_ATTR npl_zephyr_hw_enter_critical(void)
 {
-    if (hw_critical_state_status == 0) {
-        ble_port_lock_key = irq_lock();
-    }
-
-    if (hw_critical_state_status < 0xFF) {
-        hw_critical_state_status++;
-    }
-
+    esp_os_enter_critical(&ble_port_lock);
     return 0;
 }
 
 uint8_t IRAM_ATTR npl_zephyr_hw_is_in_critical(void)
 {
-    return hw_critical_state_status;
+    /* NimBLE's OS_ASSERT_CRITICAL() needs a same-core answer: is this
+     * CPU inside the lock, not "any CPU". On SMP, use atomic_get on
+     * owner_cpu for a properly fenced read; on UP, count > 0 is
+     * sufficient. Clamp at 0xFF to preserve the old uint8_t semantics.
+     */
+#ifdef CONFIG_SMP
+    if (atomic_get(&ble_port_lock.owner_cpu) != (atomic_val_t)esp_cpu_get_core_id()) {
+        return 0;
+    }
+#endif
+    uint32_t depth = ble_port_lock.count;
+
+    return (depth >= 0xFF) ? 0xFF : (uint8_t)depth;
 }
 
 void IRAM_ATTR npl_zephyr_hw_exit_critical(uint32_t ctx)
 {
-    if (hw_critical_state_status > 0) {
-        hw_critical_state_status--;
-    }
-
-    if (hw_critical_state_status == 0) {
-        irq_unlock(ble_port_lock_key);
-    }
+    ARG_UNUSED(ctx);
+    esp_os_exit_critical(&ble_port_lock);
 }
 
 uint32_t IRAM_ATTR npl_zephyr_get_time_forever(void)

--- a/components/esp_driver_dac/dac_priv_common.h
+++ b/components/esp_driver_dac/dac_priv_common.h
@@ -10,18 +10,19 @@
 #include "hal/dac_types.h"
 #include "hal/dac_ll.h"
 #include "esp_err.h"
+#include "esp_private/critical_section.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern int rtc_spinlock;  /*!< Extern global rtc spinlock */
+extern esp_os_spinlock_t rtc_spinlock;  /*!< Extern global rtc spinlock */
 
-#define DAC_RTC_ENTER_CRITICAL()         do { rtc_spinlock = irq_lock(); } while(0)
-#define DAC_RTC_EXIT_CRITICAL()          irq_unlock(rtc_spinlock)
+#define DAC_RTC_ENTER_CRITICAL()         esp_os_enter_critical(&rtc_spinlock)
+#define DAC_RTC_EXIT_CRITICAL()          esp_os_exit_critical(&rtc_spinlock)
 
-#define DAC_RTC_ENTER_CRITICAL_SAFE()    DAC_RTC_ENTER_CRITICAL()
-#define DAC_RTC_EXIT_CRITICAL_SAFE()     DAC_RTC_EXIT_CRITICAL()
+#define DAC_RTC_ENTER_CRITICAL_SAFE()    esp_os_enter_critical_safe(&rtc_spinlock)
+#define DAC_RTC_EXIT_CRITICAL_SAFE()     esp_os_exit_critical_safe(&rtc_spinlock)
 
 #define DAC_NULL_POINTER_CHECK(p)     ESP_RETURN_ON_FALSE((p), ESP_ERR_INVALID_ARG, TAG, "input parameter '"#p"' is NULL")
 #define DAC_NULL_POINTER_CHECK_ISR(p) ESP_RETURN_ON_FALSE_ISR((p), ESP_ERR_INVALID_ARG, TAG, "input parameter '"#p"' is NULL")

--- a/components/esp_driver_gpio/src/gpio.c
+++ b/components/esp_driver_gpio/src/gpio.c
@@ -18,6 +18,7 @@
 #include "esp_check.h"
 #include "hal/gpio_hal.h"
 #include "esp_private/io_mux.h"
+#include "esp_private/critical_section.h"
 
 #if (SOC_RTCIO_PIN_COUNT > 0)
 #include "hal/rtc_io_hal.h"
@@ -30,8 +31,8 @@ static const char *GPIO_TAG = "gpio";
 
 extern uint32_t esp_core_id(void);
 #define ESP_CORE_ID() esp_core_id()
-#define GPIO_ENTER_CRITICAL()    do { gpio_context.gpio_spinlock = irq_lock(); } while(0)
-#define GPIO_EXIT_CRITICAL()     irq_unlock(gpio_context.gpio_spinlock)
+#define GPIO_ENTER_CRITICAL()    esp_os_enter_critical(&gpio_context.gpio_spinlock)
+#define GPIO_EXIT_CRITICAL()     esp_os_exit_critical(&gpio_context.gpio_spinlock)
 
 #define MALLOC_CAP_INTERNAL 0
 #define MALLOC_CAP_DEFAULT 0
@@ -65,7 +66,7 @@ typedef struct {
 
 typedef struct {
     gpio_hal_context_t *gpio_hal;
-    int gpio_spinlock;
+    esp_os_spinlock_t gpio_spinlock;
     uint32_t isr_core_id;
     gpio_isr_func_t *gpio_isr_func;
     gpio_isr_handle_t gpio_isr_handle;
@@ -78,7 +79,7 @@ static gpio_hal_context_t _gpio_hal = {
 
 static gpio_context_t gpio_context = {
     .gpio_hal = &_gpio_hal,
-    .gpio_spinlock = 0,
+    .gpio_spinlock = ESP_OS_SPINLOCK_INIT,
     .isr_core_id = GPIO_ISR_CORE_ID_UNINIT,
     .gpio_isr_func = NULL,
     .isr_clr_on_entry_mask = 0,

--- a/components/esp_driver_gpio/src/rtc_io.c
+++ b/components/esp_driver_gpio/src/rtc_io.c
@@ -10,6 +10,7 @@
 #include "esp_check.h"
 #include "esp_private/periph_ctrl.h"
 #include "esp_private/io_mux.h"
+#include "esp_private/critical_section.h"
 #include <zephyr/kernel.h>
 #include "driver/rtc_io.h"
 #include "driver/lp_io.h"
@@ -26,9 +27,9 @@
 static const char __attribute__((__unused__)) *RTCIO_TAG = "RTCIO";
 
 #if SOC_RTCIO_PIN_COUNT > 0
-static unsigned int rtc_spinlock;
-#define RTCIO_ENTER_CRITICAL()  do { rtc_spinlock = irq_lock(); } while(0)
-#define RTCIO_EXIT_CRITICAL()   irq_unlock(rtc_spinlock)
+static esp_os_spinlock_t s_rtcio_spinlock = ESP_OS_SPINLOCK_INIT;
+#define RTCIO_ENTER_CRITICAL()  esp_os_enter_critical(&s_rtcio_spinlock)
+#define RTCIO_EXIT_CRITICAL()   esp_os_exit_critical(&s_rtcio_spinlock)
 #endif
 
 bool rtc_gpio_is_valid_gpio(gpio_num_t gpio_num)

--- a/components/esp_hw_support/adc_share_hw_ctrl.c
+++ b/components/esp_hw_support/adc_share_hw_ctrl.c
@@ -41,7 +41,7 @@
 
 
 ESP_LOG_ATTR_TAG(TAG, "adc_share_hw_ctrl");
-extern unsigned int rtc_spinlock;
+extern esp_os_spinlock_t rtc_spinlock;
 
 
 #if SOC_ADC_CALIBRATION_V1_SUPPORTED
@@ -199,7 +199,7 @@ esp_err_t adc2_wifi_release(void)
     return ESP_OK;
 }
 
-static unsigned int __attribute__((unused)) s_spinlock = 0;
+static esp_os_spinlock_t __attribute__((unused)) s_spinlock = ESP_OS_SPINLOCK_INIT;
 
 /*------------------------------------------------------------------------------
 * For those who use APB_SARADC periph

--- a/components/esp_hw_support/clk_ctrl_os.c
+++ b/components/esp_hw_support/clk_ctrl_os.c
@@ -21,7 +21,7 @@
 ESP_LOG_ATTR_TAG(TAG, "clk_ctrl_os");
 #endif
 
-static unsigned int periph_spinlock;
+static esp_os_spinlock_t periph_spinlock = ESP_OS_SPINLOCK_INIT;
 
 static uint8_t s_periph_ref_counts = 0;
 static uint32_t s_rc_fast_freq_hz = 0; // Frequency of the RC_FAST clock in Hz

--- a/components/esp_hw_support/esp_clk.c
+++ b/components/esp_hw_support/esp_clk.c
@@ -31,7 +31,7 @@
 // g_ticks_us defined in ROMs for PRO and APP CPU
 extern uint32_t g_ticks_per_us_pro;
 
-static unsigned int s_esp_rtc_time_lock;
+static esp_os_spinlock_t s_esp_rtc_time_lock = ESP_OS_SPINLOCK_INIT;
 
 #if SOC_RTC_MEM_SUPPORTED
 typedef struct {

--- a/components/esp_hw_support/modem/include/modem/modem_clock_impl.h
+++ b/components/esp_hw_support/modem/include/modem/modem_clock_impl.h
@@ -107,7 +107,7 @@ typedef struct {
 
 typedef struct modem_clock_context {
     modem_clock_hal_context_t     *hal;
-    unsigned int                  lock;
+    esp_os_spinlock_t             lock;
     modem_clock_device_context_t  *dev;
 #if SOC_PM_SUPPORT_MODEM_CLOCK_DOMAIN_ICG
     uint8_t *icg_config;

--- a/components/esp_hw_support/modem/modem_clock.c
+++ b/components/esp_hw_support/modem/modem_clock.c
@@ -26,7 +26,7 @@ modem_clock_context_t * __attribute__((weak)) IRAM_ATTR MODEM_CLOCK_instance(voi
     /* It should be explicitly defined in the internal RAM */
     static DRAM_ATTR modem_clock_hal_context_t modem_clock_hal = { .syscon_dev = NULL, .lpcon_dev = NULL };
     static DRAM_ATTR modem_clock_context_t modem_clock_context = {
-        .hal = &modem_clock_hal, .lock = 0,
+        .hal = &modem_clock_hal, .lock = ESP_OS_SPINLOCK_INIT,
         .dev = NULL,
 #if SOC_PM_SUPPORT_MODEM_CLOCK_DOMAIN_ICG
         .icg_config = NULL,

--- a/components/esp_hw_support/periph_ctrl.c
+++ b/components/esp_hw_support/periph_ctrl.c
@@ -109,24 +109,18 @@
 
 /* For simplicity and backward compatible, we are using the same spin lock for both bus clock on/off and reset */
 /* We may want to split them into two spin locks in the future */
-static unsigned int __attribute__((unused)) periph_spinlock;
-static atomic_t rcc_lock_counter;
+static esp_os_spinlock_t periph_spinlock = ESP_OS_SPINLOCK_INIT;
 
 static uint8_t ref_counts[PERIPH_MODULE_MAX] = {0};
 
 IRAM_ATTR void periph_rcc_enter(void)
 {
-    if (atomic_inc(&rcc_lock_counter) == 0) {
-        periph_spinlock = irq_lock();
-    }
+    esp_os_enter_critical(&periph_spinlock);
 }
 
 IRAM_ATTR void periph_rcc_exit(void)
 {
-    __ASSERT_NO_MSG(atomic_get(&rcc_lock_counter) > 0);
-    if (atomic_dec(&rcc_lock_counter) == 1) {
-        irq_unlock(periph_spinlock);
-    }
+    esp_os_exit_critical(&periph_spinlock);
 }
 
 uint8_t periph_rcc_acquire_enter(shared_periph_module_t periph)

--- a/components/esp_hw_support/port/esp32/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32/sar_periph_ctrl.c
@@ -24,7 +24,7 @@
 #include "hal/adc_ll.h"
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
-extern unsigned int rtc_spinlock;
+extern esp_os_spinlock_t rtc_spinlock;
 
 
 void sar_periph_ctrl_init(void)

--- a/components/esp_hw_support/port/esp32c2/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32c2/sar_periph_ctrl.c
@@ -26,7 +26,7 @@
 #include "hal/adc_ll.h"
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
-extern unsigned int rtc_spinlock;
+extern esp_os_spinlock_t rtc_spinlock;
 
 
 void sar_periph_ctrl_init(void)

--- a/components/esp_hw_support/port/esp32c3/adc2_init_cal.c
+++ b/components/esp_hw_support/port/esp32c3/adc2_init_cal.c
@@ -14,7 +14,7 @@ Don't put any other code into this file. */
 #include "esp_private/adc_share_hw_ctrl.h"
 #include "esp_private/critical_section.h"
 
-extern unsigned int rtc_spinlock;
+extern esp_os_spinlock_t rtc_spinlock;
 
 /**
  * @brief Set initial code to ADC2 after calibration. ADC2 RTC and ADC2 PWDET controller share the initial code.

--- a/components/esp_hw_support/port/esp32c3/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32c3/sar_periph_ctrl.c
@@ -28,7 +28,7 @@
 #include "hal/temperature_sensor_ll.h"
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
-extern unsigned int rtc_spinlock;
+extern esp_os_spinlock_t rtc_spinlock;
 K_MUTEX_DEFINE(adc_reset_lock);
 
 

--- a/components/esp_hw_support/port/esp32c5/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32c5/sar_periph_ctrl.c
@@ -28,7 +28,7 @@
 #include "hal/temperature_sensor_ll.h"
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
-extern unsigned int rtc_spinlock;
+extern esp_os_spinlock_t rtc_spinlock;
 K_MUTEX_DEFINE(adc_reset_lock);
 
 void sar_periph_ctrl_init(void)

--- a/components/esp_hw_support/port/esp32c6/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32c6/sar_periph_ctrl.c
@@ -28,7 +28,7 @@
 #include "hal/temperature_sensor_ll.h"
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
-extern unsigned int rtc_spinlock;
+extern esp_os_spinlock_t rtc_spinlock;
 K_MUTEX_DEFINE(adc_reset_lock);
 
 

--- a/components/esp_hw_support/port/esp32h2/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32h2/sar_periph_ctrl.c
@@ -27,7 +27,7 @@
 #include "hal/temperature_sensor_ll.h"
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
-extern unsigned int rtc_spinlock;
+extern esp_os_spinlock_t rtc_spinlock;
 K_MUTEX_DEFINE(adc_reset_lock);
 
 

--- a/components/esp_hw_support/port/esp32s2/adc2_init_cal.c
+++ b/components/esp_hw_support/port/esp32s2/adc2_init_cal.c
@@ -14,7 +14,7 @@ Don't put any other code into this file. */
 #include "esp_private/adc_share_hw_ctrl.h"
 #include "esp_private/critical_section.h"
 
-extern unsigned int rtc_spinlock;
+extern esp_os_spinlock_t rtc_spinlock;
 
 /**
  * @brief Set initial code to ADC2 after calibration. ADC2 RTC and ADC2 PWDET controller share the initial code.

--- a/components/esp_hw_support/port/esp32s2/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32s2/sar_periph_ctrl.c
@@ -26,7 +26,7 @@
 #include "hal/adc_ll.h"
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
-extern unsigned int rtc_spinlock;
+extern esp_os_spinlock_t rtc_spinlock;
 
 
 void sar_periph_ctrl_init(void)

--- a/components/esp_hw_support/port/esp32s3/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32s3/sar_periph_ctrl.c
@@ -26,7 +26,7 @@
 #include "hal/adc_ll.h"
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
-extern unsigned int rtc_spinlock;
+extern esp_os_spinlock_t rtc_spinlock;
 
 
 void sar_periph_ctrl_init(void)

--- a/components/esp_hw_support/regi2c_ctrl.c
+++ b/components/esp_hw_support/regi2c_ctrl.c
@@ -8,15 +8,14 @@
 #include "esp_attr.h"
 #include <stdint.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys/atomic.h>
 #include <zephyr/sys/__assert.h>
+#include "esp_private/critical_section.h"
 #include "hal/regi2c_ctrl.h"
 #include "hal/regi2c_ctrl_ll.h"
 #include "esp_hw_log.h"
 #include "soc/soc_caps.h"
 
-static unsigned int regi2c_lock;
-static atomic_t regi2c_lock_counter;
+static esp_os_spinlock_t regi2c_lock = ESP_OS_SPINLOCK_INIT;
 
 ESP_HW_LOG_ATTR_TAG_DRAM(TAG, "REGI2C");
 
@@ -60,17 +59,12 @@ void regi2c_ctrl_write_reg_mask(uint8_t block, uint8_t host_id, uint8_t reg_add,
 
 void IRAM_ATTR regi2c_enter_critical(void)
 {
-    if (atomic_inc(&regi2c_lock_counter) == 0) {
-        regi2c_lock = irq_lock();
-    }
+    esp_os_enter_critical(&regi2c_lock);
 }
 
 void IRAM_ATTR regi2c_exit_critical(void)
 {
-    __ASSERT_NO_MSG(atomic_get(&regi2c_lock_counter) > 0);
-    if (atomic_dec(&regi2c_lock_counter) == 1) {
-        irq_unlock(regi2c_lock);
-    }
+    esp_os_exit_critical(&regi2c_lock);
 }
 
 /**

--- a/components/esp_hw_support/rtc_module.c
+++ b/components/esp_hw_support/rtc_module.c
@@ -31,7 +31,7 @@ ESP_LOG_ATTR_TAG(TAG, "rtc_module");
 #endif
 
 // rtc_spinlock is used by other peripheral drivers
-unsigned int rtc_spinlock;
+esp_os_spinlock_t rtc_spinlock = ESP_OS_SPINLOCK_INIT;
 
 #if SOC_LP_PERIPH_SHARE_INTERRUPT // TODO: IDF-8008
 
@@ -59,7 +59,7 @@ typedef struct rtc_isr_handler_ {
 
 static DRAM_ATTR SLIST_HEAD(rtc_isr_handler_list_, rtc_isr_handler_) s_rtc_isr_handler_list =
         SLIST_HEAD_INITIALIZER(s_rtc_isr_handler_list);
-static DRAM_ATTR unsigned int s_rtc_isr_handler_list_lock;
+static DRAM_ATTR esp_os_spinlock_t s_rtc_isr_handler_list_lock = ESP_OS_SPINLOCK_INIT;
 static intr_handle_t s_rtc_isr_handle;
 
 IRAM_ATTR static void rtc_isr(void* arg)

--- a/components/esp_hw_support/sar_tsens_ctrl.c
+++ b/components/esp_hw_support/sar_tsens_ctrl.c
@@ -19,7 +19,7 @@
 #include "esp_private/adc_share_hw_ctrl.h"
 #include "esp_private/critical_section.h"
 
-extern __attribute__((unused)) unsigned int rtc_spinlock;
+extern __attribute__((unused)) esp_os_spinlock_t rtc_spinlock;
 
 
 /*------------------------------------------------------------------------------------------------------------

--- a/components/esp_hw_support/sleep_modes.c
+++ b/components/esp_hw_support/sleep_modes.c
@@ -265,7 +265,7 @@ typedef struct {
 #if SOC_PM_SUPPORT_PMU_CLK_ICG
     int16_t clock_icg_refs[ESP_SLEEP_CLOCK_MAX];
 #endif
-    unsigned int lock;
+    esp_os_spinlock_t lock;
     uint64_t sleep_duration;
     uint32_t wakeup_triggers : 20;
 #if SOC_PM_SUPPORT_EXT1_WAKEUP
@@ -318,7 +318,7 @@ static sleep_config_t s_config = {
 #if SOC_PM_SUPPORT_PMU_CLK_ICG
     .clock_icg_refs[0 ... ESP_SLEEP_CLOCK_MAX - 1] = 0,
 #endif
-    .lock = 0,
+    .lock = ESP_OS_SPINLOCK_INIT,
     .ccount_ticks_record = 0,
     .sleep_time_overhead_out = DEFAULT_SLEEP_OUT_OVERHEAD_US,
     .wakeup_triggers = 0,
@@ -331,7 +331,7 @@ static bool s_light_sleep_wakeup = false;
 
 /* Updating RTC_MEMORY_CRC_REG register via set_rtc_memory_crc()
    is not thread-safe, so we need to disable interrupts before going to deep sleep. */
-static unsigned int __attribute__((unused)) spinlock_rtc_deep_sleep = 0;
+static esp_os_spinlock_t __attribute__((unused)) spinlock_rtc_deep_sleep = ESP_OS_SPINLOCK_INIT;
 
 ESP_LOG_ATTR_TAG(TAG, "sleep");
 

--- a/components/esp_phy/src/phy_init.c
+++ b/components/esp_phy/src/phy_init.c
@@ -87,8 +87,7 @@ static int64_t s_phy_rf_en_ts = 0;
 #endif
 
 /* PHY spinlock for libphy.a */
-static DRAM_ATTR int s_phy_int_mux;
-static atomic_t s_phy_lock_nest;
+static DRAM_ATTR esp_os_spinlock_t s_phy_int_mux = ESP_OS_SPINLOCK_INIT;
 
 /* Indicate PHY is calibrated or not */
 static bool s_is_phy_calibrated = false;
@@ -228,19 +227,14 @@ esp_err_t phy_clear_used_time(esp_phy_modem_t modem) {
 
 uint32_t IRAM_ATTR phy_enter_critical(void)
 {
-    if (atomic_inc(&s_phy_lock_nest) == 0) {
-        s_phy_int_mux = irq_lock();
-    }
+    esp_os_enter_critical(&s_phy_int_mux);
     return 0;
 }
 
 void IRAM_ATTR phy_exit_critical(uint32_t level)
 {
     (void)level;
-    __ASSERT_NO_MSG(atomic_get(&s_phy_lock_nest) > 0);
-    if (atomic_dec(&s_phy_lock_nest) == 1) {
-        irq_unlock(s_phy_int_mux);
-    }
+    esp_os_exit_critical(&s_phy_int_mux);
 }
 
 #if CONFIG_IDF_TARGET_ESP32

--- a/components/esp_phy/src/phy_init_esp32hxx.c
+++ b/components/esp_phy/src/phy_init_esp32hxx.c
@@ -6,11 +6,11 @@
 
 #include "esp_attr.h"
 #include <zephyr/kernel.h>
-#include <zephyr/sys/atomic.h>
 #include "esp_phy_init.h"
 #include "esp_private/phy.h"
 #include "esp_timer.h"
 #include "esp_private/periph_ctrl.h"
+#include "esp_private/critical_section.h"
 
 #if SOC_MODEM_CLOCK_IS_INDEPENDENT
 #include "esp_private/esp_modem_clock.h"
@@ -24,9 +24,8 @@
 
 #define PHY_ENABLE_VERSION_PRINT 1
 
-/* PHY spinlock for libphy.a - Zephyr uses irq_lock/unlock */
-static DRAM_ATTR int s_phy_int_mux;
-static atomic_t s_phy_lock_nest;
+/* PHY spinlock for libphy.a */
+static DRAM_ATTR esp_os_spinlock_t s_phy_int_mux = ESP_OS_SPINLOCK_INIT;
 
 extern void phy_version_print(void);
 K_MUTEX_DEFINE(s_phy_access_lock);
@@ -89,19 +88,14 @@ esp_err_t phy_clear_used_time(esp_phy_modem_t modem) {
 
 uint32_t IRAM_ATTR phy_enter_critical(void)
 {
-    if (atomic_inc(&s_phy_lock_nest) == 0) {
-        s_phy_int_mux = irq_lock();
-    }
+    esp_os_enter_critical(&s_phy_int_mux);
     return 0;
 }
 
 void IRAM_ATTR phy_exit_critical(uint32_t level)
 {
     (void)level;
-    __ASSERT_NO_MSG(atomic_get(&s_phy_lock_nest) > 0);
-    if (atomic_dec(&s_phy_lock_nest) == 1) {
-        irq_unlock(s_phy_int_mux);
-    }
+    esp_os_exit_critical(&s_phy_int_mux);
 }
 
 void esp_phy_enable(esp_phy_modem_t modem)

--- a/components/esp_system/include/esp_private/critical_section.h
+++ b/components/esp_system/include/esp_private/critical_section.h
@@ -13,19 +13,14 @@
  */
 #pragma once
 
-#if !NON_OS_BUILD
-#include <zephyr/kernel.h>
-#include <zephyr/irq.h>
-#endif
+#include "esp_critical_section.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/**
- * For Zephyr, we use irq_lock/irq_unlock instead of FreeRTOS spinlocks.
- */
-#define OS_SPINLOCK 0
+typedef esp_critical_section_t esp_os_spinlock_t;
+#define ESP_OS_SPINLOCK_INIT ESP_CRITICAL_SECTION_INIT
 
 /**
  * Define and initialize a static (internal linking) lock for entering critical sections.
@@ -52,12 +47,7 @@ extern "C" {
  * esp_os_exit_critical(&my_lock);
  * @endcode
  */
-#if OS_SPINLOCK == 1
-#define DEFINE_CRIT_SECTION_LOCK_STATIC(lock_name, optional_qualifiers...) static optional_qualifiers esp_os_spinlock_t lock_name = SPINLOCK_INITIALIZER
-#else
-/* For Zephyr single-core, still define the lock variable to store irq_lock state */
-#define DEFINE_CRIT_SECTION_LOCK_STATIC(lock_name, optional_qualifiers...) static optional_qualifiers unsigned int lock_name = 0
-#endif
+#define DEFINE_CRIT_SECTION_LOCK_STATIC(lock_name, optional_qualifiers...) static optional_qualifiers esp_os_spinlock_t lock_name = ESP_OS_SPINLOCK_INIT
 
 /**
  * Define and initialize a non-static (external linking) lock for entering critical sections.
@@ -85,12 +75,7 @@ extern "C" {
  * esp_os_exit_critical(&my_lock);
  * @endcode
  */
-#if OS_SPINLOCK == 1
-#define DEFINE_CRIT_SECTION_LOCK(lock_name, optional_qualifiers...) optional_qualifiers esp_os_spinlock_t lock_name = SPINLOCK_INITIALIZER
-#else
-/* For Zephyr single-core, still define the lock variable to store irq_lock state */
-#define DEFINE_CRIT_SECTION_LOCK(lock_name, optional_qualifiers...) optional_qualifiers unsigned int lock_name = 0
-#endif
+#define DEFINE_CRIT_SECTION_LOCK(lock_name, optional_qualifiers...) optional_qualifiers esp_os_spinlock_t lock_name = ESP_OS_SPINLOCK_INIT
 
 /**
  * @brief This macro initializes a critical section lock at runtime.
@@ -121,11 +106,7 @@ extern "C" {
  * };
  * @endcode
  */
-#if OS_SPINLOCK == 1
-#define INIT_CRIT_SECTION_LOCK_RUNTIME(lock_name) spinlock_initialize(lock_name)
-#else
-#define INIT_CRIT_SECTION_LOCK_RUNTIME(lock_name)
-#endif
+#define INIT_CRIT_SECTION_LOCK_RUNTIME(lock_name) do { *(lock_name) = (esp_os_spinlock_t)ESP_OS_SPINLOCK_INIT; } while (0)
 
 /**
  * @brief This macro declares a critical section lock as a member of a struct.
@@ -151,11 +132,7 @@ extern "C" {
  * };
  * @endcode
  */
-#if OS_SPINLOCK == 1
 #define DECLARE_CRIT_SECTION_LOCK_IN_STRUCT(lock_name) esp_os_spinlock_t lock_name;
-#else
-#define DECLARE_CRIT_SECTION_LOCK_IN_STRUCT(lock_name)
-#endif
 
 /**
  * @brief This macro initializes a critical section lock as a member of a struct when using an list initialization.
@@ -192,11 +169,7 @@ extern "C" {
  * };
  * @endcode
  */
-#if OS_SPINLOCK == 1
-#define INIT_CRIT_SECTION_LOCK_IN_STRUCT(lock_name) .lock_name = portMUX_INITIALIZER_UNLOCKED,
-#else
-#define INIT_CRIT_SECTION_LOCK_IN_STRUCT(lock_name)
-#endif
+#define INIT_CRIT_SECTION_LOCK_IN_STRUCT(lock_name) .lock_name = ESP_OS_SPINLOCK_INIT,
 
 /**
  * @brief Enter a critical section, i.e., a section that will not be interrupted by any other task or interrupt.
@@ -221,7 +194,7 @@ extern "C" {
  * esp_os_exit_critical(&my_lock);
  * @endcode
  */
-#define esp_os_enter_critical(lock)         do { unsigned int *_k = (unsigned int *)(lock); *_k = irq_lock(); } while(0)
+#define esp_os_enter_critical(lock)         esp_critical_section_enter(lock)
 
 /**
  * @brief Exit a critical section.
@@ -246,7 +219,7 @@ extern "C" {
  * esp_os_exit_critical(&my_lock);
  * @endcode
  */
-#define esp_os_exit_critical(lock)          irq_unlock(*(unsigned int *)(lock))
+#define esp_os_exit_critical(lock)          esp_critical_section_exit(lock)
 
 /**
  * @brief Enter a critical section while from ISR.
@@ -271,7 +244,7 @@ extern "C" {
  * esp_os_exit_critical(&my_lock);
  * @endcode
  */
-#define esp_os_enter_critical_isr(lock)     do { unsigned int *_k = (unsigned int *)(lock); *_k = irq_lock(); } while(0)
+#define esp_os_enter_critical_isr(lock)     esp_critical_section_enter(lock)
 
 /**
  * @brief Exit a critical section after entering from ISR.
@@ -296,7 +269,7 @@ extern "C" {
  * esp_os_exit_critical(&my_lock);
  * @endcode
  */
-#define esp_os_exit_critical_isr(lock)      irq_unlock(*(unsigned int *)(lock))
+#define esp_os_exit_critical_isr(lock)      esp_critical_section_exit(lock)
 
 /**
  * @brief Enter a critical section from normal task or ISR. This macro will check if the current CPU is processing
@@ -322,7 +295,7 @@ extern "C" {
  * esp_os_exit_critical(&my_lock);
  * @endcode
  */
-#define esp_os_enter_critical_safe(lock)    do { unsigned int *_k = (unsigned int *)(lock); *_k = irq_lock(); } while(0)
+#define esp_os_enter_critical_safe(lock)    esp_critical_section_enter(lock)
 
 /**
  * @brief Exit a critical section after entering via esp_os_enter_critical_safe.
@@ -347,7 +320,7 @@ extern "C" {
  * esp_os_exit_critical(&my_lock);
  * @endcode
  */
-#define esp_os_exit_critical_safe(lock)     irq_unlock(*(unsigned int *)(lock))
+#define esp_os_exit_critical_safe(lock)     esp_critical_section_exit(lock)
 
 #ifdef __cplusplus
 }

--- a/components/esp_timer/src/esp_timer.c
+++ b/components/esp_timer/src/esp_timer.c
@@ -97,7 +97,9 @@ static struct k_sem s_timer_semaphore;
 static bool s_timer_task_created = false;
 
 /* lock key for critical sections */
-static unsigned int s_timer_lock_key[ESP_TIMER_MAX];
+static esp_os_spinlock_t s_timer_lock_key[ESP_TIMER_MAX] = {
+    [0 ... ESP_TIMER_MAX - 1] = ESP_OS_SPINLOCK_INIT,
+};
 
 #ifdef CONFIG_ESP_TIMER_SUPPORTS_ISR_DISPATCH_METHOD
 // For ISR dispatch method, a callback function of the timer may require a context switch

--- a/components/esp_timer/src/esp_timer_impl_common.c
+++ b/components/esp_timer/src/esp_timer_impl_common.c
@@ -13,7 +13,7 @@
 #include "esp_private/critical_section.h"
 
 /* Spinlock used to protect access to the hardware registers. */
-unsigned int s_time_update_lock = 0;
+esp_os_spinlock_t s_time_update_lock = ESP_OS_SPINLOCK_INIT;
 
 /* Alarm values to generate interrupt on match
  * [0] - for ESP_TIMER_TASK alarms,

--- a/components/esp_timer/src/esp_timer_impl_lac.c
+++ b/components/esp_timer/src/esp_timer_impl_lac.c
@@ -85,7 +85,7 @@ static intr_handle_t s_timer_interrupt_handle[ISR_HANDLERS] = { NULL };
 static intr_handler_t s_alarm_handler = NULL;
 
 /* Spinlock used to protect access to the hardware registers. */
-extern unsigned int s_time_update_lock;
+extern esp_os_spinlock_t s_time_update_lock;
 
 /* Alarm values to generate interrupt on match */
 extern uint64_t timestamp_id[2];

--- a/components/esp_timer/src/esp_timer_impl_systimer.c
+++ b/components/esp_timer/src/esp_timer_impl_systimer.c
@@ -56,7 +56,7 @@ static intr_handler_t s_alarm_handler = NULL;
 static systimer_hal_context_t systimer_hal;
 
 /* Spinlock used to protect access to the hardware registers. */
-extern unsigned int s_time_update_lock;
+extern esp_os_spinlock_t s_time_update_lock;
 
 /* Alarm values to generate interrupt on match */
 extern uint64_t timestamp_id[2];

--- a/components/ieee802154/driver/esp_ieee802154_dev.c
+++ b/components/ieee802154/driver/esp_ieee802154_dev.c
@@ -12,6 +12,7 @@
 #include "soc/soc.h"
 #include "hal/ieee802154_periph.h"
 #include "esp_private/esp_modem_clock.h"
+#include "esp_private/critical_section.h"
 #include "esp_check.h"
 #include "esp_coex_i154.h"
 #include "esp_err.h"
@@ -71,8 +72,7 @@ static bool s_needs_next_operation = false;
 static uint8_t s_rx_index = 0;
 static uint8_t s_enh_ack_frame[128];
 static uint8_t s_recent_rx_frame_info_index;
-static unsigned int s_ieee802154_spinlock;
-static volatile int s_ieee802154_critical_nesting;
+static esp_os_spinlock_t s_ieee802154_spinlock = ESP_OS_SPINLOCK_INIT;
 static intr_handle_t s_ieee802154_isr_handle = NULL;
 
 static esp_err_t ieee802154_sleep_init(void);
@@ -736,16 +736,12 @@ static IRAM_ATTR void isr_handle_ed_done(void)
 
 IRAM_ATTR void ieee802154_enter_critical(void)
 {
-    if (s_ieee802154_critical_nesting++ == 0) {
-        s_ieee802154_spinlock = irq_lock();
-    }
+    esp_os_enter_critical(&s_ieee802154_spinlock);
 }
 
 IRAM_ATTR void ieee802154_exit_critical(void)
 {
-    if (--s_ieee802154_critical_nesting == 0) {
-        irq_unlock(s_ieee802154_spinlock);
-    }
+    esp_os_exit_critical(&s_ieee802154_spinlock);
 }
 
 IEEE802154_NOINLINE static void ieee802154_isr(void *arg)

--- a/components/spi_flash/cache_utils.c
+++ b/components/spi_flash/cache_utils.c
@@ -32,11 +32,12 @@
 #include "esp_private/esp_cache_private.h"
 #include "esp_private/cache_utils.h"
 #include "esp_private/spi_flash_os.h"
+#include "esp_private/critical_section.h"
 #include "esp_log.h"
 
 ESP_LOG_ATTR_TAG(TAG, "cache");
 
-static unsigned int s_intr_saved_state;
+static esp_os_spinlock_t s_intr_saved_state = ESP_OS_SPINLOCK_INIT;
 
 // Used only on ROM impl. in idf, this param unused, cache status hold by hal
 static uint32_t s_flash_op_cache_state[2];
@@ -61,7 +62,7 @@ void spi_flash_op_unlock(void)
 
 void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu(void)
 {
-    s_intr_saved_state = irq_lock();
+    esp_os_enter_critical(&s_intr_saved_state);
     esp_intr_noniram_disable();
     spi_flash_disable_cache(0, &s_flash_op_cache_state[0]);
 }
@@ -70,7 +71,7 @@ void IRAM_ATTR spi_flash_enable_interrupts_caches_and_other_cpu(void)
 {
     spi_flash_restore_cache(0, s_flash_op_cache_state[0]);
     esp_intr_noniram_enable();
-    irq_unlock(s_intr_saved_state);
+    esp_os_exit_critical(&s_intr_saved_state);
 }
 
 void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu_no_os(void)

--- a/zephyr/common/include/esp_critical_section.h
+++ b/zephyr/common/include/esp_critical_section.h
@@ -1,0 +1,153 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Zephyr-port implementation of the hal_espressif critical-section
+ * primitive. Included by components/esp_system/include/esp_private/
+ * critical_section.h, which keeps the pristine ESP-IDF API surface.
+ *
+ * Design
+ * ------
+ * Single-core: IRQ save/restore with a recursion counter. Outermost
+ *   enter captures the IRQ key; outermost exit restores it.
+ *
+ * SMP: recursive CAS-based spinlock over `owner_cpu`, modelled after
+ *   pristine ESP-IDF spinlock_acquire():
+ *   - Lock state lives in `owner_cpu` (ESP_CPU_UNOWNED when free).
+ *   - Outermost enter: disable IRQs, CAS(owner_cpu, UNOWNED, me), spin
+ *     on the CAS until it succeeds, save IRQ key.
+ *   - Recursive enter on the owning CPU: bump counter under local IRQ
+ *     lock; no CAS. The atomic load of owner_cpu uses SEQ_CST
+ *     ordering, so we cannot miss an ownership transfer done by
+ *     another CPU.
+ *   - Outermost exit: atomic SEQ_CST store of ESP_CPU_UNOWNED,
+ *     restore IRQs.
+ *
+ *   This does not use k_spin_lock() because Zephyr spinlocks are
+ *   non-recursive and their key type is opaque; modelling recursion
+ *   on top is racy without an atomic ownership field. Using
+ *   atomic_cas on owner_cpu with proper memory ordering gives a
+ *   correct recursive lock in one primitive.
+ *
+ * Safety
+ * ------
+ * Safe to call from task, ISR, and pre-kernel contexts. The same
+ * primitive is used for all contexts and across the pre/post-kernel
+ * boundary, so an enter before k_start_kernel() pairs correctly with
+ * an exit after it.
+ */
+
+#pragma once
+
+#include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include "esp_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Sentinel value for "no CPU owns this lock". Must not collide with any
+ * valid esp_cpu_get_core_id() return (which is [0 .. SOC_CPU_CORES_NUM-1]).
+ */
+#define ESP_CRITICAL_SECTION_UNOWNED   ((atomic_val_t)-1)
+
+typedef struct {
+    atomic_t          owner_cpu;      /* ESP_CRITICAL_SECTION_UNOWNED or owning core id */
+    unsigned int      saved_irq_key;  /* IRQ key saved at outermost enter */
+    volatile uint32_t count;          /* recursion depth, 0 when free */
+} esp_critical_section_t;
+
+#define ESP_CRITICAL_SECTION_INIT { \
+    .owner_cpu = ATOMIC_INIT(ESP_CRITICAL_SECTION_UNOWNED), \
+    .saved_irq_key = 0, \
+    .count = 0, \
+}
+
+static ALWAYS_INLINE void esp_critical_section_enter(esp_critical_section_t *l)
+{
+    unsigned int flags = arch_irq_lock();
+
+#ifdef CONFIG_SMP
+    atomic_val_t me = (atomic_val_t)esp_cpu_get_core_id();
+
+    /*
+     * Recursive fast path: if this CPU already owns the lock, bump
+     * the counter. IRQs are disabled locally so a concurrent writer
+     * on this CPU (an ISR) cannot race us on count. Cross-CPU
+     * staleness is not a concern here because owner_cpu can only
+     * equal `me` if we set it, and we haven't released yet (count
+     * has been >= 1 the whole time).
+     */
+    if (atomic_get(&l->owner_cpu) == me) {
+        l->count++;
+        return;
+    }
+
+    /*
+     * Outermost path: spin on CAS until we win ownership. Pristine
+     * ESP-IDF's spinlock_acquire uses the same pattern; Zephyr's
+     * atomic_cas provides __ATOMIC_SEQ_CST ordering, which is
+     * sufficient (and stronger than required) for correct cross-CPU
+     * handoff.
+     */
+    while (!atomic_cas(&l->owner_cpu, ESP_CRITICAL_SECTION_UNOWNED, me)) {
+        /* Busy-wait. Interrupts are off on this CPU; the holding
+         * CPU will release soon. arch_spin_relax() is a no-op on
+         * current hal_espressif targets, so it is omitted here.
+         */
+    }
+
+    /* We now exclusively own the lock. count must be 0 (invariant). */
+    __ASSERT_NO_MSG(l->count == 0);
+    l->count = 1;
+    l->saved_irq_key = flags;
+#else
+    /* Single-core: IRQ lock alone is sufficient for mutual exclusion. */
+    if (l->count++ == 0) {
+        l->saved_irq_key = flags;
+    }
+#endif
+}
+
+static ALWAYS_INLINE void esp_critical_section_exit(esp_critical_section_t *l)
+{
+    /*
+     * Release-build safety net: an unpaired exit would underflow the
+     * count and leave the lock held forever. Debug builds assert;
+     * release builds panic to surface the bug instead of deadlocking
+     * silently.
+     */
+    if (l->count == 0) {
+        __ASSERT(false, "esp_critical_section_exit: unpaired exit on %p", l);
+        k_panic();
+        return;
+    }
+
+#ifdef CONFIG_SMP
+    __ASSERT_NO_MSG(atomic_get(&l->owner_cpu) == (atomic_val_t)esp_cpu_get_core_id());
+
+    if (--l->count == 0) {
+        unsigned int flags = l->saved_irq_key;
+
+        /* SEQ_CST store: the next acquirer's atomic_cas sees all
+         * writes we made while holding the lock.
+         */
+        atomic_set(&l->owner_cpu, ESP_CRITICAL_SECTION_UNOWNED);
+        arch_irq_unlock(flags);
+    }
+#else
+    if (--l->count == 0) {
+        arch_irq_unlock(l->saved_irq_key);
+    }
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Redesign the hal_espressif critical-section primitive as a composite struct carrying a Zephyr k_spinlock, a saved IRQ key, an owner-CPU id, and a recursion counter. On single-core the primitive uses arch_irq_lock directly; on SMP it uses k_spin_lock and tracks owner_cpu so recursive acquires on the holding core skip the underlying spinlock and just bump the counter.