### PR TITLE
mbedtls: Use private/ includes for TF-PSA-Crypto legacy crypto

### DIFF
--- a/components/mbedtls/port/include/mbedtls/bignum.h
+++ b/components/mbedtls/port/include/mbedtls/bignum.h
@@ -5,13 +5,8 @@
  */
 #pragma once
 
-/* Zephyr ships mbedtls 3.6.5, which does not expose mbedtls/private/bignum.h.
- * Upstream ESP-IDF uses #include_next "mbedtls/private/bignum.h" with
- * MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS. When Zephyr upgrades to a mbedtls
- * version that provides the private/ namespace, revert this to the upstream
- * form.
- */
-#include_next "mbedtls/bignum.h"
+/* TF-PSA-Crypto exposes legacy MPI declarations under mbedtls/private/. */
+#include_next "mbedtls/private/bignum.h"
 #include "sdkconfig.h"
 
 /**

--- a/components/mbedtls/port/include/mbedtls/ecp.h
+++ b/components/mbedtls/port/include/mbedtls/ecp.h
@@ -5,13 +5,8 @@
  */
 #pragma once
 
-/* Zephyr ships mbedtls 3.6.5, which does not expose mbedtls/private/ecp.h.
- * Upstream ESP-IDF uses #include_next "mbedtls/private/ecp.h" with
- * MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS. When Zephyr upgrades to a mbedtls
- * version that provides the private/ namespace, revert this to the upstream
- * form.
- */
-#include_next "mbedtls/ecp.h"
+/* TF-PSA-Crypto exposes legacy EC declarations under mbedtls/private/. */
+#include_next "mbedtls/private/ecp.h"
 #include "sdkconfig.h"
 
 #ifdef __cplusplus

--- a/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c
+++ b/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c
@@ -5,7 +5,7 @@
  */
 #define MBEDTLS_ALLOW_PRIVATE_ACCESS
 #include "esp_system.h"
-#include "mbedtls/bignum.h"
+#include "mbedtls/private/bignum.h"
 #include "mbedtls/esp_mbedtls_random.h"
 #include "soc/soc_caps.h"
 

--- a/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-ec.c
+++ b/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-ec.c
@@ -8,7 +8,7 @@
 
 #include "esp_system.h"
 #include "esp_random.h"
-#include "mbedtls/bignum.h"
+#include "mbedtls/private/bignum.h"
 #include "mbedtls/esp_mbedtls_random.h"
 #if CONFIG_MBEDTLS_HARDWARE_ECC
 #include "ecc_impl.h"
@@ -20,7 +20,7 @@
 #include "sha256.h"
 #include "random.h"
 
-#include "mbedtls/ecp.h"
+#include "mbedtls/private/ecp.h"
 #include "mbedtls/pk.h"
 #include "mbedtls/asn1write.h"
 #include "mbedtls/error.h"

--- a/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c
+++ b/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mbedtls/bignum.h"
+#include "mbedtls/private/bignum.h"
 #include "mbedtls/esp_mbedtls_random.h"
 
 #include "utils/includes.h"

--- a/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls.c
+++ b/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls.c
@@ -15,11 +15,11 @@
 #include "random.h"
 #include "sha256.h"
 
-#include "mbedtls/ecp.h"
+#include "mbedtls/private/ecp.h"
 #include "mbedtls/md.h"
-#include "mbedtls/bignum.h"
+#include "mbedtls/private/bignum.h"
 #include "mbedtls/nist_kw.h"
-#include "mbedtls/pkcs5.h"
+#include "mbedtls/private/pkcs5.h"
 
 #include "common.h"
 #include "utils/wpabuf.h"

--- a/tools/sync/patches/mbedtls.patch
+++ b/tools/sync/patches/mbedtls.patch
@@ -66,40 +66,26 @@
  
 --- a/components/mbedtls/port/include/mbedtls/bignum.h
 +++ b/components/mbedtls/port/include/mbedtls/bignum.h
-@@ -5,8 +5,13 @@
+@@ -5,7 +5,7 @@
   */
  #pragma once
  
 -#define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
--#include_next "mbedtls/private/bignum.h"
-+/* Zephyr ships mbedtls 3.6.5, which does not expose mbedtls/private/bignum.h.
-+ * Upstream ESP-IDF uses #include_next "mbedtls/private/bignum.h" with
-+ * MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS. When Zephyr upgrades to a mbedtls
-+ * version that provides the private/ namespace, revert this to the upstream
-+ * form.
-+ */
-+#include_next "mbedtls/bignum.h"
++/* TF-PSA-Crypto exposes legacy MPI declarations under mbedtls/private/. */
+ #include_next "mbedtls/private/bignum.h"
  #include "sdkconfig.h"
  
