### PR TITLE
cmakelists: esp32c5/c6/h2: always build spi_periph.c with spim

### DIFF
--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -204,13 +204,9 @@ if(CONFIG_SOC_SERIES_ESP32C5)
     zephyr_sources(
       ../../components/esp_hal_gpspi/spi_hal.c
       ../../components/esp_hal_gpspi/spi_hal_iram.c
+      ../../components/esp_hal_gpspi/${CONFIG_SOC_SERIES}/spi_periph.c
       ../../components/esp_hal_dma/gdma_hal_top.c
       )
-    if(CONFIG_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
-      zephyr_sources(
-        ../../components/esp_hal_gpspi/${CONFIG_SOC_SERIES}/spi_periph.c
-        )
-    endif()
   endif()
 
   if(CONFIG_SOC_FLASH_ESP32 OR NOT CONFIG_BOOTLOADER_MCUBOOT)

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -199,13 +199,9 @@ if(CONFIG_SOC_SERIES_ESP32C6)
     zephyr_sources(
       ../../components/esp_hal_gpspi/spi_hal.c
       ../../components/esp_hal_gpspi/spi_hal_iram.c
+      ../../components/esp_hal_gpspi/${CONFIG_SOC_SERIES}/spi_periph.c
       ../../components/esp_hal_dma/gdma_hal_top.c
       )
-    if(CONFIG_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
-      zephyr_sources(
-        ../../components/esp_hal_gpspi/${CONFIG_SOC_SERIES}/spi_periph.c
-        )
-    endif()
   endif()
 
   if(CONFIG_SOC_FLASH_ESP32 OR NOT CONFIG_BOOTLOADER_MCUBOOT)

--- a/zephyr/esp32h2/CMakeLists.txt
+++ b/zephyr/esp32h2/CMakeLists.txt
@@ -330,14 +330,10 @@ if(CONFIG_SOC_SERIES_ESP32H2)
     zephyr_sources(
       ../../components/esp_hal_gpspi/spi_hal.c
       ../../components/esp_hal_gpspi/spi_hal_iram.c
+      ../../components/esp_hal_gpspi/${CONFIG_SOC_SERIES}/spi_periph.c
       ../../components/esp_hal_dma/gdma_hal_top.c
       ../../components/esp_hal_dma/gdma_hal_ahb_v1.c
       )
-    if(CONFIG_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
-      zephyr_sources(
-        ../../components/esp_hal_gpspi/${CONFIG_SOC_SERIES}/spi_periph.c
-        )
-    endif()
   endif()
 
   if(CONFIG_DMA_ESP32)


### PR DESCRIPTION
Commit 75a0b92032 ("hal: peripherals: Sleep retention support") moved spi_periph.c behind CONFIG_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP on the C5, C6 and H2 ports while spi_hal.c is still built unconditionally whenever CONFIG_ESP32_SPIM is selected. Because spi_hal_init() references the spi_periph_signal[] table that lives in spi_periph.c, any image with the SPI master driver but without peripheral sleep retention fails to link with:

  undefined reference to 'spi_periph_signal'

Always source spi_periph.c alongside spi_hal.c, matching the C3 and S3 ports, so the GPSPI master driver links on every configuration.