### PR TITLE
esp32p4: add soc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ system libraries.
 - ESP32-S3
 - ESP32-C2
 - ESP32-C3
+- ESP32-C5
 - ESP32-C6
 - ESP32-H2
+- ESP32-P4
 
 ## Repository Structure
 

--- a/components/esp_hal_clock/esp32p4/clk_tree_hal.c
+++ b/components/esp_hal_clock/esp32p4/clk_tree_hal.c
@@ -20,7 +20,7 @@ uint32_t clk_hal_soc_root_get_freq_mhz(soc_cpu_clk_src_t cpu_clk_src)
     case SOC_CPU_CLK_SRC_CPLL:
         return clk_ll_cpll_get_freq_mhz(clk_hal_xtal_get_freq_mhz());
     case SOC_CPU_CLK_SRC_RC_FAST:
-        return SOC_CLK_RC_FAST_FREQ_APPROX / MHZ;
+        return SOC_CLK_RC_FAST_FREQ_APPROX / MHZ(1);
     default:
         // Unknown CPU_CLK mux input
         HAL_ASSERT(false);
@@ -37,7 +37,7 @@ uint32_t clk_hal_cpu_get_freq_hz(void)
         denominator = 1;
         numerator = 0;
     }
-    return clk_hal_soc_root_get_freq_mhz(source) * MHZ * denominator / (integer * denominator + numerator);
+    return clk_hal_soc_root_get_freq_mhz(source) * MHZ(1) * denominator / (integer * denominator + numerator);
 }
 
 static uint32_t clk_hal_mem_get_freq_hz(void)

--- a/components/esp_hal_clock/esp32p4/include/hal/clk_gate_ll.h
+++ b/components/esp_hal_clock/esp32p4/include/hal/clk_gate_ll.h
@@ -28,6 +28,8 @@
 #include "soc/lpperi_reg.h"
 #include "soc/uart_reg.h"
 #include "soc/usb_dwc_struct.h"
+#include "soc/periph_defs.h"
+#include "hal/timg_ll.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -392,6 +394,78 @@ static inline void periph_ll_clk_gate_set_default(soc_reset_reason_t rst_reason,
         }
     }
 
+}
+
+static inline uint32_t periph_ll_get_clk_en_reg(shared_periph_module_t periph)
+{
+    switch (periph) {
+    case PERIPH_TIMG0_MODULE:
+    case PERIPH_TIMG1_MODULE:
+        return HP_SYS_CLKRST_SOC_CLK_CTRL2_REG;
+    case PERIPH_SYSTIMER_MODULE:
+        return HP_SYS_CLKRST_SOC_CLK_CTRL2_REG;
+    default:
+        return 0;
+    }
+}
+
+static inline uint32_t periph_ll_get_clk_en_mask(shared_periph_module_t periph)
+{
+    switch (periph) {
+    case PERIPH_TIMG0_MODULE:
+        return HP_SYS_CLKRST_REG_TIMERGRP0_APB_CLK_EN;
+    case PERIPH_TIMG1_MODULE:
+        return HP_SYS_CLKRST_REG_TIMERGRP1_APB_CLK_EN;
+    case PERIPH_SYSTIMER_MODULE:
+        return HP_SYS_CLKRST_REG_SYSTIMER_APB_CLK_EN;
+    default:
+        return 0;
+    }
+}
+
+static inline uint32_t periph_ll_get_rst_en_reg(shared_periph_module_t periph)
+{
+    (void)periph;
+    return HP_SYS_CLKRST_HP_RST_EN1_REG;
+}
+
+static inline uint32_t periph_ll_get_rst_en_mask(shared_periph_module_t periph, bool enable)
+{
+    (void)enable;
+    switch (periph) {
+    case PERIPH_TIMG0_MODULE:
+        return HP_SYS_CLKRST_REG_RST_EN_TIMERGRP0;
+    case PERIPH_TIMG1_MODULE:
+        return HP_SYS_CLKRST_REG_RST_EN_TIMERGRP1;
+    case PERIPH_SYSTIMER_MODULE:
+        return HP_SYS_CLKRST_REG_RST_EN_STIMER;
+    default:
+        return 0;
+    }
+}
+
+static inline void periph_ll_enable_clk_clear_rst(shared_periph_module_t periph)
+{
+    SET_PERI_REG_MASK(periph_ll_get_clk_en_reg(periph), periph_ll_get_clk_en_mask(periph));
+    CLEAR_PERI_REG_MASK(periph_ll_get_rst_en_reg(periph), periph_ll_get_rst_en_mask(periph, true));
+}
+
+static inline void periph_ll_disable_clk_set_rst(shared_periph_module_t periph)
+{
+    CLEAR_PERI_REG_MASK(periph_ll_get_clk_en_reg(periph), periph_ll_get_clk_en_mask(periph));
+    SET_PERI_REG_MASK(periph_ll_get_rst_en_reg(periph), periph_ll_get_rst_en_mask(periph, false));
+}
+
+static inline void periph_ll_reset(shared_periph_module_t periph)
+{
+    SET_PERI_REG_MASK(periph_ll_get_rst_en_reg(periph), periph_ll_get_rst_en_mask(periph, false));
+    CLEAR_PERI_REG_MASK(periph_ll_get_rst_en_reg(periph), periph_ll_get_rst_en_mask(periph, false));
+}
+
+static inline bool IRAM_ATTR periph_ll_periph_enabled(shared_periph_module_t periph)
+{
+    return REG_GET_BIT(periph_ll_get_rst_en_reg(periph), periph_ll_get_rst_en_mask(periph, false)) == 0 &&
+           REG_GET_BIT(periph_ll_get_clk_en_reg(periph), periph_ll_get_clk_en_mask(periph)) != 0;
 }
 
 #ifdef __cplusplus

--- a/components/esp_hal_clock/esp32p4/include/hal/clk_tree_ll.h
+++ b/components/esp_hal_clock/esp32p4/include/hal/clk_tree_ll.h
@@ -28,7 +28,9 @@
 #include "hal/efuse_hal.h"
 #include "esp_private/regi2c_ctrl.h"
 
+#ifndef MHZ
 #define MHZ                 (1000000)
+#endif
 
 #define CLK_LL_PLL_8M_FREQ_MHZ     (8)
 

--- a/components/esp_hal_dma/esp32p4/include/hal/gdma_ll.h
+++ b/components/esp_hal_dma/esp32p4/include/hal/gdma_ll.h
@@ -48,6 +48,10 @@
 #define GDMA_LL_AXI_NUM_GROUPS        1 // Number of AXI GDMA groups
 #define GDMA_LL_AXI_PAIRS_PER_GROUP   3 // Number of GDMA pairs in each AXI group
 
+/* Compat aliases for Zephyr GDMA driver (same as C5 gdma_ll.h) */
+#define GDMA_LL_M2M_FREE_PERIPH_ID_MASK          AHB_DMA_LL_M2M_FREE_PERIPH_ID_MASK
+#define gdma_ll_force_enable_reg_clock            ahb_dma_ll_force_enable_reg_clock
+
 #define GDMA_LL_PARALLEL_CRC_DATA_WIDTH 8  // Parallel CRC data width is fixed to 8bits
 #define GDMA_LL_AHB_MAX_CRC_BIT_WIDTH   32 // Max CRC bit width supported by AHB GDMA
 #define GDMA_LL_AXI_MAX_CRC_BIT_WIDTH   16 // Max CRC bit width supported by AXI GDMA

--- a/components/esp_hal_emac/emac_hal.c
+++ b/components/esp_hal_emac/emac_hal.c
@@ -396,7 +396,7 @@ esp_err_t emac_hal_ptp_start(emac_hal_context_t *hal, const emac_hal_ptp_config_
          * ———————————— = ————————————— ==> Increment = ————————————— ≈ —————————
          *   Increment        2^31                           10^9         0.465
          */
-        base_increment = config->ptp_req_accuracy_ns / 0.465;
+        base_increment = config->ptp_req_accuracy_ns / 0.465f;
     }
     emac_ll_set_ts_sub_second_incre_val(hal->ptp_regs, base_increment);
     /* Set Update Mode */

--- a/components/esp_hal_i2s/esp32p4/include/hal/lp_i2s_ll.h
+++ b/components/esp_hal_i2s/esp32p4/include/hal/lp_i2s_ll.h
@@ -658,7 +658,7 @@ static inline void lp_i2s_ll_rx_enable_msb_shift(lp_i2s_dev_t *hw, bool msb_shif
 static inline void lp_i2s_ll_read_buffer(lp_i2s_dev_t *hw, void *buffer_to_rcv, size_t byte_len)
 {
     for (int i = 0; i < byte_len; i += 4) {
-        *(uint32_t *)(buffer_to_rcv + i) = *((uint32_t *)LP_I2S_RAM_BASE);
+        *(uint32_t *)((uint8_t *)buffer_to_rcv + i) = *((uint32_t *)LP_I2S_RAM_BASE);
     }
 }
 
@@ -673,7 +673,7 @@ static inline void lp_i2s_ll_write_buffer(lp_i2s_dev_t *hw, const void *buffer_t
 {
     for (int i = 0; i < byte_len; i += 4) {
         //Use memcpy to get around alignment issues for txdata
-        *((uint32_t *)LP_I2S_RAM_BASE) = *(uint32_t *)(buffer_to_send + i);
+        *((uint32_t *)LP_I2S_RAM_BASE) = *(const uint32_t *)((const uint8_t *)buffer_to_send + i);
     }
 }
 

--- a/components/esp_hal_mspi/esp32p4/include/hal/mspi_ll.h
+++ b/components/esp_hal_mspi/esp32p4/include/hal/mspi_ll.h
@@ -658,9 +658,9 @@ static inline uint32_t mspi_timing_ll_get_invalid_dqs_mask(uint8_t spi_num)
         return REG_GET_FIELD(SPI_MEM_C_CTRL_REG, SPI_MEM_C_FDUMMY_RIN);
     } else if (spi_num == MSPI_TIMING_LL_MSPI_ID_1) {
         return REG_GET_FIELD(SPI1_MEM_C_CTRL_REG, SPI1_MEM_C_FDUMMY_RIN);
-    } else {
-        HAL_ASSERT(false);
     }
+    HAL_ASSERT(false);
+    return 0;
 }
 
 /**

--- a/components/esp_hal_uart/esp32p4/include/hal/uart_ll.h
+++ b/components/esp_hal_uart/esp32p4/include/hal/uart_ll.h
@@ -1704,6 +1704,11 @@ FORCE_INLINE_ATTR void uart_ll_discard_error_data(uart_dev_t *hw, bool discard)
     uart_ll_update(hw);
 }
 
+FORCE_INLINE_ATTR bool uart_ll_is_mode_rs485_half_duplex(uart_dev_t *hw)
+{
+    return hw->rs485_conf_sync.rs485_en && hw->conf0_sync.sw_rts;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/esp_hw_support/clk_ctrl_os.c
+++ b/components/esp_hw_support/clk_ctrl_os.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include "esp_attr.h"
 #include "clk_ctrl_os.h"
 #include "soc/rtc.h"
 #include "esp_ldo_regulator.h"
@@ -34,7 +35,7 @@ static int s_apll_ref_cnt = 0;
 static uint32_t s_cur_mpll_freq_hz = 0;
 static int s_mpll_ref_cnt = 0;
 #endif
-#if CONFIG_ESP_LDO_RESERVE_PSRAM
+#if SOC_CLK_MPLL_SUPPORTED && !CONFIG_REGULATOR_ESP32
 static esp_ldo_channel_handle_t s_ldo_chan = NULL;
 #endif
 
@@ -144,11 +145,15 @@ esp_err_t periph_rtc_apll_freq_set(uint32_t expt_freq_hz, uint32_t *real_freq_hz
 #if SOC_CLK_MPLL_SUPPORTED
 esp_err_t IRAM_ATTR periph_rtc_mpll_acquire(void)
 {
-    // power up LDO for the MPLL
-#if CONFIG_ESP_LDO_RESERVE_PSRAM
+    /* When the Zephyr esp32 regulator driver is built, it owns the
+     * PSRAM/MPLL LDO channel (boot-on, always-on). Skip the hal_espressif
+     * acquire/release path here to avoid double-enable and a release on the
+     * always-on regulator.
+     */
+#if !CONFIG_REGULATOR_ESP32
     esp_ldo_channel_config_t ldo_mpll_config = {
-        .chan_id = CONFIG_ESP_LDO_CHAN_PSRAM_DOMAIN,
-        .voltage_mv = CONFIG_ESP_LDO_VOLTAGE_PSRAM_DOMAIN,
+        .chan_id = 2,
+        .voltage_mv = 1800,
     };
     ESP_RETURN_ON_ERROR(esp_ldo_acquire_channel(&ldo_mpll_config, &s_ldo_chan), TAG, "acquire internal LDO for MPLL failed");
 #endif