- /**
 --- a/components/mbedtls/port/include/mbedtls/ecp.h
 +++ b/components/mbedtls/port/include/mbedtls/ecp.h
-@@ -5,8 +5,13 @@
+@@ -5,7 +5,7 @@
   */
  #pragma once
  
 -#define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
--#include_next "mbedtls/private/ecp.h"
-+/* Zephyr ships mbedtls 3.6.5, which does not expose mbedtls/private/ecp.h.
-+ * Upstream ESP-IDF uses #include_next "mbedtls/private/ecp.h" with
-+ * MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS. When Zephyr upgrades to a mbedtls
-+ * version that provides the private/ namespace, revert this to the upstream
-+ * form.
-+ */
-+#include_next "mbedtls/ecp.h"
++/* TF-PSA-Crypto exposes legacy EC declarations under mbedtls/private/. */
+ #include_next "mbedtls/private/ecp.h"
  #include "sdkconfig.h"
  
- #ifdef __cplusplus
 --- a/components/mbedtls/port/include/mbedtls/esp_config.h
 +++ b/components/mbedtls/port/include/mbedtls/esp_config.h
 @@ -606,6 +606,7 @@

--- a/tools/sync/patches/wpa_supplicant.patch
+++ b/tools/sync/patches/wpa_supplicant.patch
@@ -1,15 +1,50 @@
+--- a/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c
++++ b/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c
+@@ -5,7 +5,7 @@
+  */
+ #define MBEDTLS_ALLOW_PRIVATE_ACCESS
+ #include "esp_system.h"
+-#include "mbedtls/bignum.h"
++#include "mbedtls/private/bignum.h"
+ #include "mbedtls/esp_mbedtls_random.h"
+ #include "soc/soc_caps.h"
+ 
 --- a/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls.c
 +++ b/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls.c
-@@ -19,6 +19,7 @@
+@@ -15,10 +15,11 @@
+ #include "random.h"
+ #include "sha256.h"
+ 
+-#include "mbedtls/ecp.h"
++#include "mbedtls/private/ecp.h"
  #include "mbedtls/md.h"
- #include "mbedtls/bignum.h"
+-#include "mbedtls/bignum.h"
++#include "mbedtls/private/bignum.h"
  #include "mbedtls/nist_kw.h"
-+#include "mbedtls/pkcs5.h"
++#include "mbedtls/private/pkcs5.h"
  
  #include "common.h"
  #include "utils/wpabuf.h"
 --- a/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-ec.c
 +++ b/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-ec.c
+@@ -8,7 +8,7 @@
+ 
+ #include "esp_system.h"
+ #include "esp_random.h"
+-#include "mbedtls/bignum.h"
++#include "mbedtls/private/bignum.h"
+ #include "mbedtls/esp_mbedtls_random.h"
+ #if CONFIG_MBEDTLS_HARDWARE_ECC
+ #include "ecc_impl.h"
+@@ -20,7 +20,7 @@
+ #include "sha256.h"
+ #include "random.h"
+ 
+-#include "mbedtls/ecp.h"
++#include "mbedtls/private/ecp.h"
+ #include "mbedtls/pk.h"
+ #include "mbedtls/asn1write.h"
+ #include "mbedtls/error.h"
 @@ -1542,11 +1542,13 @@
  static psa_ecc_family_t group_id_to_psa(mbedtls_ecp_group_id grp_id, size_t *bits)
  {
@@ -274,6 +309,15 @@
  
 --- a/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c
 +++ b/components/wpa_supplicant/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c
+@@ -4,7 +4,7 @@
+  * SPDX-License-Identifier: Apache-2.0
+  */
+ 
+-#include "mbedtls/bignum.h"
++#include "mbedtls/private/bignum.h"
+ #include "mbedtls/esp_mbedtls_random.h"
+ 
+ #include "utils/includes.h"
 @@ -20,7 +20,10 @@
  // #include "mbedtls/ctr_drbg.h"
  


### PR DESCRIPTION
Align ESP-IDF port wrappers, WPA supplicant crypto, BLE SM crypto, and ROM OSI shim with TF-PSA-Crypto layout: legacy algorithm headers live under mbedtls/private/. Update the Zephyr mbedtls sync patch accordingly.

Assisted-by: Cursor: Auto