@@ -165,7 +170,7 @@ esp_err_t IRAM_ATTR periph_rtc_mpll_acquire(void)
 
 void periph_rtc_mpll_release(void)
 {
-#if defined(CONFIG_ESP_LDO_CHAN_PSRAM_DOMAIN) && CONFIG_ESP_LDO_CHAN_PSRAM_DOMAIN != -1
+#if !CONFIG_REGULATOR_ESP32
     if (s_ldo_chan) {
         esp_ldo_release_channel(s_ldo_chan);
     }

--- a/components/esp_hw_support/lowpower/port/esp32p4/sleep_cpu.c
+++ b/components/esp_hw_support/lowpower/port/esp32p4/sleep_cpu.c
@@ -12,13 +12,12 @@
 
 #include "esp_attr.h"
 #include "esp_check.h"
+#include "esp_cpu.h"
 #include "esp_ipc_isr.h"
 #include "esp_sleep.h"
 #include "esp_log.h"
 #include "esp_rom_crc.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/portmacro.h"
+#include <zephyr/kernel.h>
 #include "riscv/csr.h"
 #include "soc/clic_reg.h"
 #include "soc/rtc_periph.h"
@@ -40,17 +39,17 @@
 #endif
 
 
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU && !CONFIG_FREERTOS_UNICORE
-static SPM_DRAM_ATTR smp_retention_state_t s_smp_retention_state[portNUM_PROCESSORS];
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU && CONFIG_SMP
+static SPM_DRAM_ATTR smp_retention_state_t s_smp_retention_state[CONFIG_MP_MAX_NUM_CPUS];
 #endif
 
-static bool s_fpu_saved[portNUM_PROCESSORS];
+static bool s_fpu_saved[CONFIG_MP_MAX_NUM_CPUS];
 
 ESP_LOG_ATTR_TAG(TAG, "sleep");
 
 static SPM_DRAM_ATTR __attribute__((unused)) sleep_cpu_retention_t s_cpu_retention;
 
-extern RvCoreCriticalSleepFrame *rv_core_critical_regs_frame[portNUM_PROCESSORS];
+extern RvCoreCriticalSleepFrame *rv_core_critical_regs_frame[CONFIG_MP_MAX_NUM_CPUS];
 
 FORCE_INLINE_ATTR void save_csr_disable_global_int(uint32_t *mstatus_val, uint32_t *mintthresh_val)
 {
@@ -266,6 +265,11 @@ extern void rv_core_fpu_save(RvCoreCriticalSleepFrame *frame);
 extern void rv_core_fpu_restore(RvCoreCriticalSleepFrame *frame);
 typedef uint32_t (* sleep_cpu_entry_cb_t)(uint32_t, uint32_t, uint32_t, bool);
 
+static inline SPM_IRAM_ATTR bool cpu_fpu_context_is_dirty(void)
+{
+    return (RV_READ_CSR(mstatus) & MSTATUS_FS) != 0;
+}
+
 static SPM_IRAM_ATTR esp_err_t do_cpu_retention(sleep_cpu_entry_cb_t goto_sleep,
         uint32_t wakeup_opt, uint32_t reject_opt, uint32_t lslp_mem_inf_fpu, bool dslp)
 {
@@ -276,7 +280,7 @@ static SPM_IRAM_ATTR esp_err_t do_cpu_retention(sleep_cpu_entry_cb_t goto_sleep,
     uint32_t mstatus = 0;
     uint32_t mintthresh = 0;
     save_csr_disable_global_int(&mstatus, &mintthresh);
-    s_fpu_saved[core_id] = xPortFPUContextIsDirty(core_id);
+    s_fpu_saved[core_id] = cpu_fpu_context_is_dirty();
     if (s_fpu_saved[core_id]) {
         rv_core_fpu_save(frame);
     }
@@ -289,7 +293,7 @@ static SPM_IRAM_ATTR esp_err_t do_cpu_retention(sleep_cpu_entry_cb_t goto_sleep,
 #endif
         REG_WRITE(RTC_SLEEP_WAKE_STUB_ADDR_REG, (uint32_t)rv_core_critical_regs_restore);
 
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU && !CONFIG_FREERTOS_UNICORE
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU && CONFIG_SMP
         atomic_store(&s_smp_retention_state[core_id], SMP_BACKUP_DONE);
         while (atomic_load(&s_smp_retention_state[!core_id]) != SMP_BACKUP_DONE) {
             ;
@@ -315,7 +319,7 @@ esp_err_t SPM_IRAM_ATTR esp_sleep_cpu_retention(uint32_t (*goto_sleep)(uint32_t,
 {
     esp_sleep_execute_event_callbacks(SLEEP_EVENT_SW_CPU_TO_MEM_START, (void *)0);
     uint8_t core_id = esp_cpu_get_core_id();
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU && !CONFIG_FREERTOS_UNICORE
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU && CONFIG_SMP
     atomic_store(&s_smp_retention_state[core_id], SMP_BACKUP_START);
 #endif
     cpu_domain_dev_regs_save(s_cpu_retention.retent.clic_frame[core_id]);
@@ -334,7 +338,7 @@ esp_err_t SPM_IRAM_ATTR esp_sleep_cpu_retention(uint32_t (*goto_sleep)(uint32_t,
         validate_retention_frame_crc((uint32_t*)frame, sizeof(RvCoreNonCriticalSleepFrame) - sizeof(long), (uint32_t *)(&frame->frame_crc));
 #endif
     }
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU && !CONFIG_FREERTOS_UNICORE
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU && CONFIG_SMP
     // Start core1
     if (core_id == 0) {
         REG_SET_BIT(HP_SYS_CLKRST_SOC_CLK_CTRL0_REG, HP_SYS_CLKRST_REG_CORE1_CPU_CLK_EN);
@@ -348,7 +352,7 @@ esp_err_t SPM_IRAM_ATTR esp_sleep_cpu_retention(uint32_t (*goto_sleep)(uint32_t,
         rv_core_noncritical_regs_restore();
     }
 
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU && !CONFIG_FREERTOS_UNICORE
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU && CONFIG_SMP
     atomic_store(&s_smp_retention_state[core_id], SMP_RESTORE_DONE);
 #endif
     return err;
@@ -356,7 +360,7 @@ esp_err_t SPM_IRAM_ATTR esp_sleep_cpu_retention(uint32_t (*goto_sleep)(uint32_t,
 
 esp_err_t esp_sleep_cpu_retention_init(void)
 {
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU && !CONFIG_FREERTOS_UNICORE
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU && CONFIG_SMP
     return esp_sleep_cpu_retention_init_impl(& s_cpu_retention, s_smp_retention_state);
 #else
     return esp_sleep_cpu_retention_init_impl(& s_cpu_retention);
@@ -371,11 +375,11 @@ esp_err_t esp_sleep_cpu_retention_deinit(void)
 bool cpu_domain_pd_allowed(void)
 {
     bool allowed = true;
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         allowed &= (s_cpu_retention.retent.critical_frame[core_id] != NULL);
         allowed &= (s_cpu_retention.retent.non_critical_frame[core_id] != NULL);
     }
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         allowed &= (s_cpu_retention.retent.clic_frame[core_id] != NULL);
     }
     return allowed;
@@ -383,7 +387,7 @@ bool cpu_domain_pd_allowed(void)
 
 esp_err_t sleep_cpu_configure(bool light_sleep_enable)
 {
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU
     if (light_sleep_enable) {
         ESP_RETURN_ON_ERROR(esp_sleep_cpu_retention_init(), TAG, "Failed to enable CPU power down during light sleep.");
     } else {
@@ -393,8 +397,8 @@ esp_err_t sleep_cpu_configure(bool light_sleep_enable)
     return ESP_OK;
 }
 
-#if !CONFIG_FREERTOS_UNICORE
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU
+#if CONFIG_SMP
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU
 static SPM_IRAM_ATTR void smp_core_do_retention(void)
 {
     uint8_t core_id = esp_cpu_get_core_id();
@@ -429,7 +433,7 @@ static SPM_IRAM_ATTR void smp_core_do_retention(void)
         cpu_domain_dev_regs_save(s_cpu_retention.retent.clic_frame[core_id]);
         RvCoreCriticalSleepFrame *frame_critical = s_cpu_retention.retent.critical_frame[core_id];
         save_csr_disable_global_int(&mstatus, &mintthresh);
-        s_fpu_saved[core_id] = xPortFPUContextIsDirty(core_id);
+        s_fpu_saved[core_id] = cpu_fpu_context_is_dirty();
         if (s_fpu_saved[core_id]) {
             rv_core_fpu_save(frame_critical);
         }
@@ -475,7 +479,7 @@ SPM_IRAM_ATTR void esp_sleep_cpu_skip_retention(void) {
 
 void sleep_smp_cpu_sleep_prepare(void)
 {
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU
     while (atomic_load(&s_smp_retention_state[!esp_cpu_get_core_id()]) != SMP_IDLE) {
         ;
     }
@@ -487,7 +491,7 @@ void sleep_smp_cpu_sleep_prepare(void)
 
 void sleep_smp_cpu_wakeup_prepare(void)
 {
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU
     uint8_t core_id = esp_cpu_get_core_id();
     if (atomic_load(&s_smp_retention_state[core_id]) == SMP_RESTORE_DONE) {
         ESP_COMPILER_DIAGNOSTIC_PUSH_IGNORE("-Wanalyzer-infinite-loop")
@@ -501,4 +505,4 @@ void sleep_smp_cpu_wakeup_prepare(void)
     esp_ipc_isr_release_other_cpu();
 #endif
 }
-#endif //!CONFIG_FREERTOS_UNICORE
+#endif //CONFIG_SMP

--- a/components/esp_hw_support/lowpower/port/esp32p4/sleep_cpu_asm.S
+++ b/components/esp_hw_support/lowpower/port/esp32p4/sleep_cpu_asm.S
@@ -6,7 +6,6 @@
 
 #include "soc/soc.h"
 #include "rvsleep-frames.h"
-#include "freertos/FreeRTOSConfig.h"
 #include "sdkconfig.h"
 
 #include "soc/cache_reg.h"
@@ -19,7 +18,7 @@
     .type       rv_core_critical_regs_frame,@object
     .align      4
 rv_core_critical_regs_frame:
-    .rept (portNUM_PROCESSORS)
+    .rept (CONFIG_MP_MAX_NUM_CPUS)
     .word       0
     .endr
 

--- a/components/esp_hw_support/lowpower/port/esp32p4/sleep_cpu_dynamic.c
+++ b/components/esp_hw_support/lowpower/port/esp32p4/sleep_cpu_dynamic.c
@@ -15,7 +15,7 @@
 #include "sleep_cpu_retention.h"
 
 
-extern RvCoreCriticalSleepFrame *rv_core_critical_regs_frame[portNUM_PROCESSORS];
+extern RvCoreCriticalSleepFrame *rv_core_critical_regs_frame[CONFIG_MP_MAX_NUM_CPUS];
 
 static void * cpu_domain_dev_sleep_frame_alloc_and_init(const cpu_domain_dev_regs_region_t *regions, const int region_num)
 {
@@ -41,8 +41,8 @@ static void * cpu_domain_dev_sleep_frame_alloc_and_init(const cpu_domain_dev_reg
 
 static inline void * cpu_domain_clic_sleep_frame_alloc_and_init(uint8_t core_id)
 {
-    const static cpu_domain_dev_regs_region_t regions[portNUM_PROCESSORS][2] = {
-       [0 ... portNUM_PROCESSORS - 1] = {
+    const static cpu_domain_dev_regs_region_t regions[CONFIG_MP_MAX_NUM_CPUS][2] = {
+       [0 ... CONFIG_MP_MAX_NUM_CPUS - 1] = {
             { .start = CLIC_INT_CONFIG_REG, .end = CLIC_INT_THRESH_REG + 4 },
             { .start = CLIC_INT_CTRL_REG(0), .end = CLIC_INT_CTRL_REG(47) + 4 },
         }
@@ -50,10 +50,10 @@ static inline void * cpu_domain_clic_sleep_frame_alloc_and_init(uint8_t core_id)
     return cpu_domain_dev_sleep_frame_alloc_and_init(regions[core_id], sizeof(regions[core_id]) / sizeof(cpu_domain_dev_regs_region_t));
 }
 
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU && !CONFIG_FREERTOS_UNICORE
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU && CONFIG_SMP
 esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_retention_ptr, smp_retention_state_t *s_smp_retention_state)
 {
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         if (sleep_cpu_retention_ptr->retent.critical_frame[core_id] == NULL) {
             void *frame = heap_caps_calloc(1, RV_SLEEP_CTX_FRMSZ, MALLOC_CAP_32BIT|MALLOC_CAP_INTERNAL);
             if (frame == NULL) {
@@ -70,7 +70,7 @@ esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_ret
             sleep_cpu_retention_ptr->retent.non_critical_frame[core_id] = (RvCoreNonCriticalSleepFrame *)frame;
         }
     }
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         if (sleep_cpu_retention_ptr->retent.clic_frame[core_id] == NULL) {
             void *frame = cpu_domain_clic_sleep_frame_alloc_and_init(core_id);
             if (frame == NULL) {
@@ -79,7 +79,7 @@ esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_ret
             sleep_cpu_retention_ptr->retent.clic_frame[core_id] = (cpu_domain_dev_sleep_frame_t *)frame;
         }
     }
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         atomic_init(&s_smp_retention_state[core_id], SMP_IDLE);
     }
     return ESP_OK;
@@ -90,7 +90,7 @@ err:
 #else
 esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_retention_ptr)
 {
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         if (sleep_cpu_retention_ptr->retent.critical_frame[core_id] == NULL) {
             void *frame = heap_caps_calloc(1, RV_SLEEP_CTX_FRMSZ, MALLOC_CAP_32BIT|MALLOC_CAP_INTERNAL);
             if (frame == NULL) {
@@ -107,7 +107,7 @@ esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_ret
             sleep_cpu_retention_ptr->retent.non_critical_frame[core_id] = (RvCoreNonCriticalSleepFrame *)frame;
         }
     }
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         if (sleep_cpu_retention_ptr->retent.clic_frame[core_id] == NULL) {
             void *frame = cpu_domain_clic_sleep_frame_alloc_and_init(core_id);
             if (frame == NULL) {
@@ -125,7 +125,7 @@ err:
 
 esp_err_t esp_sleep_cpu_retention_deinit_impl(sleep_cpu_retention_t *sleep_cpu_retention_ptr)
 {
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         if (sleep_cpu_retention_ptr->retent.critical_frame[core_id]) {
             heap_caps_free((void *)sleep_cpu_retention_ptr->retent.critical_frame[core_id]);
             sleep_cpu_retention_ptr->retent.critical_frame[core_id] = NULL;
@@ -136,7 +136,7 @@ esp_err_t esp_sleep_cpu_retention_deinit_impl(sleep_cpu_retention_t *sleep_cpu_r
             sleep_cpu_retention_ptr->retent.non_critical_frame[core_id] = NULL;
         }
     }
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         if (sleep_cpu_retention_ptr->retent.clic_frame[core_id]) {
             heap_caps_free((void *)sleep_cpu_retention_ptr->retent.clic_frame[core_id]);
             sleep_cpu_retention_ptr->retent.clic_frame[core_id] = NULL;

--- a/components/esp_hw_support/lowpower/port/esp32p4/sleep_cpu_retention.h
+++ b/components/esp_hw_support/lowpower/port/esp32p4/sleep_cpu_retention.h
@@ -8,10 +8,9 @@
 #define __SLEEP_CPU_RETENTION_H__
 
 #include "rvsleep-frames.h"
-#include "freertos/FreeRTOS.h"
 #include "esp_err.h"
 
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU && !CONFIG_FREERTOS_UNICORE
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU && CONFIG_SMP
 #include <stdatomic.h>
 #include "soc/hp_system_reg.h"
 typedef enum {
@@ -40,13 +39,13 @@ typedef struct {
  */
 typedef struct {
     struct {
-        RvCoreCriticalSleepFrame *critical_frame[portNUM_PROCESSORS];
-        RvCoreNonCriticalSleepFrame *non_critical_frame[portNUM_PROCESSORS];
-        cpu_domain_dev_sleep_frame_t *clic_frame[portNUM_PROCESSORS];
+        RvCoreCriticalSleepFrame *critical_frame[CONFIG_MP_MAX_NUM_CPUS];
+        RvCoreNonCriticalSleepFrame *non_critical_frame[CONFIG_MP_MAX_NUM_CPUS];
+        cpu_domain_dev_sleep_frame_t *clic_frame[CONFIG_MP_MAX_NUM_CPUS];
     } retent;
 } sleep_cpu_retention_t;
 
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU && !CONFIG_FREERTOS_UNICORE
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU && CONFIG_SMP
     esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_retention_ptr, smp_retention_state_t *s_smp_retention_state);
 #else
     esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_retention_ptr);

--- a/components/esp_hw_support/lowpower/port/esp32p4/sleep_cpu_static.c
+++ b/components/esp_hw_support/lowpower/port/esp32p4/sleep_cpu_static.c
@@ -13,7 +13,7 @@
 #include "sleep_cpu_retention.h"
 
 
-extern RvCoreCriticalSleepFrame *rv_core_critical_regs_frame[portNUM_PROCESSORS];
+extern RvCoreCriticalSleepFrame *rv_core_critical_regs_frame[CONFIG_MP_MAX_NUM_CPUS];
 
 #define R_CONCAT(s1, s2)    _R_CONCAT(s1, s2)
 #define _R_CONCAT(s1, s2)   s1 ## s2
@@ -73,22 +73,22 @@ static void * cpu_domain_dev_sleep_frame_alloc_and_init(const cpu_domain_dev_reg
 
 static inline void * cpu_domain_clic_sleep_frame_alloc_and_init(uint8_t core_id)
 {
-    static DRAM_ATTR cpu_domain_dev_regs_region_t regions[portNUM_PROCESSORS][2] = {
-       [0 ... portNUM_PROCESSORS - 1] = {
+    static DRAM_ATTR cpu_domain_dev_regs_region_t regions[CONFIG_MP_MAX_NUM_CPUS][2] = {
+       [0 ... CONFIG_MP_MAX_NUM_CPUS - 1] = {
             { .start = CPU_DOMAIN_DEV_START_ADDR0, .end = CPU_DOMAIN_DEV_END_ADDR0 },
             { .start = CPU_DOMAIN_DEV_START_ADDR1, .end = CPU_DOMAIN_DEV_END_ADDR1 },
         }
     };
-    static DRAM_ATTR uint8_t sleep_frame[portNUM_PROCESSORS][CPU_DOMAIN_DEV_TOTAL_SZ(2)] __attribute__((aligned(4)));
+    static DRAM_ATTR uint8_t sleep_frame[CONFIG_MP_MAX_NUM_CPUS][CPU_DOMAIN_DEV_TOTAL_SZ(2)] __attribute__((aligned(4)));
     return cpu_domain_dev_sleep_frame_alloc_and_init(regions[core_id], sizeof(regions[core_id]) / sizeof(regions[core_id][0]), sleep_frame[core_id]);
 }
 
-#if CONFIG_PM_ESP_SLEEP_POWER_DOWN_CPU && !CONFIG_FREERTOS_UNICORE
+#if CONFIG_ESP32_PM_ESP_SLEEP_POWER_DOWN_CPU && CONFIG_SMP
 esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_retention_ptr, smp_retention_state_t *s_smp_retention_state)
 {
-    static DRAM_ATTR uint8_t rv_core_critical_regs[RV_SLEEP_CTX_FRMSZ * portNUM_PROCESSORS] __attribute__((aligned(4)));
-    static DRAM_ATTR uint8_t rv_core_non_critical_regs[sizeof(RvCoreNonCriticalSleepFrame)* portNUM_PROCESSORS] __attribute__((aligned(4)));
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    static DRAM_ATTR uint8_t rv_core_critical_regs[RV_SLEEP_CTX_FRMSZ * CONFIG_MP_MAX_NUM_CPUS] __attribute__((aligned(4)));
+    static DRAM_ATTR uint8_t rv_core_non_critical_regs[sizeof(RvCoreNonCriticalSleepFrame)* CONFIG_MP_MAX_NUM_CPUS] __attribute__((aligned(4)));
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         if (sleep_cpu_retention_ptr->retent.critical_frame[core_id] == NULL) {
             void * regs = rv_core_critical_regs + core_id * RV_SLEEP_CTX_FRMSZ;
             sleep_cpu_retention_ptr->retent.critical_frame[core_id] = (RvCoreCriticalSleepFrame *) regs;
@@ -99,13 +99,13 @@ esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_ret
         }
     }
 
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         if (sleep_cpu_retention_ptr->retent.clic_frame[core_id] == NULL) {
             void *frame = cpu_domain_clic_sleep_frame_alloc_and_init(core_id);
             sleep_cpu_retention_ptr->retent.clic_frame[core_id] = (cpu_domain_dev_sleep_frame_t *)frame;
         }
     }
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         atomic_init(&s_smp_retention_state[core_id], SMP_IDLE);
     }
     return ESP_OK;
@@ -113,9 +113,9 @@ esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_ret
 #else
 esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_retention_ptr)
 {
-    static DRAM_ATTR uint8_t rv_core_critical_regs[RV_SLEEP_CTX_FRMSZ * portNUM_PROCESSORS] __attribute__((aligned(4)));
-    static DRAM_ATTR uint8_t rv_core_non_critical_regs[sizeof(RvCoreNonCriticalSleepFrame)* portNUM_PROCESSORS] __attribute__((aligned(4)));
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    static DRAM_ATTR uint8_t rv_core_critical_regs[RV_SLEEP_CTX_FRMSZ * CONFIG_MP_MAX_NUM_CPUS] __attribute__((aligned(4)));
+    static DRAM_ATTR uint8_t rv_core_non_critical_regs[sizeof(RvCoreNonCriticalSleepFrame)* CONFIG_MP_MAX_NUM_CPUS] __attribute__((aligned(4)));
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         if (sleep_cpu_retention_ptr->retent.critical_frame[core_id] == NULL) {
             void * regs = rv_core_critical_regs + core_id * RV_SLEEP_CTX_FRMSZ;
             sleep_cpu_retention_ptr->retent.critical_frame[core_id] = (RvCoreCriticalSleepFrame *) regs;
@@ -126,7 +126,7 @@ esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_ret
         }
     }
 
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         if (sleep_cpu_retention_ptr->retent.clic_frame[core_id] == NULL) {
             void *frame = cpu_domain_clic_sleep_frame_alloc_and_init(core_id);
             sleep_cpu_retention_ptr->retent.clic_frame[core_id] = (cpu_domain_dev_sleep_frame_t *)frame;
@@ -138,7 +138,7 @@ esp_err_t esp_sleep_cpu_retention_init_impl(sleep_cpu_retention_t *sleep_cpu_ret
 
 esp_err_t esp_sleep_cpu_retention_deinit_impl(sleep_cpu_retention_t *sleep_cpu_retention_ptr)
 {
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         if (sleep_cpu_retention_ptr->retent.critical_frame[core_id]) {
             sleep_cpu_retention_ptr->retent.critical_frame[core_id] = NULL;
             rv_core_critical_regs_frame[core_id] = NULL;
@@ -147,7 +147,7 @@ esp_err_t esp_sleep_cpu_retention_deinit_impl(sleep_cpu_retention_t *sleep_cpu_r
             sleep_cpu_retention_ptr->retent.non_critical_frame[core_id] = NULL;
         }
     }
-    for (uint8_t core_id = 0; core_id < portNUM_PROCESSORS; ++core_id) {
+    for (uint8_t core_id = 0; core_id < CONFIG_MP_MAX_NUM_CPUS; ++core_id) {
         if (sleep_cpu_retention_ptr->retent.clic_frame[core_id]) {
             sleep_cpu_retention_ptr->retent.clic_frame[core_id] = NULL;
         }

--- a/components/esp_hw_support/lowpower/port/esp32p4/sleep_fpu_asm.S
+++ b/components/esp_hw_support/lowpower/port/esp32p4/sleep_fpu_asm.S
@@ -5,7 +5,6 @@
  */
 
 #include "rvsleep-frames.h"
-#include "freertos/FreeRTOSConfig.h"
 #include "sdkconfig.h"
 
     .section    .spm.text,"ax"

--- a/components/esp_hw_support/periph_ctrl.c
+++ b/components/esp_hw_support/periph_ctrl.c
@@ -31,6 +31,8 @@
 #include <zephyr/dt-bindings/clock/esp32c6_clock.h>
 #elif defined(CONFIG_SOC_SERIES_ESP32H2)
 #include <zephyr/dt-bindings/clock/esp32h2_clock.h>
+#elif defined(CONFIG_SOC_SERIES_ESP32P4)
+#include <zephyr/dt-bindings/clock/esp32p4_clock.h>
 #endif
 
 #include <hal/uart_ll.h>
@@ -57,14 +59,21 @@
 #if SOC_MCPWM_SUPPORTED
 #include <hal/mcpwm_ll.h>
 #endif
+#if SOC_RMT_SUPPORTED
+#include <hal/rmt_ll.h>
+#endif
 #if SOC_I2S_SUPPORTED
 #include <hal/i2s_ll.h>
 #endif
 #if SOC_USB_SERIAL_JTAG_SUPPORTED
 #include <hal/usb_serial_jtag_ll.h>
 #endif
+#if SOC_USB_OTG_SUPPORTED && SOC_USB_UTMI_PHY_NUM > 0
+#include <hal/usb_utmi_ll.h>
+#endif
 #if SOC_SDMMC_HOST_SUPPORTED
 #include <hal/sdmmc_ll.h>
+#include <hal/clk_gate_ll.h>
 #endif
 #if SOC_EMAC_SUPPORTED
 #include <hal/emac_ll.h>
@@ -204,6 +213,24 @@ void non_shared_periph_module_enable(int periph)
         uart_ll_reset_register(1);
         break;
 #endif
+#if defined(ESP32_UART2_MODULE) && ESP32_UART2_MODULE >= 100
+    case ESP32_UART2_MODULE:
+        uart_ll_enable_bus_clock(2, true);
+        uart_ll_reset_register(2);
+        break;
+#endif
+#if defined(ESP32_UART3_MODULE) && ESP32_UART3_MODULE >= 100
+    case ESP32_UART3_MODULE:
+        uart_ll_enable_bus_clock(3, true);
+        uart_ll_reset_register(3);
+        break;
+#endif
+#if defined(ESP32_UART4_MODULE) && ESP32_UART4_MODULE >= 100
+    case ESP32_UART4_MODULE:
+        uart_ll_enable_bus_clock(4, true);
+        uart_ll_reset_register(4);
+        break;
+#endif
     case ESP32_I2C0_MODULE:
         i2c_ll_enable_bus_clock(0, true);
         i2c_ll_reset_register(0);
@@ -271,6 +298,14 @@ void non_shared_periph_module_enable(int periph)
         twai_ll_enable_clock(1, true);
         break;
 #endif
+#ifdef ESP32_TWAI2_MODULE
+    case ESP32_TWAI2_MODULE:
+        twai_ll_enable_bus_clock(2, true);
+        twai_ll_reset_register(2);
+        twai_ll_set_clock_source(2, TWAI_CLK_SRC_DEFAULT);
+        twai_ll_enable_clock(2, true);
+        break;
+#endif
 #endif /* SOC_TWAI_SUPPORTED */
 #ifdef ESP32_SPI_DMA_MODULE
     case ESP32_SPI_DMA_MODULE:
@@ -294,6 +329,12 @@ void non_shared_periph_module_enable(int periph)
     case ESP32_MCPWM0_MODULE:
         mcpwm_ll_enable_bus_clock(0, true);
         mcpwm_ll_reset_register(0);
+        break;
+#endif
+#ifdef ESP32_MCPWM1_MODULE
+    case ESP32_MCPWM1_MODULE:
+        mcpwm_ll_enable_bus_clock(1, true);
+        mcpwm_ll_reset_register(1);
         break;
 #endif
 #ifdef ESP32_PWM0_MODULE
@@ -333,7 +374,21 @@ void non_shared_periph_module_enable(int periph)
         i2s_ll_reset_register(1);
         break;
 #endif
+#ifdef ESP32_I2S2_MODULE
+    case ESP32_I2S2_MODULE:
+        i2s_ll_enable_bus_clock(2, true);
+        i2s_ll_reset_register(2);
+        break;
+#endif
 #endif /* SOC_I2S_SUPPORTED */
+#if SOC_RMT_SUPPORTED
+#ifdef ESP32_RMT_MODULE
+    case ESP32_RMT_MODULE:
+        rmt_ll_enable_bus_clock(0, true);
+        rmt_ll_reset_register(0);
+        break;
+#endif
+#endif
 #if SOC_AES_SUPPORTED
 #ifdef ESP32_AES_MODULE
 #if ESP32_AES_MODULE >= 100
@@ -364,11 +419,22 @@ void non_shared_periph_module_enable(int periph)
         break;
 #endif
 #endif
+#if SOC_USB_OTG_SUPPORTED && SOC_USB_UTMI_PHY_NUM > 0
+#ifdef ESP32_USB_OTG_MODULE
+    case ESP32_USB_OTG_MODULE:
+        _usb_utmi_ll_enable_bus_clock(true);
+        _usb_utmi_ll_reset_register();
+        break;
+#endif
+#endif
 #if SOC_SDMMC_HOST_SUPPORTED
 #ifdef ESP32_SDMMC_MODULE
     case ESP32_SDMMC_MODULE:
         sdmmc_ll_enable_bus_clock(0, true);
         sdmmc_ll_reset_register(0);
+#if defined(CONFIG_SOC_SERIES_ESP32P4)
+        _clk_gate_ll_ref_160m_clk_en(true);
+#endif
         break;
 #endif
 #endif
@@ -510,6 +576,21 @@ void non_shared_periph_module_disable(int periph)
         uart_ll_enable_bus_clock(1, false);
         break;
 #endif
+#if defined(ESP32_UART2_MODULE) && ESP32_UART2_MODULE >= 100
+    case ESP32_UART2_MODULE:
+        uart_ll_enable_bus_clock(2, false);
+        break;
+#endif
+#if defined(ESP32_UART3_MODULE) && ESP32_UART3_MODULE >= 100
+    case ESP32_UART3_MODULE:
+        uart_ll_enable_bus_clock(3, false);
+        break;
+#endif
+#if defined(ESP32_UART4_MODULE) && ESP32_UART4_MODULE >= 100
+    case ESP32_UART4_MODULE:
+        uart_ll_enable_bus_clock(4, false);
+        break;
+#endif
     case ESP32_I2C0_MODULE:
         i2c_ll_enable_bus_clock(0, false);
         break;
@@ -561,6 +642,11 @@ void non_shared_periph_module_disable(int periph)
         twai_ll_enable_bus_clock(1, false);
         break;
 #endif
+#ifdef ESP32_TWAI2_MODULE
+    case ESP32_TWAI2_MODULE:
+        twai_ll_enable_bus_clock(2, false);
+        break;
+#endif
 #endif /* SOC_TWAI_SUPPORTED */
 #ifdef ESP32_SPI_DMA_MODULE
     case ESP32_SPI_DMA_MODULE:
@@ -580,6 +666,11 @@ void non_shared_periph_module_disable(int periph)
 #ifdef ESP32_MCPWM0_MODULE
     case ESP32_MCPWM0_MODULE:
         mcpwm_ll_enable_bus_clock(0, false);
+        break;
+#endif
+#ifdef ESP32_MCPWM1_MODULE
+    case ESP32_MCPWM1_MODULE:
+        mcpwm_ll_enable_bus_clock(1, false);
         break;
 #endif
 #ifdef ESP32_PWM0_MODULE
@@ -613,7 +704,19 @@ void non_shared_periph_module_disable(int periph)
         i2s_ll_enable_bus_clock(1, false);
         break;
 #endif
+#ifdef ESP32_I2S2_MODULE
+    case ESP32_I2S2_MODULE:
+        i2s_ll_enable_bus_clock(2, false);
+        break;
+#endif
 #endif /* SOC_I2S_SUPPORTED */
+#if SOC_RMT_SUPPORTED
+#ifdef ESP32_RMT_MODULE
+    case ESP32_RMT_MODULE:
+        rmt_ll_enable_bus_clock(0, false);
+        break;
+#endif
+#endif
 #if SOC_AES_SUPPORTED
 #ifdef ESP32_AES_MODULE
 #if ESP32_AES_MODULE >= 100
@@ -642,10 +745,20 @@ void non_shared_periph_module_disable(int periph)
         break;
 #endif
 #endif
+#if SOC_USB_OTG_SUPPORTED && SOC_USB_UTMI_PHY_NUM > 0
+#ifdef ESP32_USB_OTG_MODULE
+    case ESP32_USB_OTG_MODULE:
+        _usb_utmi_ll_enable_bus_clock(false);
+        break;
+#endif
+#endif
 #if SOC_SDMMC_HOST_SUPPORTED
 #ifdef ESP32_SDMMC_MODULE
     case ESP32_SDMMC_MODULE:
         sdmmc_ll_enable_bus_clock(0, false);
+#if defined(CONFIG_SOC_SERIES_ESP32P4)
+        _clk_gate_ll_ref_160m_clk_en(false);
+#endif
         break;
 #endif
 #endif

--- a/components/esp_hw_support/port/esp32p4/esp_clk_tree.c
+++ b/components/esp_hw_support/port/esp32p4/esp_clk_tree.c
@@ -35,7 +35,7 @@ esp_err_t esp_clk_tree_src_get_freq_hz(soc_module_clk_t clk_src, esp_clk_tree_sr
         clk_src_freq = clk_hal_cpu_get_freq_hz();
         break;
     case SOC_MOD_CLK_XTAL:
-        clk_src_freq = clk_hal_xtal_get_freq_mhz() * MHZ;
+        clk_src_freq = clk_hal_xtal_get_freq_mhz() * MHZ(1);
         break;
     case SOC_MOD_CLK_SYS:
         clk_src_freq = clk_hal_sys_get_freq_hz();
@@ -44,34 +44,34 @@ esp_err_t esp_clk_tree_src_get_freq_hz(soc_module_clk_t clk_src, esp_clk_tree_sr
         clk_src_freq = clk_hal_apb_get_freq_hz();
         break;
     case SOC_MOD_CLK_PLL_F20M:
-        clk_src_freq = CLK_LL_PLL_480M_FREQ_MHZ / clk_ll_pll_f20m_get_divider() * MHZ;
+        clk_src_freq = CLK_LL_PLL_480M_FREQ_MHZ / clk_ll_pll_f20m_get_divider() * MHZ(1);
         break;
     case SOC_MOD_CLK_PLL_F80M:
-        clk_src_freq = CLK_LL_PLL_80M_FREQ_MHZ * MHZ;
+        clk_src_freq = CLK_LL_PLL_80M_FREQ_MHZ * MHZ(1);
         break;
     case SOC_MOD_CLK_PLL_F120M:
-        clk_src_freq = CLK_LL_PLL_120M_FREQ_MHZ * MHZ;
+        clk_src_freq = CLK_LL_PLL_120M_FREQ_MHZ * MHZ(1);
         break;
     case SOC_MOD_CLK_PLL_F160M:
-        clk_src_freq = CLK_LL_PLL_160M_FREQ_MHZ * MHZ;
+        clk_src_freq = CLK_LL_PLL_160M_FREQ_MHZ * MHZ(1);
         break;
     case SOC_MOD_CLK_PLL_F240M:
-        clk_src_freq = CLK_LL_PLL_240M_FREQ_MHZ * MHZ;
+        clk_src_freq = CLK_LL_PLL_240M_FREQ_MHZ * MHZ(1);
         break;
     case SOC_MOD_CLK_CPLL:
-        clk_src_freq = clk_ll_cpll_get_freq_mhz(clk_hal_xtal_get_freq_mhz()) * MHZ;
+        clk_src_freq = clk_ll_cpll_get_freq_mhz(clk_hal_xtal_get_freq_mhz()) * MHZ(1);
         break;
     case SOC_MOD_CLK_SPLL:
-        clk_src_freq = CLK_LL_PLL_480M_FREQ_MHZ * MHZ;
+        clk_src_freq = CLK_LL_PLL_480M_FREQ_MHZ * MHZ(1);
         break;
     case SOC_MOD_CLK_MPLL:
-        clk_src_freq = clk_ll_mpll_get_freq_mhz(clk_hal_xtal_get_freq_mhz()) * MHZ;
+        clk_src_freq = clk_ll_mpll_get_freq_mhz(clk_hal_xtal_get_freq_mhz()) * MHZ(1);
         break;
     case SOC_MOD_CLK_APLL:
         clk_src_freq = clk_hal_apll_get_freq_hz();
         break;
     case SOC_MOD_CLK_SDIO_PLL:
-        clk_src_freq = CLK_LL_PLL_SDIO_FREQ_MHZ * MHZ;
+        clk_src_freq = CLK_LL_PLL_SDIO_FREQ_MHZ * MHZ(1);
         break;
     case SOC_MOD_CLK_RTC_SLOW:
         clk_src_freq = esp_clk_tree_lp_slow_get_freq_hz(precision);
@@ -88,10 +88,10 @@ esp_err_t esp_clk_tree_src_get_freq_hz(soc_module_clk_t clk_src, esp_clk_tree_sr
         clk_src_freq = esp_clk_tree_xtal32k_get_freq_hz(precision);
         break;
     case SOC_MOD_CLK_XTAL_D2:
-        clk_src_freq = (clk_hal_xtal_get_freq_mhz() * MHZ) >> 1;
+        clk_src_freq = (clk_hal_xtal_get_freq_mhz() * MHZ(1)) >> 1;
         break;
     case SOC_MOD_CLK_LP_PLL:
-        clk_src_freq = clk_ll_lp_pll_get_freq_mhz() * MHZ;
+        clk_src_freq = clk_ll_lp_pll_get_freq_mhz() * MHZ(1);
         break;
     default:
         break;

--- a/components/esp_hw_support/port/esp32p4/include/soc/rtc.h
+++ b/components/esp_hw_support/port/esp32p4/include/soc/rtc.h
@@ -48,7 +48,9 @@ extern "C" {
  * - rtc_time: reading RTC counter, conversion between counter values and time
  */
 
+#ifndef MHZ
 #define MHZ (1000000)
+#endif
 
 #define OTHER_BLOCKS_POWERUP        1
 #define OTHER_BLOCKS_WAIT           1

--- a/components/esp_hw_support/port/esp32p4/pmu_sleep.c
+++ b/components/esp_hw_support/port/esp32p4/pmu_sleep.c
@@ -216,7 +216,7 @@ const pmu_sleep_config_t* pmu_sleep_config_default(
             analog_default.lp_sys[LP(SLEEP)].analog.dbg_atten = PMU_DBG_ATTEN_ACTIVE_DEFAULT;
         }
         power_default.hp_sys.dig_power.dcdc_switch_pd_en = 0;
-        analog_default.hp_sys.analog.dcm_vset = CONFIG_ESP_SLEEP_DCM_VSET_VAL_IN_SLEEP;
+        analog_default.hp_sys.analog.dcm_vset = CONFIG_ESP32_SLEEP_DCM_VSET_VAL_IN_SLEEP;
         if (sleep_flags & PMU_SLEEP_PD_VDDSDIO) {
             analog_default.hp_sys.analog.xpd_0p1a = 0;
         } else {
@@ -449,10 +449,10 @@ SPM_IRAM_ATTR uint32_t pmu_sleep_start(uint32_t wakeup_opt, uint32_t reject_opt,
     }
 
 
-#if CONFIG_SPIRAM && CONFIG_ESP_LDO_RESERVE_PSRAM
+#if CONFIG_SPIRAM && CONFIG_REGULATOR_ESP32
     // Disable PSRAM chip power supply
     if (dslp) {
-        ldo_ll_enable(LDO_ID2UNIT(CONFIG_ESP_LDO_CHAN_PSRAM_DOMAIN), false);
+        ldo_ll_enable(LDO_ID2UNIT(2), false);
     }
 #endif
 
@@ -470,9 +470,9 @@ SPM_IRAM_ATTR uint32_t pmu_sleep_start(uint32_t wakeup_opt, uint32_t reject_opt,
     }
 
     if (dslp) {
-#if CONFIG_SPIRAM && CONFIG_ESP_LDO_RESERVE_PSRAM
+#if CONFIG_SPIRAM && CONFIG_REGULATOR_ESP32
         // Enable PSRAM chip power supply after deepsleep request rejected
-        ldo_ll_enable(LDO_ID2UNIT(CONFIG_ESP_LDO_CHAN_PSRAM_DOMAIN), true);
+        ldo_ll_enable(LDO_ID2UNIT(2), true);
 #endif
 #if CONFIG_P4_REV3_MSPI_CRASH_AFTER_POWER_UP_WORKAROUND
         if (efuse_hal_chip_revision() == 300) {

--- a/components/esp_hw_support/port/esp32p4/pmu_sleep_clock_icg.c
+++ b/components/esp_hw_support/port/esp32p4/pmu_sleep_clock_icg.c
@@ -144,7 +144,7 @@ static esp_err_t sleep_clock_icg_init(void *arg)
     return ESP_OK;
 }
 
-ESP_SYSTEM_INIT_FN(sleep_clock_icg_startup_init, SECONDARY, BIT(0), 106)
+esp_err_t sleep_clock_icg_startup_init(void)
 {
     sleep_clock_icg_init_args_t init_args = { .config = clock_icg_config, .size = ARRAY_SIZE(clock_icg_config) };
     sleep_retention_module_init_param_t clock_icg_init_param = {

--- a/components/esp_hw_support/port/esp32p4/rtc_clk.c
+++ b/components/esp_hw_support/port/esp32p4/rtc_clk.c
@@ -534,7 +534,7 @@ uint32_t rtc_clk_apb_freq_get(void)
         denominator = 1;
         numerator = 0;
     }
-    uint32_t cpu_freq_hz = source_freq_mhz * MHZ * denominator / (integer * denominator + numerator);
+    uint32_t cpu_freq_hz = source_freq_mhz * MHZ(1) * denominator / (integer * denominator + numerator);
     uint32_t mem_freq_hz = cpu_freq_hz / clk_ll_mem_get_divider();
     uint32_t sys_freq_hz = mem_freq_hz / clk_ll_sys_get_divider();
     return sys_freq_hz / clk_ll_apb_get_divider();
@@ -586,21 +586,18 @@ uint32_t rtc_clk_apll_coeff_calc(uint32_t freq, uint32_t *_o_div, uint32_t *_sdm
         }
     }
     // sdm2 = (int)(((o_div + 2) * 2) * apll_freq / xtal_freq) - 4
-    sdm2 = (int)(((o_div + 2) * 2 * freq) / (rtc_xtal_freq * MHZ)) - 4;
+    sdm2 = (int)(((o_div + 2) * 2 * freq) / (rtc_xtal_freq * MHZ(1))) - 4;
     // numrator = (((o_div + 2) * 2) * apll_freq / xtal_freq) - 4 - sdm2
-    float numrator = (((o_div + 2) * 2 * freq) / ((float)rtc_xtal_freq * MHZ)) - 4 - sdm2;
+    float numrator = (((o_div + 2) * 2 * freq) / ((float)rtc_xtal_freq * MHZ(1))) - 4 - sdm2;
     // If numrator is bigger than 255/256 + 255/65536 + (1/65536)/2 = 1 - (1 / 65536)/2, carry bit to sdm2
-    if (numrator > 1.0 - (1.0 / 65536.0) / 2.0) {
+    if (numrator > 1.0f - (1.0f / 65536.0f) / 2.0f) {
         sdm2++;
     }
-    // If numrator is smaller than (1/65536)/2, keep sdm0 = sdm1 = 0, otherwise calculate sdm0 and sdm1
-    else if (numrator > (1.0 / 65536.0) / 2.0) {
-        // Get the closest sdm1
-        sdm1 = (int)(numrator * 65536.0 + 0.5) / 256;
-        // Get the closest sdm0
-        sdm0 = (int)(numrator * 65536.0 + 0.5) % 256;
+    else if (numrator > (1.0f / 65536.0f) / 2.0f) {
+        sdm1 = (int)(numrator * 65536.0f + 0.5f) / 256;
+        sdm0 = (int)(numrator * 65536.0f + 0.5f) % 256;
     }
-    uint32_t real_freq = (uint32_t)(rtc_xtal_freq * MHZ * (4 + sdm2 + (float)sdm1/256.0 + (float)sdm0/65536.0) / (((float)o_div + 2) * 2));
+    uint32_t real_freq = (uint32_t)(rtc_xtal_freq * MHZ(1) * (4 + sdm2 + (float)sdm1/256.0f + (float)sdm0/65536.0f) / (((float)o_div + 2) * 2));
     *_o_div = o_div;
     *_sdm0 = sdm0;
     *_sdm1 = sdm1;

--- a/components/esp_hw_support/port/esp32p4/rtc_time.c
+++ b/components/esp_hw_support/port/esp32p4/rtc_time.c
@@ -32,16 +32,16 @@ ESP_LOG_ATTR_TAG(TAG, "rtc_time");
 
 // CLK_CAL_FREQ_APPROX = CLK_FREQ_APPROX / CLK_CAL_DIV_VAL
 #define CLK_CAL_FREQ_APPROX(cal_clk_sel) \
-            ((cal_clk_sel == CLK_CAL_MPLL) ? (CLK_LL_PLL_500M_FREQ_MHZ * MHZ / 4000) : \
-             (cal_clk_sel == CLK_CAL_SPLL) ? (CLK_LL_PLL_480M_FREQ_MHZ * MHZ / 4000) : \
-             (cal_clk_sel == CLK_CAL_CPLL) ? (CLK_LL_PLL_400M_FREQ_MHZ * MHZ / 4000) : \
-             (cal_clk_sel == CLK_CAL_APLL) ? (105 * MHZ / 200) : \
-             (cal_clk_sel == CLK_CAL_SDIO_PLL0 || cal_clk_sel == CLK_CAL_SDIO_PLL1 || cal_clk_sel == CLK_CAL_SDIO_PLL2) ? (200 * MHZ / 4000) : \
+            ((cal_clk_sel == CLK_CAL_MPLL) ? (CLK_LL_PLL_500M_FREQ_MHZ * MHZ(1) / 4000) : \
+             (cal_clk_sel == CLK_CAL_SPLL) ? (CLK_LL_PLL_480M_FREQ_MHZ * MHZ(1) / 4000) : \
+             (cal_clk_sel == CLK_CAL_CPLL) ? (CLK_LL_PLL_400M_FREQ_MHZ * MHZ(1) / 4000) : \
+             (cal_clk_sel == CLK_CAL_APLL) ? (105 * MHZ(1) / 200) : \
+             (cal_clk_sel == CLK_CAL_SDIO_PLL0 || cal_clk_sel == CLK_CAL_SDIO_PLL1 || cal_clk_sel == CLK_CAL_SDIO_PLL2) ? (200 * MHZ(1) / 4000) : \
              (cal_clk_sel == CLK_CAL_RC_FAST) ? (SOC_CLK_RC_FAST_FREQ_APPROX / 50) : \
              (cal_clk_sel == CLK_CAL_RC_SLOW) ? (SOC_CLK_RC_SLOW_FREQ_APPROX) : \
              (cal_clk_sel == CLK_CAL_RC32K) ? (SOC_CLK_RC32K_FREQ_APPROX) : \
              (cal_clk_sel == CLK_CAL_32K_XTAL) ? (SOC_CLK_XTAL32K_FREQ_APPROX) : \
-             (cal_clk_sel == CLK_CAL_LP_PLL) ? (CLK_LL_PLL_8M_FREQ_MHZ * MHZ / 25) : \
+             (cal_clk_sel == CLK_CAL_LP_PLL) ? (CLK_LL_PLL_8M_FREQ_MHZ * MHZ(1) / 25) : \
              0)
 
 /**
@@ -126,7 +126,7 @@ static uint32_t rtc_clk_cal_internal(soc_clk_freq_calculation_src_t cal_clk_sel,
     REG_SET_FIELD(TIMG_RTCCALICFG2_REG(0), TIMG_RTC_CALI_TIMEOUT_THRES, CLK_CAL_TIMEOUT_THRES(cal_clk_sel, slowclk_cycles));
     uint32_t expected_freq = CLK_CAL_FREQ_APPROX(cal_clk_sel);
     assert(expected_freq);
-    uint32_t us_time_estimate = (uint32_t)(((uint64_t) slowclk_cycles) * MHZ / expected_freq);
+    uint32_t us_time_estimate = (uint32_t)(((uint64_t) slowclk_cycles) * MHZ(1) / expected_freq);
     /* Start calibration */
     CLEAR_PERI_REG_MASK(TIMG_RTCCALICFG_REG(0), TIMG_RTC_CALI_START);
     SET_PERI_REG_MASK(TIMG_RTCCALICFG_REG(0), TIMG_RTC_CALI_START);
@@ -229,7 +229,7 @@ uint32_t rtc_clk_freq_to_period(uint32_t) __attribute__((alias("rtc_clk_freq_cal
 
 /// @brief if the calibration is used, we need to enable the timer group0 first
 
-static void enable_timer_group0_for_calibration(void)
+static void __attribute__((unused)) enable_timer_group0_for_calibration(void)
 {
 #ifndef BOOTLOADER_BUILD
     PERIPH_RCC_ACQUIRE_ATOMIC(PERIPH_TIMG0_MODULE, ref_count) {

--- a/components/esp_hw_support/port/esp32p4/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32p4/sar_periph_ctrl.c
@@ -14,9 +14,9 @@
  * - PWDET
  */
 
+#include <zephyr/kernel.h>
 #include "sdkconfig.h"
 #include "esp_log.h"
-#include "freertos/FreeRTOS.h"
 #include "esp_private/sar_periph_ctrl.h"
 #include "esp_private/regi2c_ctrl.h"
 #include "esp_private/critical_section.h"
@@ -25,7 +25,7 @@
 #include "hal/adc_ll.h"
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
-extern portMUX_TYPE rtc_spinlock;
+extern esp_os_spinlock_t rtc_spinlock;
 
 
 void sar_periph_ctrl_init(void)

--- a/components/esp_hw_support/sleep_modes.c
+++ b/components/esp_hw_support/sleep_modes.c
@@ -487,7 +487,7 @@ void esp_default_wake_deep_sleep(void)
                      _DPORT_REG_READ(DPORT_PRO_CACHE_CTRL1_REG) | DPORT_PRO_CACHE_MMU_IA_CLR);
     _DPORT_REG_WRITE(DPORT_PRO_CACHE_CTRL1_REG,
                      _DPORT_REG_READ(DPORT_PRO_CACHE_CTRL1_REG) & (~DPORT_PRO_CACHE_MMU_IA_CLR));
-#if CONFIG_ESP_SLEEP_WAIT_FLASH_READY_EXTRA_DELAY > 0
+#if CONFIG_ESP32_SLEEP_WAIT_FLASH_READY_EXTRA_DELAY > 0
     // ROM code has not started yet, so we need to set delay factor
     // used by esp_rom_delay_us first.
     ets_update_cpu_frequency_rom(ets_get_detected_xtal_freq() / 1000000);
@@ -496,7 +496,7 @@ void esp_default_wake_deep_sleep(void)
     // it can be used to give the flash chip some extra time to become ready.
     // For later chips, we have EFUSE_FLASH_TPUW field to configure it and do
     // this delay in the ROM.
-    esp_rom_delay_us(CONFIG_ESP_SLEEP_WAIT_FLASH_READY_EXTRA_DELAY);
+    esp_rom_delay_us(CONFIG_ESP32_SLEEP_WAIT_FLASH_READY_EXTRA_DELAY);
 #endif
 #elif CONFIG_IDF_TARGET_ESP32S2
     REG_SET_BIT(EXTMEM_CACHE_DBG_INT_ENA_REG, EXTMEM_CACHE_DBG_EN);
@@ -1581,7 +1581,7 @@ esp_err_t esp_light_sleep_start(void)
 
     // Decide if VDD_SDIO needs to be powered down;
     // If it needs to be powered down, adjust sleep time.
-    const uint32_t flash_enable_time_us = ESP_SLEEP_WAIT_FLASH_READY_DEFAULT_DELAY_US + CONFIG_ESP_SLEEP_WAIT_FLASH_READY_EXTRA_DELAY;
+    const uint32_t flash_enable_time_us = ESP_SLEEP_WAIT_FLASH_READY_DEFAULT_DELAY_US + CONFIG_ESP32_SLEEP_WAIT_FLASH_READY_EXTRA_DELAY;
 
     /**
      * If VDD_SDIO power domain is requested to be turned off, bit `RTC_SLEEP_PD_VDDSDIO`

--- a/components/esp_rom/esp32p4/include/esp32p4/rom/uart.h
+++ b/components/esp_rom/esp32p4/include/esp32p4/rom/uart.h
@@ -113,6 +113,10 @@ typedef enum {
     XON_XOFF_CTRL
 } UartFlowCtrl;
 
+/* Undef EMPTY if defined by Zephyr util_macro.h */
+#ifdef EMPTY
+#undef EMPTY
+#endif
 typedef enum {
     EMPTY,
     UNDER_WRITE,

--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.libc.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.libc.ld
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+/* ZEPHYR: Keep PROVIDE for these symbols: */
+PROVIDE ( longjmp = 0x4fc00330 );
+PROVIDE ( setjmp = 0x4fc00334 );
+/*******************************************/
+
+/* Functions */
 esp_rom_newlib_init_common_mutexes = 0x4fc00264;
 memset = 0x4fc00268;
 strlen = 0x4fc00288;
@@ -44,8 +50,6 @@ strsep = 0x4fc00320;
 strspn = 0x4fc00324;
 strtok_r = 0x4fc00328;
 strupr = 0x4fc0032c;
-longjmp = 0x4fc00330;
-setjmp = 0x4fc00334;
 abs = 0x4fc00338;
 div = 0x4fc0033c;
 labs = 0x4fc00340;

--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.newlib.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.newlib.ld
@@ -19,23 +19,26 @@
  Group newlib
  ***************************************/
 
+/* ZEPHYR: Keep PROVIDE for these symbols: */
+PROVIDE ( strdup = 0x4fc002f0 );
+PROVIDE ( strndup = 0x4fc00314 );
+PROVIDE ( rand_r = 0x4fc0034c );
+PROVIDE ( rand = 0x4fc00350 );
+PROVIDE ( srand = 0x4fc00354 );
+PROVIDE ( atoi = 0x4fc00360 );
+PROVIDE ( atol = 0x4fc00364 );
+PROVIDE ( strtol = 0x4fc00368 );
+PROVIDE ( strtoul = 0x4fc0036c );
+PROVIDE ( fflush = 0x4fc00370 );
+PROVIDE ( _fflush_r = 0x4fc00374 );
+PROVIDE ( _fwalk = 0x4fc00378 );
+PROVIDE ( _fwalk_reent = 0x4fc0037c );
+PROVIDE ( __swbuf_r = 0x4fc00388 );
+/*******************************************/
+
 /* Functions */
 _isatty_r = 0x4fc00294;
-strdup = 0x4fc002f0;
-strndup = 0x4fc00314;
-rand_r = 0x4fc0034c;
-rand = 0x4fc00350;
-srand = 0x4fc00354;
-atoi = 0x4fc00360;
-atol = 0x4fc00364;
-strtol = 0x4fc00368;
-strtoul = 0x4fc0036c;
-fflush = 0x4fc00370;
-_fflush_r = 0x4fc00374;
-_fwalk = 0x4fc00378;
-_fwalk_reent = 0x4fc0037c;
 __smakebuf_r = 0x4fc00380;
 __swhatbuf_r = 0x4fc00384;
-__swbuf_r = 0x4fc00388;
 __swbuf = 0x4fc0038c;
 __swsetup_r = 0x4fc00390;

--- a/components/esp_rom/esp32p4/ld/esp32p4lp.rom.newlib.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4lp.rom.newlib.ld
@@ -64,14 +64,16 @@ strsep = 0x501001dc;
 strspn = 0x501001e0;
 strtok_r = 0x501001e4;
 strupr = 0x501001e8;
-longjmp = 0x501001ec;
-setjmp = 0x501001f0;
+/* ZEPHYR: Keep PROVIDE for these symbols: */
+PROVIDE ( longjmp = 0x501001ec );
+PROVIDE ( setjmp = 0x501001f0 );
+PROVIDE ( atoi = 0x50100208 );
+PROVIDE ( atol = 0x5010020c );
+/*******************************************/
 abs = 0x501001f4;
 div = 0x501001f8;
 labs = 0x501001fc;
 ldiv = 0x50100200;
 qsort = 0x50100204;
-atoi = 0x50100208;
-atol = 0x5010020c;
 itoa = 0x50100210;
 utoa = 0x50100214;

--- a/components/esp_system/port/soc/esp32p4/clk.c
+++ b/components/esp_system/port/soc/esp32p4/clk.c
@@ -5,8 +5,6 @@
  */
 
 #include <stdint.h>
-#include <sys/cdefs.h>
-#include <sys/time.h>
 #include <zephyr/sys/util.h>
 #include "sdkconfig.h"
 #include "esp_attr.h"
@@ -36,7 +34,9 @@
  */
 #define SLOW_CLK_CAL_CYCLES     CONFIG_CLOCK_CONTROL_ESP32_RTC_CLK_CAL_CYCLES
 
+#ifndef MHZ
 #define MHZ (1000000)
+#endif
 
 static void select_rtc_slow_clk(soc_rtc_slow_clk_src_t rtc_slow_clk_src);
 
@@ -45,9 +45,9 @@ ESP_LOG_ATTR_TAG(TAG, "clk");
 // This function must be allocated in IRAM.
 void IRAM_ATTR esp_rtc_init(void)
 {
-#if SOC_PMU_SUPPORTED
+#if SOC_PMU_SUPPORTED && !CONFIG_MCUBOOT
     pmu_init();
-#endif  //SOC_PMU_SUPPORTED
+#endif  //SOC_PMU_SUPPORTED && !CONFIG_MCUBOOT
 }
 
 __attribute__((weak)) void esp_clk_init(void)
@@ -55,16 +55,7 @@ __attribute__((weak)) void esp_clk_init(void)
     assert(rtc_clk_xtal_freq_get() == SOC_XTAL_FREQ_40M);
 
     rtc_clk_8m_enable(true);
-#if CONFIG_RTC_FAST_CLK_SRC_RC_FAST
     rtc_clk_fast_src_set(SOC_RTC_FAST_CLK_SRC_RC_FAST);
-#elif CONFIG_RTC_FAST_CLK_SRC_XTAL
-    rtc_clk_fast_src_set(SOC_RTC_FAST_CLK_SRC_XTAL);
-    if (esp_sleep_sub_mode_dump_config(NULL)[ESP_SLEEP_RTC_FAST_USE_XTAL_MODE] == 0) {
-        esp_sleep_sub_mode_config(ESP_SLEEP_RTC_FAST_USE_XTAL_MODE, true);
-    }
-#else
-#error "No RTC fast clock source configured"
-#endif
 
 #if defined(CONFIG_BOOTLOADER_WDT_ENABLE) && SOC_RTC_WDT_SUPPORTED
     // WDT uses a SLOW_CLK clock source. After a function select_rtc_slow_clk a frequency of this source can changed.

--- a/components/esp_system/port/soc/esp32p4/reset_reason.c
+++ b/components/esp_system/port/soc/esp32p4/reset_reason.c
@@ -72,7 +72,7 @@ static esp_reset_reason_t get_reset_reason(soc_reset_reason_t rtc_reset_reason, 
     }
 }
 
-static void esp_reset_reason_init(void)
+void esp_reset_reason_init(void)
 {
     esp_reset_reason_t hint = esp_reset_reason_get_hint();
     s_reset_reason = get_reset_reason(esp_rom_get_reset_reason(PRO_CPU_NUM), hint);

--- a/components/ulp/lp_core/lp_core.c
+++ b/components/ulp/lp_core/lp_core.c
@@ -5,6 +5,7 @@
  */
 
 #include "sdkconfig.h"
+#include <zephyr/devicetree.h>
 #include "esp_rom_caps.h"
 #include "soc/soc_caps.h"
 #include "esp_log.h"
@@ -28,14 +29,16 @@
 #endif
 
 #if ESP_ROM_HAS_LP_ROM
-extern uint32_t _rtc_ulp_memory_start;
+#define ULP_LP_MEMORY_BASE DT_REG_ADDR(DT_NODELABEL(ulp_ram))
 #endif //ESP_ROM_HAS_LP_ROM
 
 const static char* TAG = "ulp-lp-core";
 
 #define WAKEUP_SOURCE_MAX_NUMBER 6
 
-#define RESET_HANDLER_ADDR ((intptr_t)&_rtc_ulp_memory_start + 0x80) // Placed after the 0x80 byte long vector table
+#if ESP_ROM_HAS_LP_ROM
+#define RESET_HANDLER_ADDR ((intptr_t)ULP_LP_MEMORY_BASE + 0x80) // Placed after the 0x80 byte long vector table
+#endif
 
 /* Maps the flags defined in ulp_lp_core.h e.g. ULP_LP_CORE_WAKEUP_SOURCE_HP_CPU to their actual HW values */
 static uint32_t wakeup_src_sw_to_hw_flag_lookup[WAKEUP_SOURCE_MAX_NUMBER] = {
@@ -163,7 +166,7 @@ esp_err_t ulp_lp_core_load_binary(const uint8_t* program_binary, size_t program_
     /* Turn off LP CPU before loading binary */
     ulp_lp_core_stop();
 #if ESP_ROM_HAS_LP_ROM
-    uint32_t* base = (uint32_t*)&_rtc_ulp_memory_start;
+    uint32_t* base = (uint32_t*)ULP_LP_MEMORY_BASE;
 #else
     uint32_t* base = RTC_SLOW_MEM;
 #endif

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -40,7 +40,7 @@ zephyr_sources_ifdef(
   ../components/soc/dport_access_common.c
   )
 
-if(CONFIG_SOC_SERIES_ESP32C5 OR CONFIG_SOC_SERIES_ESP32C6 OR CONFIG_SOC_SERIES_ESP32H2)
+if(CONFIG_SOC_SERIES_ESP32C5 OR CONFIG_SOC_SERIES_ESP32C6 OR CONFIG_SOC_SERIES_ESP32H2 OR CONFIG_SOC_SERIES_ESP32P4)
   zephyr_sources(../components/esp_hal_security/apm_hal.c)
 endif()
 
@@ -50,6 +50,7 @@ add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32C3 esp32c3)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32C5 esp32c5)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32C6 esp32c6)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32H2 esp32h2)
+add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32P4 esp32p4)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32S2 esp32s2)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32S3 esp32s3)
 

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -42,6 +42,10 @@ if SOC_SERIES_ESP32H2
 rsource "../components/soc/esp32h2/include/soc/Kconfig.soc_caps.in"
 endif
 
+if SOC_SERIES_ESP32P4
+rsource "../components/soc/esp32p4/include/soc/Kconfig.soc_caps.in"
+endif
+
 # XTAL frequency in Hz from devicetree
 config XTAL_FREQ_HZ
 	int
@@ -79,6 +83,7 @@ config BOOTLOADER_OFFSET_IN_FLASH
 config BOOTLOADER_CPU_CLK_FREQ_MHZ
 	int
 	default 64 if SOC_SERIES_ESP32H2
+	default 100 if SOC_SERIES_ESP32P4
 	default 80
 
 config ESP_SYSTEM_RTC_EXT_XTAL_BOOTSTRAP_CYCLES
@@ -106,15 +111,18 @@ config ESP_DEFAULT_CPU_FREQ_MHZ
 	default 120 if ESP_CLK_FREQ_HZ = 120000000
 	default 160 if ESP_CLK_FREQ_HZ = 160000000
 	default 240 if ESP_CLK_FREQ_HZ = 240000000
+	default 400 if ESP_CLK_FREQ_HZ = 400000000
 
 # CPU clock frequency in Hz from devicetree
 config ESP_CLK_FREQ_HZ
 	int
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
-# Console serial port number for ESP-IDF ROM functions
+# Console serial port number for ESP-IDF ROM functions.
+# Set to -1 for USB Serial JTAG console (no UART TX wait needed).
 config ESP_CONSOLE_ROM_SERIAL_PORT_NUM
 	int
+	default -1 if ESP_CONSOLE_USB_SERIAL_JTAG
 	default ESP_CONSOLE_UART_NUM
 
 # ESP timer interrupt level (only ESP32 supports 1-3, others only 1)
@@ -179,6 +187,7 @@ config IDF_FIRMWARE_CHIP_ID
 	default 0x0017 if SOC_SERIES_ESP32C5
 	default 0x000D if SOC_SERIES_ESP32C6
 	default 0x0010 if SOC_SERIES_ESP32H2
+	default 0x0012 if SOC_SERIES_ESP32P4
 
 config SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY
 	bool
@@ -191,6 +200,19 @@ config SPIRAM_ALLOW_NOINIT_SEG_EXTERNAL_MEMORY
 	default y if SOC_SERIES_ESP32
 	default y if SOC_SERIES_ESP32S2
 	default y if SOC_SERIES_ESP32S3
+
+config IDF_TARGET
+	string
+	default SOC
+
+config PM_SLP_SPIRAM_HALFSLEEP_EXIT_WAIT_DELAY
+	int
+	default 150
+	help
+	  Delay in microseconds between waking PSRAM out of halfsleep
+	  and the first access to it. Mirrors the ESP-IDF symbol of
+	  the same name so HAL halfsleep recovery code compiles even
+	  when PM is not enabled in the application.
 
 config IDF_TARGET_ESP32
 	bool
@@ -223,6 +245,10 @@ config IDF_TARGET_ESP32C6
 config IDF_TARGET_ESP32H2
 	bool
 	default y if SOC_SERIES_ESP32H2
+
+config IDF_TARGET_ESP32P4
+	bool
+	default y if SOC_SERIES_ESP32P4
 
 config ESP_TIMER_IMPL_TG0_LAC
 	bool
@@ -273,34 +299,51 @@ config ESP_ENABLE_PVT
 
 menu "Sleep config"
 
-config ESP_SLEEP_WAIT_FLASH_READY_EXTRA_DELAY
-	int "Extra delay (in us) after flash powerdown sleep wakeup to wait flash ready"
-	default 2000 if SOC_SERIES_ESP32 || SOC_SERIES_ESP32S3
-	default 0
-	range 0 5000
+config ESP_SLEEP_RTC_BUS_ISO_WORKAROUND
+	bool
+	default y if SOC_SERIES_ESP32 || SOC_SERIES_ESP32S2 || SOC_SERIES_ESP32S3
+
+config ESP_SLEEP_GPIO_RESET_WORKAROUND
+	bool
+	default y if !(SOC_SERIES_ESP32 || SOC_SERIES_ESP32S2)
 	help
-	  When the chip exits sleep, the CPU and the flash chip are powered on at the same time.
-	  CPU will run rom code (deepsleep) or ram code (lightsleep) first, and then load or execute
-	  code from flash.
+	  Software workaround for the GPIO ESD reset issue. On wake-up, a GPIO
+	  configured input-only that receives a small electrostatic pulse (>6V)
+	  during light sleep can trigger a reset. Enabling this configures all
+	  GPIO pins to isolate state during sleep.
 
-	  Some flash chips need sufficient time to pass between power on and first read operation.
-	  By default, without any extra delay, this time is approximately 900us, although
-	  some flash chip types need more than that.
+config ESP_SLEEP_CACHE_SAFE_ASSERTION
+	bool
+	help
+	  Check cache safety in the sleep wake path before flash is ready. For
+	  code quality inspection only; adds overhead.
 
-	  (!!! Please adjust this value according to the Data Sheet of SPI Flash used in your project.)
-	  In Flash Data Sheet, the parameters that define the Flash ready timing after power-up (minimum
-	  time from Vcc(min) to CS active) usually named tVSL in ELECTRICAL CHARACTERISTICS chapter,
-	  and the configuration value here should be:
-	  ESP_SLEEP_WAIT_FLASH_READY_EXTRA_DELAY = tVSL - 900
+config ESP_SLEEP_GPIO_ENABLE_INTERNAL_RESISTORS
+	bool
+	default y
+	help
+	  Allow enabling internal pull-ups/pull-downs for RTC GPIO deep-sleep
+	  wakeup IOs when external resistors are absent.
 
-	  For esp32 and esp32s3, the default extra delay is set to 2000us. When optimizing startup time
-	  for applications which require it, this value may be reduced.
+config ESP_SLEEP_ENABLE_RTC_WDT_IN_SLEEP
+	bool
 
-	  If you are seeing "flash read err, 1000" message printed to the console after deep sleep reset
-	  on esp32, or triggered RTC_WDT/LP_WDT after lightsleep wakeup, try increasing this value.
-	  (For esp32, the delay will be executed in both deep sleep and light sleep wake up flow.
-	  For chips after esp32, the delay will be executed only in light sleep flow, the delay
-	  controlled by the EFUSE_FLASH_TPUW in ROM will be executed in deepsleep wake up flow.)
+config ESP_SLEEP_ENABLE_RTC_WDT_IN_DEEP_SLEEP
+	bool
+
+config PM_SLP_DISABLE_GPIO
+	bool
+	default y if ESP_SLEEP_GPIO_RESET_WORKAROUND
+	help
+	  Disable GPIO outputs during sleep to reduce leakage. Implied by the GPIO
+	  reset workaround.
+
+config PM_CHECK_SLEEP_RETENTION_FRAME
+	bool
+	help
+	  Validate the CPU/peripheral sleep retention frame with a CRC across
+	  light sleep. Adds sleep and wake-up overhead, so it is not user
+	  selectable and is intended for internal validation only.
 
 config ESP_SLEEP_FLASH_LEAKAGE_WORKAROUND
 	bool "Pull up flash CS pin in light sleep"

--- a/zephyr/esp32p4/CMakeLists.txt
+++ b/zephyr/esp32p4/CMakeLists.txt
@@ -1,0 +1,546 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_SOC_SERIES_ESP32P4)
+
+  zephyr_compile_options(-fstrict-volatile-bitfields)
+  zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
+  zephyr_compile_definitions_ifndef(asm asm=__asm__)
+  zephyr_compile_definitions_ifndef(typeof typeof=__typeof__)
+  zephyr_compile_definitions(CONFIG_ESP_REV_MIN_FULL=500)
+
+  zephyr_include_directories(
+    include
+    ../common/include
+    ../port/include
+    ../port/include/boot
+    ../../components/bootloader_support/bootloader_flash/include
+    ../../components/bootloader_support/include
+    ../../components/bootloader_support/private_include
+    ../../components/driver/deprecated
+    ../../components/driver/gpio/include
+    ../../components/driver/include
+    ../../components/driver/spi/include
+    ../../components/driver/uart/include
+    ../../components/efuse/include
+    ../../components/efuse/private_include
+    ../../components/efuse/${CONFIG_SOC_SERIES}/include
+    ../../components/efuse/${CONFIG_SOC_SERIES}/private_include
+    ../../components/esp_common/include
+    ../../components/esp_driver_gpio/include
+    ../../components/esp_event/include
+    ../../components/esp_hal_ana_conv/include
+    ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_clock/include
+    ../../components/esp_hal_clock/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_cam/include
+    ../../components/esp_hal_cam/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_dma/include
+    ../../components/esp_hal_dma/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_emac/include
+    ../../components/esp_hal_emac/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_gpio/include
+    ../../components/esp_hal_gpio/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_gpspi/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_gpspi/include
+    ../../components/esp_hal_i2c/include
+    ../../components/esp_hal_i2c/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_i2s/include
+    ../../components/esp_hal_i2s/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_lcd/include
+    ../../components/esp_hal_lcd/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_ledc/include
+    ../../components/esp_hal_ledc/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_mcpwm/include
+    ../../components/esp_hal_mcpwm/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_mspi/include
+    ../../components/esp_hal_mspi/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_pcnt/include
+    ../../components/esp_hal_pcnt/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_parlio/include
+    ../../components/esp_hal_parlio/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_pmu/include
+    ../../components/esp_hal_pmu/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_regi2c/include
+    ../../components/esp_hal_regi2c/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_rmt/include
+    ../../components/esp_hal_rmt/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_rtc_timer/include
+    ../../components/esp_hal_rtc_timer/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_sd/include
+    ../../components/esp_hal_sd/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_security/include
+    ../../components/esp_hal_security/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_systimer/include
+    ../../components/esp_hal_systimer/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_touch_sens/include
+    ../../components/esp_hal_touch_sens/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_timg/include
+    ../../components/esp_hal_timg/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_twai/include
+    ../../components/esp_hal_twai/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_uart/include
+    ../../components/esp_hal_uart/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_usb/include
+    ../../components/esp_hal_usb/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_wdt/include
+    ../../components/esp_hal_wdt/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hw_support/dma
+    ../../components/esp_hw_support/etm/include
+    ../../components/esp_hw_support/include
+    ../../components/esp_hw_support/include/esp_private
+    ../../components/esp_hw_support/include/hal
+    ../../components/esp_hw_support/include/soc
+    ../../components/esp_hw_support/include/soc/${CONFIG_SOC_SERIES}
+    ../../components/esp_hw_support/ldo/include
+    ../../components/esp_hw_support/mspi/mspi_intr/include
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/include
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/port/${CONFIG_SOC_SERIES}
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/tuning_scheme_impl/include
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/private_include
+    ../../components/esp_hw_support/port/include
+    ../../components/esp_hw_support/power_supply/include
+    ../../components/esp_mm/include
+    ../../components/esp_pm/include
+    ../../components/esp_psram/device/include
+    ../../components/esp_psram/include
+    ../../components/esp_psram/xip_impl/include
+    ../../components/esp_rom/${CONFIG_SOC_SERIES}
+    ../../components/esp_rom/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_rom/include
+    ../../components/esp_rom/${CONFIG_SOC_SERIES}/include/${CONFIG_SOC_SERIES}
+    ../../components/esp_rom/${CONFIG_SOC_SERIES}/ld
+    ../../components/esp_system/include
+    ../../components/esp_system/include/esp_private
+    ../../components/esp_system/port/include
+    ../../components/esp_system/port/include/private
+    ../../components/esp_system/port/include/private/esp_private
+    ../../components/esp_timer/include
+    ../../components/esp_timer/private_include
+    ../../components/hal/${CONFIG_SOC_SERIES}/include
+    ../../components/hal/include
+    ../../components/hal/platform_port/include
+    ../../components/heap/include
+    ../../components/mbedtls/port/include
+    ../../components/riscv/include
+    ../../components/riscv/include/esp_private
+    ../../components/riscv/include/xtensa
+    ../../components/soc/${CONFIG_SOC_SERIES}/include
+    ../../components/soc/include
+    ../../components/soc/${CONFIG_SOC_SERIES}/ld
+    ../../components/soc/${CONFIG_SOC_SERIES}/register
+    ../../components/soc/${CONFIG_SOC_SERIES}/register/hw_ver3
+    ../../components/spi_flash/include
+    ../../components/spi_flash/include/esp_private
+    ../../components/ulp/lp_core/include
+    ../../components/ulp/lp_core/lp_core/include
+    ../../components/ulp/lp_core/shared/include
+    ../../components/ulp/ulp_common/include
+  )
+
+  zephyr_link_libraries(
+    gcc
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/soc/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.peripherals.ld
+  )
+
+  if(NOT CONFIG_SOC_ESP32P4_LPCORE)
+    zephyr_link_libraries(
+      -T${CMAKE_CURRENT_SOURCE_DIR}/src/linker/${CONFIG_SOC_SERIES}.rom.alias.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.api.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.rvfp.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.newlib.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.version.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.libc.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.libc-suboptimal_for_misaligned_mem.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.libgcc.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_hal_wdt/${CONFIG_SOC_SERIES}/rom.wdt.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/riscv/ld/rom.api.ld
+    )
+  endif()
+
+  if(CONFIG_SOC_ESP32P4_LPCORE)
+    zephyr_link_libraries(
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}lp.rom.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}lp.rom.api.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}lp.rom.newlib.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}lp.rom.version.ld
+    )
+  endif()
+
+  zephyr_compile_definitions(ESP_PLATFORM)
+
+  zephyr_sources(
+    ../../components/efuse/src/esp_efuse_api.c
+    ../../components/efuse/src/esp_efuse_fields.c
+    ../../components/efuse/src/esp_efuse_utility.c
+    ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_table.c
+    ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_fields.c
+    ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_utility.c
+    ../../components/efuse/src/efuse_controller/keys/with_key_purposes/esp_efuse_api_key.c
+  )
+
+  zephyr_sources_ifdef(CONFIG_ESP32_SPIM
+    ../../components/esp_hal_gpspi/spi_hal.c
+    ../../components/esp_hal_gpspi/${CONFIG_SOC_SERIES}/spi_periph.c
+    ../../components/esp_hal_gpspi/spi_hal_iram.c
+    ../../components/soc/lldesc.c
+    ../../components/esp_hal_dma/gdma_hal_top.c
+    )
+
+  if(CONFIG_SOC_FLASH_ESP32 OR NOT CONFIG_BOOTLOADER_MCUBOOT)
+    zephyr_sources(
+    ../../components/esp_mm/esp_mmu_map.c
+    ../../components/esp_mm/esp_cache_utils.c
+    ../../components/esp_mm/port/${CONFIG_SOC_SERIES}/ext_mem_layout.c
+    ../../components/bootloader_support/src/flash_encrypt.c
+    ../../components/esp_hw_support/esp_gpio_reserve.c
+    ../../components/hal/cache_hal.c
+    ../../components/hal/mmu_hal.c
+    ../../components/esp_hal_mspi/spi_flash_encrypt_hal_iram.c
+    ../../components/esp_hal_mspi/spi_flash_hal.c
+    ../../components/esp_hal_mspi/spi_flash_hal_iram.c
+    ../../components/esp_hal_mspi/spi_flash_hal_gpspi.c
+    ../../components/spi_flash/esp_flash_api.c
+    ../../components/spi_flash/esp_flash_spi_init.c
+    ../../components/spi_flash/flash_mmap.c
+    ../../components/spi_flash/flash_ops.c
+    ../../components/spi_flash/memspi_host_driver.c
+    ../../components/spi_flash/spi_flash_chip_boya.c
+    ../../components/spi_flash/spi_flash_chip_drivers.c
+    ../../components/spi_flash/spi_flash_chip_gd.c
+    ../../components/spi_flash/spi_flash_chip_generic.c
+    ../../components/spi_flash/spi_flash_chip_issi.c
+    ../../components/spi_flash/spi_flash_chip_mxic.c
+    ../../components/spi_flash/spi_flash_chip_mxic_opi.c
+    ../../components/spi_flash/spi_flash_chip_th.c
+    ../../components/spi_flash/spi_flash_chip_winbond.c
+    ../../components/spi_flash/spi_flash_os_func_noos.c
+    ../../components/spi_flash/spi_flash_os_func_app.c
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/mspi_timing_tuning.c
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/port/${CONFIG_SOC_SERIES}/mspi_timing_config.c
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/tuning_scheme_impl/mspi_timing_by_dqs.c
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/tuning_scheme_impl/mspi_timing_by_flash_delay.c
+    )
+  endif()
+
+  zephyr_sources_ifdef(CONFIG_ESPRESSIF_RMT
+    ../../components/esp_hal_rmt/rmt_hal.c
+    ../../components/esp_hal_gpio/gpio_hal.c
+    ../../components/esp_driver_gpio/src/gpio.c
+    ../../components/esp_driver_gpio/src/rtc_io.c
+    ../../components/esp_hal_rmt/${CONFIG_SOC_SERIES}/rmt_periph.c
+    )
+
+  if(CONFIG_PM OR CONFIG_POWEROFF)
+    zephyr_sources(
+      ../../components/esp_driver_gpio/src/gpio.c
+      ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_sleep.c
+      ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_sleep_clock_icg.c
+      ../../components/esp_hw_support/port/pau_regdma.c
+      ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_clock.c
+      ../../components/esp_hw_support/sleep_gpio.c
+      ../../components/esp_hw_support/sleep_event.c
+      ../../components/esp_hw_support/sleep_console.c
+      ../../components/esp_hw_support/sleep_modem.c
+      ../../components/esp_hw_support/sleep_system_peripheral.c
+      ../../components/esp_hw_support/sleep_usb.c
+      ../../components/soc/${CONFIG_SOC_SERIES}/system_retention_periph.c
+      ../../components/esp_hal_pmu/${CONFIG_SOC_SERIES}/pau_hal.c
+      ../../components/esp_hal_pmu/${CONFIG_SOC_SERIES}/pmu_hal.c
+      ../../components/esp_hw_support/sleep_uart.c
+      ../../components/esp_hw_support/clk_utils.c
+      ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/peripheral_domain_pd.c
+      ../common/pm_impl_zephyr.c
+      )
+    if(CONFIG_ESP32_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP)
+      zephyr_sources(
+        ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_cpu.c
+        ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_cpu_asm.S
+        ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_fpu_asm.S
+        )
+      zephyr_sources_ifdef(CONFIG_ESP32_PM_CPU_RETENTION_DYNAMIC
+        ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_cpu_dynamic.c
+        )
+      zephyr_sources_ifdef(CONFIG_ESP32_PM_CPU_RETENTION_STATIC
+        ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_cpu_static.c
+        )
+    endif()
+  endif()
+
+  if(CONFIG_DMA_ESP32)
+    zephyr_sources(
+      ../../components/soc/lldesc.c
+      ../../components/esp_hal_dma/gdma_hal_top.c
+      ../../components/esp_hal_dma/gdma_hal_ahb_v2.c
+      ../../components/esp_hal_dma/gdma_hal_axi.c
+      ../../components/esp_hal_dma/gdma_hal_crc_gen.c
+      )
+
+    if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_sources(
+        ../../components/esp_hal_dma/${CONFIG_SOC_SERIES}/gdma_periph.c
+        )
+    endif()
+  endif()
+
+  if(CONFIG_WDT_ESP32 AND CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+    zephyr_sources(
+      ../../components/esp_hal_wdt/${CONFIG_SOC_SERIES}/mwdt_periph.c
+      )
+  endif()
+
+  if (CONFIG_ESP_SPIRAM)
+    zephyr_compile_definitions(CONFIG_SPIRAM)
+    zephyr_sources(
+      ../../components/esp_psram/system_layer/esp_psram.c
+      ../../components/esp_hw_support/esp_gpio_reserve.c
+      )
+
+    zephyr_sources_ifdef(CONFIG_SPIRAM_MODE_HEX
+      ../../components/esp_psram/device/esp_psram_impl_ap_hex.c
+      )
+
+    if (CONFIG_SPIRAM_FETCH_INSTRUCTIONS OR CONFIG_SPIRAM_RODATA)
+      zephyr_sources(
+        ../../components/esp_psram/xip_impl/mmu_psram_flash.c
+        )
+    endif()
+  endif()
+
+  if (CONFIG_MCUBOOT)
+    zephyr_sources(
+        ../port/boot/esp_image_loader.c
+        )
+  endif()
+
+  if (CONFIG_MCUBOOT OR NOT CONFIG_BOOTLOADER_MCUBOOT)
+    zephyr_include_directories(
+      ../../components/esp_rom/${CONFIG_SOC_SERIES}
+      )
+
+    zephyr_sources(
+      ../../components/bootloader_support/src/bootloader_clock_init.c
+      ../../components/bootloader_support/bootloader_flash/src/flash_qio_mode.c
+      ../common/console_init.c
+      ../common/soc_init.c
+      )
+  endif()
+
+  zephyr_sources_ifdef(CONFIG_SOC_ESP32P4_HPCORE
+    ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
+    ../../components/esp_driver_gpio/src/rtc_io.c
+    ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/temperature_sensor_periph.c
+    ../../components/esp_hal_ana_conv/temperature_sensor_hal.c
+    ../../components/esp_hal_clock/${CONFIG_SOC_SERIES}/clk_tree_hal.c
+    ../../components/esp_hal_gpio/${CONFIG_SOC_SERIES}/rtc_io_periph.c
+    ../../components/esp_hal_gpio/gpio_hal.c
+    ../../components/esp_hal_gpio/rtc_io_hal.c
+    ../../components/esp_hal_systimer/systimer_hal.c
+    ../../components/esp_hal_touch_sens/touch_sens_hal.c
+    ../../components/esp_hal_wdt/wdt_hal_iram.c
+    ../../components/esp_hw_support/adc_share_hw_ctrl.c
+    ../../components/esp_hw_support/clk_ctrl_os.c
+    ../../components/esp_hw_support/cpu.c
+    ../../components/esp_hw_support/esp_clk.c
+    ../../components/esp_hw_support/hw_random.c
+    ../../components/esp_hw_support/mac_addr.c
+    ../../components/esp_hw_support/periph_ctrl.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/cpu_region_protect.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/esp_clk_tree.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/esp_cpu_intr.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/io_mux.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_init.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_param.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/rtc_clk.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/rtc_clk_init.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/rtc_time.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/sar_periph_ctrl.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/systimer.c
+    ../../components/esp_hw_support/port/esp_clk_tree_common.c
+    ../../components/esp_hw_support/port/regdma_link.c
+    ../../components/esp_hw_support/regi2c_ctrl.c
+    ../../components/esp_hal_ana_conv/adc_hal_common.c
+    ../../components/esp_hw_support/sar_periph_ctrl_common.c
+    ../../components/esp_hw_support/rtc_module.c
+    ../../components/esp_hw_support/sar_tsens_ctrl.c
+    ../../components/esp_hw_support/sleep_modes.c
+    ../../components/esp_hw_support/sleep_retention.c
+    ../../components/esp_hw_support/esp_memory_utils.c
+    ../../components/esp_mm/esp_cache_msync.c
+    ../../components/esp_rom/patches/esp_rom_crc.c
+    ../../components/esp_rom/patches/esp_rom_efuse.c
+    ../../components/esp_rom/patches/esp_rom_gpio.c
+    ../../components/esp_hal_regi2c/${CONFIG_SOC_SERIES}/regi2c_impl.c
+    ../../components/esp_rom/patches/esp_rom_print.c
+    ../../components/esp_rom/patches/esp_rom_serial_output.c
+    ../../components/esp_rom/patches/esp_rom_spiflash.c
+    ../../components/esp_rom/patches/esp_rom_sys.c
+    ../../components/esp_system/esp_err.c
+    ../../components/esp_system/port/soc/${CONFIG_SOC_SERIES}/clk.c
+    ../../components/esp_system/port/soc/${CONFIG_SOC_SERIES}/reset_reason.c
+    ../../components/esp_system/port/soc/${CONFIG_SOC_SERIES}/system_internal.c
+    ../../components/esp_timer/src/esp_timer.c
+    ../../components/esp_timer/src/esp_timer_etm.c
+    ../../components/esp_timer/src/esp_timer_impl_common.c
+    ../../components/esp_timer/src/esp_timer_impl_systimer.c
+    ../../components/esp_timer/src/esp_timer_init.c
+    ../../components/esp_timer/src/ets_timer_legacy.c
+    ../../components/esp_timer/src/system_time.c
+    ../../components/hal/${CONFIG_SOC_SERIES}/efuse_hal.c
+    ../../components/hal/efuse_hal.c
+    ../../components/riscv/instruction_decode.c
+    ../../components/riscv/interrupt.c
+    ../../components/riscv/interrupt_clic.c
+    ../../components/riscv/rv_utils.c
+    ../../components/soc/${CONFIG_SOC_SERIES}/gpio_periph.c
+    ../../components/spi_flash/cache_utils.c
+    ../common/esp_restart.c
+    ../common/flash_init.c
+    ../port/bootloader/bootloader_flash.c
+    ../port/heap/heap_caps_zephyr.c
+    src/soc_flash_init.c
+    src/soc_init.c
+    src/soc_random.c
+  )
+
+  zephyr_sources_ifdef(CONFIG_ESP_ENABLE_PVT
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_pvt.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_I2C_ESP32
+    ../../components/esp_hal_i2c/i2c_hal_iram.c
+    ../../components/esp_hal_i2c/i2c_hal.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_I2S_ESP32
+    ../../components/esp_hal_i2s/i2s_hal.c
+    ../../components/hal/hal_utils.c
+    )
+
+  if(CONFIG_COUNTER_TMR_ESP32)
+    zephyr_sources(
+      ../../components/esp_hal_timg/timer_hal.c
+      )
+    if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_sources(
+        ../../components/esp_hal_timg/${CONFIG_SOC_SERIES}/timer_periph.c
+        )
+    endif()
+  endif()
+
+  zephyr_sources_ifdef(CONFIG_UART_ESP32
+    ../../components/esp_hal_uart/uart_hal.c
+    ../../components/esp_hal_uart/uart_hal_iram.c
+    ../../components/esp_hal_uart/${CONFIG_SOC_SERIES}/uart_periph.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_PWM_LED_ESP32
+    ../../components/esp_hal_ledc/${CONFIG_SOC_SERIES}/ledc_periph.c
+    ../../components/esp_hal_ledc/ledc_hal_iram.c
+    ../../components/esp_hal_ledc/ledc_hal.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_MCPWM_ESP32
+    ../../components/esp_hal_mcpwm/mcpwm_hal.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_PCNT_ESP32
+    ../../components/esp_hal_pcnt/pcnt_hal.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_SDHC_ESP32
+    ../../components/esp_hal_sd/sdmmc_hal.c
+    ../../components/esp_hal_sd/${CONFIG_SOC_SERIES}/sdmmc_periph.c
+    )
+
+  if (CONFIG_UDC_DWC2 OR CONFIG_UHC_DWC2)
+    zephyr_sources(
+    ../../components/esp_hal_usb/usb_wrap_hal.c
+    ../../components/esp_hal_usb/usb_utmi_hal.c
+    )
+  endif()
+
+  zephyr_sources_ifdef(CONFIG_VIDEO_ESP32
+    ../../components/esp_hal_cam/cam_hal.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_MIPI_DBI_ESP32
+    ../../components/esp_hal_lcd/lcd_hal.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_MIPI_DSI_ESP32
+    ../../components/esp_hal_lcd/mipi_dsi_hal.c
+    ../../components/esp_hal_lcd/${CONFIG_SOC_SERIES}/mipi_dsi_periph.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_INPUT_ESP32_TOUCH_SENSOR
+    ../../components/esp_hal_touch_sens/esp32p4/touch_sensor_periph.c
+    )
+
+  if (CONFIG_ESP32_TEMP)
+    zephyr_include_directories(
+    ../../components/esp_driver_tsens/include
+    )
+
+    zephyr_sources(
+    ../../components/esp_driver_tsens/src/temperature_sensor.c
+    ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_rtc_calib.c
+    )
+  endif()
+
+  if (CONFIG_ADC_ESP32)
+    zephyr_include_directories(
+    ../../components/esp_adc/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_adc/include
+    ../../components/esp_adc/interface
+    )
+
+    zephyr_sources(
+    ../../components/esp_hal_ana_conv/adc_hal.c
+    ../../components/esp_hal_ana_conv/adc_oneshot_hal.c
+    ../../components/esp_adc/adc_cali.c
+    ../../components/esp_adc/adc_cali_curve_fitting.c
+    ../../components/esp_adc/${CONFIG_SOC_SERIES}/curve_fitting_coefficients.c
+    ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/adc_periph.c
+    ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_rtc_calib.c
+    )
+  endif()
+
+  if(CONFIG_SOC_ESP32P4_LPCORE)
+    zephyr_compile_definitions(IS_ULP_COCPU)
+    zephyr_ld_options("-nostartfiles")
+    zephyr_ld_options("-Wl,--no-warn-rwx-segments")
+    zephyr_ld_options("-Wl,--gc-sections")
+  endif()
+
+  if(CONFIG_ESP32_ULP_COPROC_ENABLED)
+    zephyr_sources_ifdef(CONFIG_SOC_ESP32P4_HPCORE
+      ../../components/ulp/lp_core/lp_core.c
+      ../../components/ulp/lp_core/shared/ulp_lp_core_lp_timer_shared.c
+      ../../components/ulp/lp_core/shared/ulp_lp_core_memory_shared.c
+      )
+
+    zephyr_sources_ifdef(CONFIG_SOC_ESP32P4_LPCORE
+      ../../components/ulp/lp_core/lp_core/lp_core_interrupt.c
+      ../../components/ulp/lp_core/lp_core/lp_core_utils.c
+      ../../components/ulp/lp_core/lp_core/lp_core_print.c
+      ../../components/ulp/lp_core/lp_core/lp_core_uart.c
+      ../../components/ulp/lp_core/shared/ulp_lp_core_lp_timer_shared.c
+      ../../components/ulp/lp_core/shared/ulp_lp_core_memory_shared.c
+      ../../components/esp_hal_uart/uart_hal.c
+      ../../components/esp_hal_uart/uart_hal_iram.c
+      ../../components/esp_hal_gpio/rtc_io_hal.c
+      ../../components/esp_hal_gpio/${CONFIG_SOC_SERIES}/rtc_io_periph.c
+      )
+  endif()
+
+  zephyr_sources_ifdef(CONFIG_ESP32P4_EMAC
+    ../../components/esp_hal_emac/emac_hal.c
+    ../../components/esp_hal_emac/${CONFIG_SOC_SERIES}/emac_periph.c
+    )
+
+  zephyr_link_libraries_ifdef(CONFIG_NEWLIB_LIBC c)
+
+endif()

--- a/zephyr/esp32p4/include/esp_key_mgr.h
+++ b/zephyr/esp32p4/include/esp_key_mgr.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Stub header: key manager API not yet supported in Zephyr.
+ */
+
+#pragma once

--- a/zephyr/esp32p4/src/linker/esp32p4.rom.alias.ld
+++ b/zephyr/esp32p4/src/linker/esp32p4.rom.alias.ld
@@ -1,0 +1,17 @@
+/* Aliases used on Zephyr environment */
+
+/* Consider using prefix in all names when adding it */
+/* into zephyr source files */
+
+PROVIDE ( esp_rom_uart_tx_one_char = uart_tx_one_char );
+PROVIDE ( esp_rom_uart_rx_one_char = uart_rx_one_char );
+PROVIDE ( esp_rom_uart_tx_wait_idle = uart_tx_wait_idle );
+PROVIDE ( esp_rom_intr_matrix_set = intr_matrix_set );
+PROVIDE ( esp_rom_ets_set_user_start = ets_set_user_start );
+PROVIDE ( esp_rom_ets_printf = ets_printf );
+PROVIDE ( esp_rom_ets_delay_us = ets_delay_us );
+PROVIDE ( esp_rom_cache_set_idrom_mmu_size = Cache_Set_IDROM_MMU_Size );
+PROVIDE ( esp_rom_gpio_matrix_in = rom_gpio_matrix_in );
+PROVIDE ( esp_rom_gpio_matrix_out = rom_gpio_matrix_out );
+PROVIDE ( esp_rom_usb_serial_device_rx_one_char = usb_serial_device_rx_one_char );
+PROVIDE ( esp_rom_usb_serial_device_tx_one_char = usb_serial_device_tx_one_char );

--- a/zephyr/esp32p4/src/soc_flash_init.c
+++ b/zephyr/esp32p4/src/soc_flash_init.c
@@ -1,0 +1,251 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdbool.h>
+#include <assert.h>
+#include <string.h>
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_rom_gpio.h"
+#include "esp_rom_efuse.h"
+#include "esp32p4/rom/gpio.h"
+#include "esp32p4/rom/spi_flash.h"
+#include "esp32p4/rom/efuse.h"
+#include "soc/gpio_periph.h"
+#include "soc/efuse_reg.h"
+#include "soc/spi_reg.h"
+#include "soc/spi_mem_reg.h"
+#include "soc/soc_caps.h"
+#include "soc/spi_pins.h"
+
+/* Legacy SPI pin macro compatibility */
+#define SPI_CLK_GPIO_NUM   MSPI_IOMUX_PIN_NUM_CLK
+#define SPI_Q_GPIO_NUM     MSPI_IOMUX_PIN_NUM_MISO
+#define SPI_D_GPIO_NUM     MSPI_IOMUX_PIN_NUM_MOSI
+#define SPI_CS0_GPIO_NUM   MSPI_IOMUX_PIN_NUM_CS0
+#define SPI_HD_GPIO_NUM    MSPI_IOMUX_PIN_NUM_HD
+#define SPI_WP_GPIO_NUM    MSPI_IOMUX_PIN_NUM_WP
+#define MAX_PAD_GPIO_NUM   SOC_GPIO_PIN_COUNT
+#include "flash_qio_mode.h"
+#include "bootloader_flash_config.h"
+#include "bootloader_common.h"
+#include "bootloader_flash_priv.h"
+#include "bootloader_init.h"
+#include "hal/mmu_hal.h"
+#include "hal/cache_hal.h"
+#include "hal/cache_ll.h"
+#include "hal/mmu_ll.h"
+
+#define TAG "flash_init"
+
+extern esp_image_header_t bootloader_image_hdr;
+
+void flash_update_id(void)
+{
+	esp_rom_spiflash_chip_t *chip = &rom_spiflash_legacy_data->chip;
+
+	chip->device_id = bootloader_read_flash_id();
+}
+
+void flash_cs_timing_config(void)
+{
+	SET_PERI_REG_MASK(SPI_MEM_C_USER_REG, SPI_MEM_C_CS_HOLD_M | SPI_MEM_C_CS_SETUP_M);
+	SET_PERI_REG_BITS(SPI_MEM_C_CTRL2_REG, SPI_MEM_C_CS_HOLD_TIME_V, 0,
+			  SPI_MEM_C_CS_HOLD_TIME_S);
+	SET_PERI_REG_BITS(SPI_MEM_C_CTRL2_REG, SPI_MEM_C_CS_SETUP_TIME_V, 0,
+			  SPI_MEM_C_CS_SETUP_TIME_S);
+}
+
+void flash_clock_config(const esp_image_header_t *pfhdr)
+{
+	uint32_t spi_clk_div = 0;
+
+	switch (pfhdr->spi_speed) {
+	case ESP_IMAGE_SPI_SPEED_DIV_1:
+		spi_clk_div = 1;
+		break;
+	case ESP_IMAGE_SPI_SPEED_DIV_2:
+		spi_clk_div = 2;
+		break;
+	case ESP_IMAGE_SPI_SPEED_DIV_3:
+		spi_clk_div = 3;
+		break;
+	case ESP_IMAGE_SPI_SPEED_DIV_4:
+		spi_clk_div = 4;
+		break;
+	default:
+		break;
+	}
+	esp_rom_spiflash_config_clk(spi_clk_div, 0);
+}
+
+void configure_spi_pins(int drv)
+{
+	uint8_t clk_gpio_num = SPI_CLK_GPIO_NUM;
+	uint8_t q_gpio_num = SPI_Q_GPIO_NUM;
+	uint8_t d_gpio_num = SPI_D_GPIO_NUM;
+	uint8_t cs0_gpio_num = SPI_CS0_GPIO_NUM;
+	uint8_t hd_gpio_num = SPI_HD_GPIO_NUM;
+	uint8_t wp_gpio_num = SPI_WP_GPIO_NUM;
+
+	esp_rom_gpio_pad_set_drv(clk_gpio_num, drv);
+	esp_rom_gpio_pad_set_drv(q_gpio_num, drv);
+	esp_rom_gpio_pad_set_drv(d_gpio_num, drv);
+	esp_rom_gpio_pad_set_drv(cs0_gpio_num, drv);
+	esp_rom_gpio_pad_set_drv(hd_gpio_num, drv);
+	esp_rom_gpio_pad_set_drv(wp_gpio_num, drv);
+}
+
+static void update_flash_config(const esp_image_header_t *bootloader_hdr)
+{
+	volatile uint32_t size;
+
+	switch (bootloader_hdr->spi_size) {
+	case ESP_IMAGE_FLASH_SIZE_1MB:
+		size = 1;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_2MB:
+		size = 2;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_4MB:
+		size = 4;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_8MB:
+		size = 8;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_16MB:
+		size = 16;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_32MB:
+		size = 32;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_64MB:
+		size = 64;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_128MB:
+		size = 128;
+		break;
+	default:
+		size = 2;
+	}
+	cache_hal_disable(CACHE_LL_LEVEL_EXT_MEM, CACHE_TYPE_ALL);
+	/* Set flash chip size */
+	esp_rom_spiflash_config_param(rom_spiflash_legacy_data->chip.device_id, size * 0x100000,
+				      0x10000, 0x1000, 0x100, 0xffff);
+	cache_hal_enable(CACHE_LL_LEVEL_EXT_MEM, CACHE_TYPE_ALL);
+}
+
+static void print_flash_info(const esp_image_header_t *bootloader_hdr)
+{
+	ESP_EARLY_LOGD(TAG, "magic %02x", bootloader_hdr->magic);
+	ESP_EARLY_LOGD(TAG, "segments %02x", bootloader_hdr->segment_count);
+	ESP_EARLY_LOGD(TAG, "spi_mode %02x", bootloader_hdr->spi_mode);
+	ESP_EARLY_LOGD(TAG, "spi_speed %02x", bootloader_hdr->spi_speed);
+	ESP_EARLY_LOGD(TAG, "spi_size %02x", bootloader_hdr->spi_size);
+
+	const char *str;
+
+	switch (bootloader_hdr->spi_speed) {
+	case ESP_IMAGE_SPI_SPEED_DIV_2:
+		str = "40MHz";
+		break;
+	case ESP_IMAGE_SPI_SPEED_DIV_3:
+		str = "26.7MHz";
+		break;
+	case ESP_IMAGE_SPI_SPEED_DIV_4:
+		str = "20MHz";
+		break;
+	case ESP_IMAGE_SPI_SPEED_DIV_1:
+		str = "80MHz";
+		break;
+	default:
+		str = "20MHz";
+		break;
+	}
+	ESP_EARLY_LOGI(TAG, "SPI Speed      : %s", str);
+
+	/* SPI mode could have been set to QIO during boot already,
+	 * so test the SPI registers not the flash header
+	 */
+	uint32_t spi_ctrl = REG_READ(SPI_MEM_C_CTRL_REG);
+
+	if (spi_ctrl & SPI_MEM_C_FREAD_QIO_M) {
+		str = "QIO";
+	} else if (spi_ctrl & SPI_MEM_C_FREAD_QUAD_M) {
+		str = "QOUT";
+	} else if (spi_ctrl & SPI_MEM_C_FREAD_DIO_M) {
+		str = "DIO";
+	} else if (spi_ctrl & SPI_MEM_C_FREAD_DUAL_M) {
+		str = "DOUT";
+	} else if (spi_ctrl & SPI_MEM_C_FASTRD_MODE_M) {
+		str = "FAST READ";
+	} else {
+		str = "SLOW READ";
+	}
+	ESP_EARLY_LOGI(TAG, "SPI Mode       : %s", str);
+
+	switch (bootloader_hdr->spi_size) {
+	case ESP_IMAGE_FLASH_SIZE_1MB:
+		str = "1MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_2MB:
+		str = "2MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_4MB:
+		str = "4MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_8MB:
+		str = "8MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_16MB:
+		str = "16MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_32MB:
+		str = "32MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_64MB:
+		str = "64MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_128MB:
+		str = "128MB";
+		break;
+	default:
+		str = "2MB";
+		break;
+	}
+	ESP_EARLY_LOGI(TAG, "SPI Flash Size : %s", str);
+}
+
+static void init_flash_configure(void)
+{
+	configure_spi_pins(1);
+	flash_cs_timing_config();
+}
+
+static void spi_flash_resume(void)
+{
+	bootloader_execute_flash_command(CMD_RESUME, 0, 0, 0);
+	esp_rom_spiflash_wait_idle(&g_rom_flashchip);
+}
+
+esp_err_t init_spi_flash(void)
+{
+	init_flash_configure();
+	spi_flash_resume();
+	bootloader_flash_unlock();
+
+#if CONFIG_ESPTOOLPY_FLASHMODE_QIO || CONFIG_ESPTOOLPY_FLASHMODE_QOUT
+	bootloader_enable_qio_mode();
+#endif
+
+#if CONFIG_ESPTOOLPY_FLASHFREQ_80M
+	bootloader_image_hdr.spi_speed = ESP_IMAGE_SPI_SPEED_DIV_1;
+#endif
+	print_flash_info(&bootloader_image_hdr);
+	update_flash_config(&bootloader_image_hdr);
+	/* ensure the flash is write-protected */
+	bootloader_enable_wp();
+	return ESP_OK;
+}

--- a/zephyr/esp32p4/src/soc_init.c
+++ b/zephyr/esp32p4/src/soc_init.c
@@ -1,0 +1,201 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdbool.h>
+#include <assert.h>
+#include "soc_init.h"
+#include <soc/soc.h>
+#include "hal/clk_tree_ll.h"
+#include "hal/brownout_ll.h"
+#include "hal/regi2c_ctrl_ll.h"
+#include "regi2c_ctrl.h"
+#include "hal/pmu_ll.h"
+#include "hal/mspi_ll.h"
+#include "hal/assist_debug_ll.h"
+#include "hal/lpwdt_ll.h"
+#include "esp32p4/rom/spi_flash.h"
+#include "soc/assist_debug_reg.h"
+#include "soc/lp_wdt_reg.h"
+#include "soc/regi2c_bias.h"
+#include "esp_log.h"
+#include "esp_rom_sys.h"
+#include "esp_rom_regi2c.h"
+
+const static char *TAG = "soc_init";
+
+void soc_hw_init(void)
+{
+	_regi2c_ctrl_ll_master_enable_clock(true);
+	regi2c_ctrl_ll_master_configure_clock();
+
+	REGI2C_WRITE_MASK(I2C_BIAS, I2C_BIAS_DREG_1P1, 10);
+	REGI2C_WRITE_MASK(I2C_BIAS, I2C_BIAS_DREG_1P1_PVT, 10);
+}
+
+void ana_super_wdt_reset_config(bool enable)
+{
+	(void)enable;
+}
+
+void ana_bod_reset_config(bool enable)
+{
+	brownout_ll_ana_reset_enable(enable);
+}
+
+void ana_reset_config(void)
+{
+	ana_super_wdt_reset_config(true);
+	ana_bod_reset_config(true);
+}
+
+void super_wdt_auto_feed(void)
+{
+	REG_WRITE(LP_WDT_SWD_WPROTECT_REG, LP_WDT_SWD_WKEY_VALUE);
+	REG_SET_BIT(LP_WDT_SWD_CONFIG_REG, LP_WDT_SWD_AUTO_FEED_EN);
+	REG_WRITE(LP_WDT_SWD_WPROTECT_REG, 0);
+}
+
+void wdt_reset_cpu0_info_enable(void)
+{
+	_assist_debug_ll_enable_bus_clock(0, true);
+	assist_debug_ll_enable_pc_recording(0, true);
+}
+
+void check_wdt_reset(void)
+{
+	int wdt_rst = 0;
+	soc_reset_reason_t rst_reas;
+
+	rst_reas = esp_rom_get_reset_reason(0);
+	if (rst_reas == RESET_REASON_CPU_MWDT || rst_reas == RESET_REASON_CPU_RWDT ||
+	    rst_reas == RESET_REASON_CORE_MWDT || rst_reas == RESET_REASON_CORE_RWDT ||
+	    rst_reas == RESET_REASON_SYS_RWDT) {
+		ESP_EARLY_LOGW(TAG, "PRO CPU has been reset by WDT.");
+		wdt_rst = 1;
+	}
+
+	(void)wdt_rst;
+	wdt_reset_cpu0_info_enable();
+}
+
+/* Not supported but common bootloader calls the function. Do nothing */
+void ana_clock_glitch_reset_config(bool enable)
+{
+	(void)enable;
+}
+
+#if defined(CONFIG_ESP_SIMPLE_BOOT) || defined(CONFIG_MCUBOOT)
+#include "soc/pmu_reg.h"
+#include "soc/lp_system_reg.h"
+#include "soc/chip_revision.h"
+#include "esp_rom_serial_output.h"
+#include "esp_rom_regi2c.h"
+#include "soc/regi2c_cpll.h"
+#include "hal/mspi_ll.h"
+#include "hal/efuse_hal.h"
+#include "pmu_param.h"
+
+/*
+ * Custom bootloader_clock_configure() for ESP32-P4 simple boot mode.
+ *
+ * In simple boot mode, we enable PLL and switch CPU clock source so that
+ * flash can run at higher speeds. The ROM bootloader leaves CPU on XTAL.
+ */
+void bootloader_clock_configure(void)
+{
+	esp_rom_output_tx_wait_idle(0);
+
+	clk_ll_xtal_store_freq_mhz(SOC_XTAL_FREQ_40M);
+
+	clk_ll_cpll_enable();
+
+	clk_ll_cpll_calibration_start();
+	while (!clk_ll_cpll_calibration_is_done()) {
+		;
+	}
+	esp_rom_delay_us(10);
+	clk_ll_cpll_calibration_stop();
+
+	/*
+	 * Voltage regulator + DCDC handoff, mirroring ESP-IDF rtc_clk_init().
+	 * The ROM leaves the chip on LDO with default dbias. This sequence
+	 * calibrates dbias, enables the DCDC switch, hands DIG dbias control
+	 * to PMU, and finally turns the LDO off so DCDC drives HP. Required
+	 * before deep sleep, because pmu_sleep_shutdown_ldo() expects DCDC
+	 * to be the active regulator on wake.
+	 */
+	uint32_t hp_cali_dbias = get_act_hp_dbias();
+	uint32_t lp_cali_dbias = get_act_lp_dbias();
+	unsigned chip_version = efuse_hal_chip_revision();
+
+	pmu_ll_hp_set_regulator_xpd(&PMU, PMU_MODE_HP_ACTIVE, true);
+	pmu_ll_hp_set_regulator_dbias(&PMU, PMU_MODE_HP_ACTIVE, hp_cali_dbias);
+	pmu_ll_lp_set_regulator_dbias(&PMU, PMU_MODE_LP_ACTIVE, lp_cali_dbias);
+
+	uint32_t pvt_hp_dcmvset =
+		GET_PERI_REG_BITS2(PMU_HP_ACTIVE_HP_REGULATOR0_REG,
+				   PMU_HP_DBIAS_VOL_V, PMU_HP_DBIAS_VOL_S);
+	uint32_t hp_dcmvset = HP_CALI_ACTIVE_DCM_VSET_DEFAULT;
+
+	if (pvt_hp_dcmvset > hp_dcmvset) {
+		hp_dcmvset = pvt_hp_dcmvset;
+	}
+
+	if (ESP_CHIP_REV_ABOVE(chip_version, 301)) {
+		SET_PERI_REG_MASK(PMU_DCM_CTRL_REG, PMU_DCDC_FB_RES_FORCE_PD);
+	}
+	pmu_ll_set_dcdc_en(&PMU, true);
+	pmu_ll_set_dcdc_switch_force_power_down(&PMU, false);
+	pmu_ll_hp_set_dcm_vset(&PMU, PMU_MODE_HP_ACTIVE, hp_dcmvset);
+	SET_PERI_REG_MASK(PMU_HP_ACTIVE_HP_REGULATOR0_REG,
+			  PMU_DIG_REGULATOR0_DBIAS_SEL);
+	esp_rom_delay_us(1000);
+	if (ESP_CHIP_REV_ABOVE(chip_version, 301)) {
+		REG_SET_FIELD(LP_SYSTEM_REG_SYS_CTRL_REG,
+			      LP_SYSTEM_REG_LP_FIB_SEL, 0xEF);
+		CLEAR_PERI_REG_MASK(PMU_DCM_CTRL_REG, PMU_DCDC_FB_RES_FORCE_PD);
+		esp_rom_delay_us(10);
+	}
+	pmu_ll_hp_set_regulator_xpd(&PMU, PMU_MODE_HP_ACTIVE, false);
+
+	/* Upscale CPU to CONFIG_BOOTLOADER_CPU_CLK_FREQ_MHZ (100 MHz on
+	 * ECO >= 3.0), matching ESP-IDF rtc_clk_cpu_freq_to_cpll_mhz():
+	 *   CPLL = 400 MHz, cpu_div = 4 -> CPU = 100 MHz
+	 *   mem_div = 1, sys_div = 1, apb_div = 1
+	 * Upscaling order: APB -> SYS -> MEM -> CPU -> src switch.
+	 */
+	clk_ll_apb_set_divider(1);
+	clk_ll_bus_update();
+	clk_ll_sys_set_divider(1);
+	clk_ll_bus_update();
+	clk_ll_mem_set_divider(1);
+	clk_ll_bus_update();
+	clk_ll_cpu_set_divider(4, 0, 0);
+	clk_ll_bus_update();
+	clk_ll_cpu_set_src(SOC_CPU_CLK_SRC_CPLL);
+	esp_rom_set_cpu_ticks_per_us(CONFIG_BOOTLOADER_CPU_CLK_FREQ_MHZ);
+
+	/* MSPI flash: SPLL (480MHz) with core clock at 80MHz */
+	_mspi_timing_ll_set_flash_clk_src(0, FLASH_CLK_SRC_SPLL);
+	_mspi_timing_ll_set_flash_core_clock(0, 80);
+
+	CLEAR_PERI_REG_MASK(LP_WDT_INT_ENA_REG, LP_WDT_SUPER_WDT_INT_ENA);
+	CLEAR_PERI_REG_MASK(LP_WDT_INT_ENA_REG, LP_WDT_LP_WDT_INT_ENA);
+	CLEAR_PERI_REG_MASK(PMU_HP_INT_ENA_REG, PMU_SOC_WAKEUP_INT_ENA);
+	CLEAR_PERI_REG_MASK(PMU_HP_INT_ENA_REG, PMU_SOC_SLEEP_REJECT_INT_ENA);
+
+	SET_PERI_REG_MASK(LP_WDT_INT_CLR_REG, LP_WDT_SUPER_WDT_INT_CLR);
+	SET_PERI_REG_MASK(LP_WDT_INT_CLR_REG, LP_WDT_LP_WDT_INT_CLR);
+}
+#endif /* CONFIG_ESP_SIMPLE_BOOT || CONFIG_MCUBOOT */
+
+#include "esp_sleep.h"
+__attribute__((weak)) esp_err_t esp_sleep_pd_config(esp_sleep_pd_domain_t domain,
+						    esp_sleep_pd_option_t option)
+{
+	(void)domain;
+	(void)option;
+	return 0;
+}

--- a/zephyr/esp32p4/src/soc_random.c
+++ b/zephyr/esp32p4/src/soc_random.c
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include "soc_random.h"
+#include <esp_private/regi2c_ctrl.h>
+#include <hal/adc_ll.h>
+#include <hal/adc_types.h>
+#include <hal/regi2c_ctrl_ll.h>
+
+#define I2C_SAR_ADC_INIT_CODE_VAL       2166
+#define ADC_RNG_CLKM_DIV_NUM            0
+#define ADC_RNG_CLKM_DIV_B              0
+#define ADC_RNG_CLKM_DIV_A              0
+
+void soc_random_enable(void)
+{
+	_adc_ll_reset_register();
+	_adc_ll_enable_bus_clock(true);
+
+	adc_ll_digi_clk_sel(ADC_DIGI_CLK_SRC_XTAL);
+	adc_ll_digi_controller_clk_div(ADC_RNG_CLKM_DIV_NUM, ADC_RNG_CLKM_DIV_B, ADC_RNG_CLKM_DIV_A);
+
+	/* Some ADC sensor registers are in power group PERIF_I2C and need to be enabled via PMU */
+	regi2c_ctrl_ll_i2c_sar_periph_enable();
+
+	/* Enable analog I2C master clock for RNG runtime */
+	ANALOG_CLOCK_ENABLE();
+
+	adc_ll_regi2c_init();
+	adc_ll_set_calibration_param(ADC_UNIT_1, I2C_SAR_ADC_INIT_CODE_VAL);
+
+	adc_digi_pattern_config_t pattern_config = {};
+
+	pattern_config.unit = ADC_UNIT_1;
+	pattern_config.atten = ADC_ATTEN_DB_12;
+	pattern_config.channel = ADC_CHANNEL_10;
+	adc_ll_digi_set_pattern_table(ADC_UNIT_1, 0, pattern_config);
+	adc_ll_digi_set_pattern_table(ADC_UNIT_1, 1, pattern_config);
+	adc_ll_digi_set_pattern_table(ADC_UNIT_1, 2, pattern_config);
+	adc_ll_digi_set_pattern_table(ADC_UNIT_1, 3, pattern_config);
+	adc_ll_digi_set_pattern_table_len(ADC_UNIT_1, 1);
+
+	adc_ll_set_controller(ADC_UNIT_1, ADC_LL_CTRL_DIG);
+	adc_ll_digi_set_power_manage(ADC_UNIT_1, ADC_LL_POWER_SW_ON);
+
+	adc_ll_digi_set_clk_div(15);
+	adc_ll_digi_set_trigger_interval(100);
+	adc_ll_digi_trigger_enable();
+}
+
+void soc_random_disable(void)
+{
+	adc_ll_digi_trigger_disable();
+	adc_ll_digi_reset_pattern_table();
+	adc_ll_set_calibration_param(ADC_UNIT_1, 0x0);
+	adc_ll_set_calibration_param(ADC_UNIT_2, 0x0);
+
+	adc_ll_regi2c_adc_deinit();
+
+	/* Disable analog I2C master clock */
+	ANALOG_CLOCK_DISABLE();
+	adc_ll_digi_controller_clk_div(4, 0, 0);
+	adc_ll_digi_clk_sel(ADC_DIGI_CLK_SRC_XTAL);
+
+	adc_ll_set_controller(ADC_UNIT_1, ADC_LL_CTRL_ULP);
+}

--- a/zephyr/port/boot/esp_image_loader.c
+++ b/zephyr/port/boot/esp_image_loader.c
@@ -18,15 +18,21 @@
 	!defined(CONFIG_SOC_SERIES_ESP32C3) &&	\
 	!defined(CONFIG_SOC_SERIES_ESP32C5) &&	\
 	!defined(CONFIG_SOC_SERIES_ESP32C6) &&	\
-	!defined(CONFIG_SOC_SERIES_ESP32H2)
+	!defined(CONFIG_SOC_SERIES_ESP32H2) &&	\
+	!defined(CONFIG_SOC_SERIES_ESP32P4)
 #include "soc/dport_reg.h"
 #endif
 
 #include "esp_rom_sys.h"
+#include "soc/soc_caps.h"
+#if SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE
+#include "hal/cache_ll.h"
+#include "hal/cache_types.h"
+#endif
 #include "soc/gpio_periph.h"
 #include "soc/rtc_periph.h"
 #if !defined(CONFIG_SOC_SERIES_ESP32C5) && !defined(CONFIG_SOC_SERIES_ESP32C6) && \
-	!defined(CONFIG_SOC_SERIES_ESP32H2)
+	!defined(CONFIG_SOC_SERIES_ESP32H2) && !defined(CONFIG_SOC_SERIES_ESP32P4)
 #include "soc/rtc_cntl_reg.h"
 #endif
 #include "esp_cpu.h"
@@ -55,6 +61,9 @@
 #define LP_RTC_PREFIX "LP"
 #elif CONFIG_SOC_SERIES_ESP32H2
 #include "esp32h2/rom/uart.h"
+#define LP_RTC_PREFIX "LP"
+#elif CONFIG_SOC_SERIES_ESP32P4
+#include "esp32p4/rom/uart.h"
 #define LP_RTC_PREFIX "LP"
 #endif
 
@@ -194,6 +203,18 @@ void esp_app_image_load(int image_index, int slot,
                  load_header.iram_size, load_header.iram_size);
     load_segment(fap, load_header.iram_flash_offset,
                  load_header.iram_size, load_header.iram_dest_addr);
+
+#if SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE
+    /*
+     * On SoCs where internal SRAM is accessed via L1 cache (e.g. ESP32-P4),
+     * the memcpy above writes through the D-cache so the freshly loaded
+     * segments may live in dirty D-cache lines that have not yet been
+     * pushed to physical SRAM. The CPU will fetch the app's instructions
+     * via the I-cache, which reads physical SRAM and would see stale data.
+     * Writeback the D-cache so the I-cache fetch sees the loaded image.
+     */
+    cache_ll_writeback_all(CACHE_LL_LEVEL_INT_MEM, CACHE_TYPE_DATA, CACHE_LL_ID_ALL);
+#endif
 
     uart_tx_wait_idle(0);
 

--- a/zephyr/port/pincfgs/esp32p4.yml
+++ b/zephyr/port/pincfgs/esp32p4.yml
@@ -1,0 +1,341 @@
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# Notes:
+# - ESP32-P4 has 55 GPIO pads (0-54)
+# - Some pads may be reserved for flash/PSRAM depending on package
+
+uart0:
+  tx:
+    sigo: u0txd_out
+    gpio: [[0, 54]]
+  rx:
+    sigi: u0rxd_in
+    gpio: [[0, 54]]
+  rts:
+    sigo: u0rts_out
+    gpio: [[0, 54]]
+  cts:
+    sigi: u0cts_in
+    gpio: [[0, 54]]
+  dtr:
+    sigo: u0dtr_out
+    gpio: [[0, 54]]
+  dsr:
+    sigi: u0dsr_in
+    gpio: [[0, 54]]
+
+uart1:
+  tx:
+    sigo: u1txd_out
+    gpio: [[0, 54]]
+  rx:
+    sigi: u1rxd_in
+    gpio: [[0, 54]]
+  rts:
+    sigo: u1rts_out
+    gpio: [[0, 54]]
+  cts:
+    sigi: u1cts_in
+    gpio: [[0, 54]]
+  dtr:
+    sigo: u1dtr_out
+    gpio: [[0, 54]]
+  dsr:
+    sigi: u1dsr_in
+    gpio: [[0, 54]]
+
+uart2:
+  tx:
+    sigo: u2txd_out
+    gpio: [[0, 54]]
+  rx:
+    sigi: u2rxd_in
+    gpio: [[0, 54]]
+  rts:
+    sigo: u2rts_out
+    gpio: [[0, 54]]
+  cts:
+    sigi: u2cts_in
+    gpio: [[0, 54]]
+  dtr:
+    sigo: u2dtr_out
+    gpio: [[0, 54]]
+  dsr:
+    sigi: u2dsr_in
+    gpio: [[0, 54]]
+
+uart3:
+  tx:
+    sigo: u3txd_out
+    gpio: [[0, 54]]
+  rx:
+    sigi: u3rxd_in
+    gpio: [[0, 54]]
+  rts:
+    sigo: u3rts_out
+    gpio: [[0, 54]]
+  cts:
+    sigi: u3cts_in
+    gpio: [[0, 54]]
+  dtr:
+    sigo: u3dtr_out
+    gpio: [[0, 54]]
+  dsr:
+    sigi: u3dsr_in
+    gpio: [[0, 54]]
+
+uart4:
+  tx:
+    sigo: u4txd_out
+    gpio: [[0, 54]]
+  rx:
+    sigi: u4rxd_in
+    gpio: [[0, 54]]
+  rts:
+    sigo: u4rts_out
+    gpio: [[0, 54]]
+  cts:
+    sigi: u4cts_in
+    gpio: [[0, 54]]
+  dtr:
+    sigo: u4dtr_out
+    gpio: [[0, 54]]
+  dsr:
+    sigi: u4dsr_in
+    gpio: [[0, 54]]
+
+spim2:
+  miso:
+    sigi: fspiq_in
+    gpio: [[0, 54]]
+  mosi:
+    sigo: fspid_out
+    gpio: [[0, 54]]
+  sclk:
+    sigo: fspiclk_out
+    gpio: [[0, 54]]
+  csel:
+    sigo: fspics0_out
+    gpio: [[0, 54]]
+
+spim3:
+  miso:
+    sigi: spi3_q_in
+    gpio: [[0, 54]]
+  mosi:
+    sigo: spi3_d_out
+    gpio: [[0, 54]]
+  sclk:
+    sigo: spi3_ck_out
+    gpio: [[0, 54]]
+  csel:
+    sigo: spi3_cs_out
+    gpio: [[0, 54]]
+
+i2c0:
+  sda:
+    sigo: i2cext0_sda_out
+    sigi: i2cext0_sda_in
+    gpio: [[0, 54]]
+  scl:
+    sigo: i2cext0_scl_out
+    sigi: i2cext0_scl_in
+    gpio: [[0, 54]]
+
+i2c1:
+  sda:
+    sigo: i2cext1_sda_out
+    sigi: i2cext1_sda_in
+    gpio: [[0, 54]]
+  scl:
+    sigo: i2cext1_scl_out
+    sigi: i2cext1_scl_in
+    gpio: [[0, 54]]
+
+ledc:
+  ch0:
+    sigo: ledc_ls_sig_out0
+    gpio: [[0, 54]]
+  ch1:
+    sigo: ledc_ls_sig_out1
+    gpio: [[0, 54]]
+  ch2:
+    sigo: ledc_ls_sig_out2
+    gpio: [[0, 54]]
+  ch3:
+    sigo: ledc_ls_sig_out3
+    gpio: [[0, 54]]
+  ch4:
+    sigo: ledc_ls_sig_out4
+    gpio: [[0, 54]]
+  ch5:
+    sigo: ledc_ls_sig_out5
+    gpio: [[0, 54]]
+  ch6:
+    sigo: ledc_ls_sig_out6
+    gpio: [[0, 54]]
+  ch7:
+    sigo: ledc_ls_sig_out7
+    gpio: [[0, 54]]
+
+mcpwm0:
+  out0a:
+    sigo: pwm0_ch0_a_out
+    gpio: [[0, 54]]
+  out0b:
+    sigo: pwm0_ch0_b_out
+    gpio: [[0, 54]]
+  out1a:
+    sigo: pwm0_ch1_a_out
+    gpio: [[0, 54]]
+  out1b:
+    sigo: pwm0_ch1_b_out
+    gpio: [[0, 54]]
+  out2a:
+    sigo: pwm0_ch2_a_out
+    gpio: [[0, 54]]
+  out2b:
+    sigo: pwm0_ch2_b_out
+    gpio: [[0, 54]]
+  sync0:
+    sigi: pwm0_sync0_in
+    gpio: [[0, 54]]
+  sync1:
+    sigi: pwm0_sync1_in
+    gpio: [[0, 54]]
+  sync2:
+    sigi: pwm0_sync2_in
+    gpio: [[0, 54]]
+  fault0:
+    sigi: pwm0_f0_in
+    gpio: [[0, 54]]
+  fault1:
+    sigi: pwm0_f1_in
+    gpio: [[0, 54]]
+  fault2:
+    sigi: pwm0_f2_in
+    gpio: [[0, 54]]
+  cap0:
+    sigi: pwm0_cap0_in
+    gpio: [[0, 54]]
+  cap1:
+    sigi: pwm0_cap1_in
+    gpio: [[0, 54]]
+  cap2:
+    sigi: pwm0_cap2_in
+    gpio: [[0, 54]]
+
+i2s0:
+  o_bck:
+    sigo: i2s0_o_bck_out
+    sigi: i2s0_o_bck_in
+    gpio: [[0, 54]]
+  o_ws:
+    sigo: i2s0_o_ws_out
+    sigi: i2s0_o_ws_in
+    gpio: [[0, 54]]
+  o_sd:
+    sigo: i2s0_o_sd_out
+    gpio: [[0, 54]]
+  i_sd:
+    sigi: i2s0_i_sd_in
+    gpio: [[0, 54]]
+  i_bck:
+    sigo: i2s0_i_bck_out
+    sigi: i2s0_i_bck_in
+    gpio: [[0, 54]]
+  i_ws:
+    sigo: i2s0_i_ws_out
+    sigi: i2s0_i_ws_in
+    gpio: [[0, 54]]
+  mclk:
+    sigo: i2s0_mclk_out
+    sigi: i2s0_mclk_in
+    gpio: [[0, 54]]
+
+i2s1:
+  o_bck:
+    sigo: i2s1_o_bck_out
+    sigi: i2s1_o_bck_in
+    gpio: [[0, 54]]
+  o_ws:
+    sigo: i2s1_o_ws_out
+    sigi: i2s1_o_ws_in
+    gpio: [[0, 54]]
+  o_sd:
+    sigo: i2s1_o_sd_out
+    gpio: [[0, 54]]
+  i_sd:
+    sigi: i2s1_i_sd_in
+    gpio: [[0, 54]]
+  i_bck:
+    sigo: i2s1_i_bck_out
+    sigi: i2s1_i_bck_in
+    gpio: [[0, 54]]
+  i_ws:
+    sigo: i2s1_i_ws_out
+    sigi: i2s1_i_ws_in
+    gpio: [[0, 54]]
+  mclk:
+    sigo: i2s1_mclk_out
+    sigi: i2s1_mclk_in
+    gpio: [[0, 54]]
+
+twai0:
+  tx:
+    sigo: twai0_tx_out
+    gpio: [[0, 54]]
+  rx:
+    sigi: twai0_rx_in
+    gpio: [[0, 54]]
+
+twai1:
+  tx:
+    sigo: twai1_tx_out
+    gpio: [[0, 54]]
+  rx:
+    sigi: twai1_rx_in
+    gpio: [[0, 54]]
+
+twai2:
+  tx:
+    sigo: twai2_tx_out
+    gpio: [[0, 54]]
+  rx:
+    sigi: twai2_rx_in
+    gpio: [[0, 54]]
+
+smi:
+  mdc:
+    sigo: emac_mdc_o
+    gpio: [[0, 54]]
+  mdio:
+    sigi: emac_mdi_i
+    sigo: emac_mdo_o
+    gpio: [[0, 54]]
+
+sdhc1:
+  clkout:
+    sigo: sd_card_cclk_2_out
+    gpio: [[0, 54]]
+  cmd:
+    sigi: sd_card_ccmd_2_in
+    sigo: sd_card_ccmd_2_out
+    gpio: [[0, 54]]
+  data0:
+    sigi: sd_card_cdata0_2_in
+    sigo: sd_card_cdata0_2_out
+    gpio: [[0, 54]]
+  data1:
+    sigi: sd_card_cdata1_2_in
+    sigo: sd_card_cdata1_2_out
+    gpio: [[0, 54]]
+  data2:
+    sigi: sd_card_cdata2_2_in
+    sigo: sd_card_cdata2_2_out
+    gpio: [[0, 54]]
+  data3:
+    sigi: sd_card_cdata3_2_in
+    sigo: sd_card_cdata3_2_out
+    gpio: [[0, 54]]


### PR DESCRIPTION
This adds all needed components folder porting, custom soc porting and needed sources for ESP32-P4.