### PR TITLE
zephyr: enable LLVM/Clang build compatibility for Espressif targets

### DIFF
--- a/components/riscv/include/riscv/csr.h
+++ b/components/riscv/include/riscv/csr.h
@@ -240,8 +240,12 @@ extern "C" {
   asm volatile ("csrrci %0, mstatus, 0x8"  : "=r"(__tmp)); __tmp; })
 
 
-#define _CSR_STRINGIFY(REG) #REG /* needed so the 'reg' argument can be a macro or a register name */
+#ifndef tcontrol
+#define tcontrol 0x7a5
+#endif
 
+#define __CSR_STRINGIFY(REG) #REG
+#define _CSR_STRINGIFY(REG) __CSR_STRINGIFY(REG) /* needed so the 'reg' argument can be a macro or a register name */
 #ifdef __cplusplus
 }
 #endif

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -40,9 +40,16 @@ zephyr_sources_ifdef(
   ../components/soc/dport_access_common.c
   )
 
+zephyr_sources_ifdef(
+  CONFIG_ATOMIC_OPERATIONS_C
+  common/atomic_stubs.c
+)
+
 if(CONFIG_SOC_SERIES_ESP32C5 OR CONFIG_SOC_SERIES_ESP32C6 OR CONFIG_SOC_SERIES_ESP32H2)
   zephyr_sources(../components/esp_hal_security/apm_hal.c)
 endif()
+
+set(ESPRESSIF_ZEPHYR_LINK_LIBGCC $<IF:$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>>,,gcc>)
 
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32 esp32)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32C2 esp32c2)

--- a/zephyr/common/atomic_stubs.c
+++ b/zephyr/common/atomic_stubs.c
@@ -1,0 +1,97 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <zephyr/irq.h>
+#include <esp_attr.h>
+
+#define ATOMIC_LOAD(size, type) \
+    IRAM_ATTR __attribute__((weak)) type __atomic_load_##size(const volatile void *ptr, const int memorder) { \
+        (void)memorder; \
+        return *(const volatile type *)ptr; \
+    }
+
+#define ATOMIC_STORE(size, type) \
+    IRAM_ATTR __attribute__((weak)) void __atomic_store_##size(volatile void *ptr, const type val, const int memorder) { \
+        (void)memorder; \
+        *(volatile type *)ptr = val; \
+    }
+
+#define ATOMIC_EXCHANGE(size, type) \
+    IRAM_ATTR __attribute__((weak)) type __atomic_exchange_##size(volatile void *ptr, const type val, const int memorder) { \
+        (void)memorder; \
+        const unsigned int key = irq_lock(); \
+        const type old = *(volatile type *)ptr; \
+        *(volatile type *)ptr = val; \
+        irq_unlock(key); \
+        return old; \
+    }
+
+#define ATOMIC_COMPARE_EXCHANGE(size, type) \
+    IRAM_ATTR __attribute__((weak)) bool __atomic_compare_exchange_##size(volatile void *ptr, void *expected, const type desired, const bool weak, const int success_memorder, const int failure_memorder) { \
+        (void)weak; (void)success_memorder; (void)failure_memorder; \
+        const unsigned int key = irq_lock(); \
+        const type actual = *(volatile type *)ptr; \
+        const type exp = *(type *)expected; \
+        if (actual == exp) { \
+            *(volatile type *)ptr = desired; \
+            irq_unlock(key); \
+            return true; \
+        } else { \
+            *(type *)expected = actual; \
+            irq_unlock(key); \
+            return false; \
+        } \
+    }
+
+#define ATOMIC_FETCH_OP(op, name, size, type) \
+    IRAM_ATTR __attribute__((weak)) type __atomic_fetch_##name##_##size(volatile void *ptr, const type val, const int memorder) { \
+        (void)memorder; \
+        const unsigned int key = irq_lock(); \
+        const type old = *(volatile type *)ptr; \
+        *(volatile type *)ptr = old op val; \
+        irq_unlock(key); \
+        return old; \
+    }
+
+// 1-byte atomics
+ATOMIC_LOAD(1, uint8_t)
+ATOMIC_STORE(1, uint8_t)
+ATOMIC_EXCHANGE(1, uint8_t)
+ATOMIC_COMPARE_EXCHANGE(1, uint8_t)
+ATOMIC_FETCH_OP(+, add, 1, uint8_t)
+ATOMIC_FETCH_OP(-, sub, 1, uint8_t)
+ATOMIC_FETCH_OP(&, and, 1, uint8_t)
+ATOMIC_FETCH_OP(|, or, 1, uint8_t)
+ATOMIC_FETCH_OP(^, xor, 1, uint8_t)
+
+// 2-byte atomics
+ATOMIC_LOAD(2, uint16_t)
+ATOMIC_STORE(2, uint16_t)
+ATOMIC_EXCHANGE(2, uint16_t)
+ATOMIC_COMPARE_EXCHANGE(2, uint16_t)
+ATOMIC_FETCH_OP(+, add, 2, uint16_t)
+ATOMIC_FETCH_OP(-, sub, 2, uint16_t)
+ATOMIC_FETCH_OP(&, and, 2, uint16_t)
+ATOMIC_FETCH_OP(|, or, 2, uint16_t)
+ATOMIC_FETCH_OP(^, xor, 2, uint16_t)
+
+// 4-byte atomics
+ATOMIC_LOAD(4, uint32_t)
+ATOMIC_STORE(4, uint32_t)
+ATOMIC_EXCHANGE(4, uint32_t)
+ATOMIC_COMPARE_EXCHANGE(4, uint32_t)
+ATOMIC_FETCH_OP(+, add, 4, uint32_t)
+ATOMIC_FETCH_OP(-, sub, 4, uint32_t)
+ATOMIC_FETCH_OP(&, and, 4, uint32_t)
+ATOMIC_FETCH_OP(|, or, 4, uint32_t)
+ATOMIC_FETCH_OP(^, xor, 4, uint32_t)
+
+// 8-byte atomics
+ATOMIC_LOAD(8, uint64_t)
+ATOMIC_STORE(8, uint64_t)
+ATOMIC_EXCHANGE(8, uint64_t)
+ATOMIC_COMPARE_EXCHANGE(8, uint64_t)
+ATOMIC_FETCH_OP(+, add, 8, uint64_t)
+ATOMIC_FETCH_OP(-, sub, 8, uint64_t)
+ATOMIC_FETCH_OP(&, and, 8, uint64_t)
+ATOMIC_FETCH_OP(|, or, 8, uint64_t)
+ATOMIC_FETCH_OP(^, xor, 8, uint64_t)

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 if(CONFIG_SOC_SERIES_ESP32)
 
-  zephyr_compile_options(-fstrict-volatile-bitfields)
+  zephyr_cc_option(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
   zephyr_compile_definitions_ifndef(typeof typeof=__typeof__)
@@ -160,7 +160,7 @@ if(CONFIG_SOC_SERIES_ESP32)
   endif()
 
   zephyr_link_libraries(
-    gcc
+    ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
       -T${CMAKE_CURRENT_SOURCE_DIR}/src/linker/${CONFIG_SOC_SERIES}.rom.alias.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.api.ld
@@ -458,7 +458,7 @@ if(CONFIG_SOC_SERIES_ESP32)
       phy
       rtc
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
-      gcc
+      ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
         -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32
       )
   endif()

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 if(CONFIG_SOC_SERIES_ESP32C2)
 
-  zephyr_compile_options(-fstrict-volatile-bitfields)
+  zephyr_cc_option(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
   zephyr_compile_definitions_ifndef(typeof typeof=__typeof__)
@@ -142,18 +142,18 @@ if(CONFIG_SOC_SERIES_ESP32C2)
   endif()
 
   zephyr_link_libraries_ifdef(CONFIG_SOC_ESP32C2_REV_2_0
-    gcc
+    ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.eco4.ld
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.ble-eco4.ld
   )
 
   zephyr_link_libraries_ifndef(CONFIG_SOC_ESP32C2_REV_2_0
-    gcc
+    ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.ble.ld
   )
 
   zephyr_link_libraries(
-    gcc
+    ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
     -T${CMAKE_CURRENT_SOURCE_DIR}/src/linker/${CONFIG_SOC_SERIES}.rom.alias.ld
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.ld
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.api.ld
@@ -409,7 +409,7 @@ if(CONFIG_SOC_SERIES_ESP32C2)
       pp
       phy
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
-      gcc
+      ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
         -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
       )
   endif()

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 if(CONFIG_SOC_SERIES_ESP32C3)
 
-  zephyr_compile_options(-fstrict-volatile-bitfields)
+  zephyr_cc_option(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
   zephyr_compile_definitions_ifndef(typeof typeof=__typeof__)
@@ -148,12 +148,12 @@ if(CONFIG_SOC_SERIES_ESP32C3)
   endif()
 
   zephyr_link_libraries_ifdef(CONFIG_SOC_ESP32C3_REV_1_1
-    gcc
+    ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.eco7.ld
   )
 
   zephyr_link_libraries(
-    gcc
+    ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
     -T${CMAKE_CURRENT_SOURCE_DIR}/src/linker/${CONFIG_SOC_SERIES}.rom.alias.ld
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.ld
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.api.ld
@@ -428,7 +428,7 @@ if(CONFIG_SOC_SERIES_ESP32C3)
       phy
       mesh
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
-      gcc
+      ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
         -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32c3
       )
   endif()
@@ -453,12 +453,12 @@ if(CONFIG_SOC_SERIES_ESP32C3)
 
 
     zephyr_link_libraries_ifdef(CONFIG_SOC_ESP32C3_REV_1_1
-      gcc
+      ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.eco7_bt_funcs.ld
       )
 
     zephyr_link_libraries(
-      gcc
+      ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.bt_funcs.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.eco3_bt_funcs.ld
       )

--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 if(CONFIG_SOC_SERIES_ESP32C5)
 
-  zephyr_compile_options(-fstrict-volatile-bitfields)
+  zephyr_cc_option(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
   zephyr_compile_definitions_ifndef(typeof typeof=__typeof__)
@@ -174,7 +174,7 @@ if(CONFIG_SOC_SERIES_ESP32C5)
   endif()
 
   zephyr_link_libraries(
-    gcc
+    ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/soc/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.peripherals.ld
   )
 
@@ -574,7 +574,7 @@ if(CONFIG_SOC_SERIES_ESP32C5)
       phy
       mesh
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
-      gcc
+      ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
         -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.pp.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.phy.ld

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 if(CONFIG_SOC_SERIES_ESP32C6)
 
-  zephyr_compile_options(-fstrict-volatile-bitfields)
+  zephyr_cc_option(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
   zephyr_compile_definitions_ifndef(typeof typeof=__typeof__)
@@ -169,7 +169,7 @@ if(CONFIG_SOC_SERIES_ESP32C6)
   endif()
 
   zephyr_link_libraries(
-    gcc
+    ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/soc/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.peripherals.ld
   )
 
@@ -546,7 +546,7 @@ if(CONFIG_SOC_SERIES_ESP32C6)
       phy
       mesh
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
-      gcc
+      ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
         -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.pp.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.phy.ld

--- a/zephyr/esp32h2/CMakeLists.txt
+++ b/zephyr/esp32h2/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 if(CONFIG_SOC_SERIES_ESP32H2)
 
-  zephyr_compile_options(-fstrict-volatile-bitfields)
+  zephyr_cc_option(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
   zephyr_compile_definitions_ifndef(typeof typeof=__typeof__)
@@ -140,7 +140,7 @@ if(CONFIG_SOC_SERIES_ESP32H2)
   )
 
   zephyr_link_libraries(
-    gcc
+    ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
     -T${CMAKE_CURRENT_SOURCE_DIR}/src/linker/${CONFIG_SOC_SERIES}.rom.alias.ld
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.ld
     -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.api.ld
@@ -541,7 +541,7 @@ if(CONFIG_SOC_SERIES_ESP32H2)
     zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
       phy
       ## esp-idf libs refer gcc libs symbols, so linked in libgcc
-      gcc
+      ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
         -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
       )
   endif()

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 if(CONFIG_SOC_SERIES_ESP32S2)
 
-  zephyr_compile_options(-fstrict-volatile-bitfields)
+  zephyr_cc_option(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
   zephyr_compile_definitions_ifndef(typeof typeof=__typeof__)
@@ -151,7 +151,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
   endif()
 
   zephyr_link_libraries(
-    gcc
+    ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
       -T${CMAKE_CURRENT_SOURCE_DIR}/src/linker/${CONFIG_SOC_SERIES}.rom.alias.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.api.ld
@@ -687,7 +687,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
       pp
       phy
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
-      gcc
+      ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
         -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32s2
     )
 

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 if(CONFIG_SOC_SERIES_ESP32S3)
 
-  zephyr_compile_options(-fstrict-volatile-bitfields)
+  zephyr_cc_option(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
   zephyr_compile_definitions_ifndef(typeof typeof=__typeof__)
@@ -168,7 +168,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
   endif()
 
   zephyr_link_libraries(
-    gcc
+    ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
       -T${CMAKE_CURRENT_SOURCE_DIR}/src/linker/${CONFIG_SOC_SERIES}.rom.alias.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.api.ld
@@ -505,7 +505,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       pp
       phy
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
-      gcc
+      ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
         -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32s3
       )
   endif()
@@ -529,7 +529,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       )
 
     zephyr_link_libraries(
-      gcc
+      ${ESPRESSIF_ZEPHYR_LINK_LIBGCC}
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.bt_funcs.ld
       )
 


### PR DESCRIPTION
> [!IMPORTANT]
> **BLOCKING**: This PR is a prerequisite and is blocking the primary LLVM enablement PR in the main Zephyr repository: [Zephyr PR](https://github.com/zephyrproject-rtos/zephyr/pull/109801).
> This module PR must be merged first or vendored in order for the primary Zephyr build enablement to succeed.
### Description
This PR addresses compiler warnings and errors when building the Espressif HAL (`hal_espressif`) module for Zephyr RTOS targets using Clang/LLVM.
Key changes:
1. **`-fstrict-volatile-bitfields` auto-fallback**: Clang does not support `-fstrict-volatile-bitfields` and raises a fatal error. I replaced `zephyr_compile_options(-fstrict-volatile-bitfields)` with `zephyr_cc_option(-fstrict-volatile-bitfields)` inside the target Integration CMake scripts. This allows GCC to use the optimization while letting Clang gracefully ignore it.
2. **`tcontrol` CSR compatibility on older LLVM engines**: LLVM versions 19 and older do not natively recognize the RISC-V debug register `tcontrol` by name. I updated `csr.h` to define `tcontrol` to its numeric value (`0x7a5`) when compiling under Clang <= 19, and updated the `_CSR_STRINGIFY(REG)` macro to perform double expansion so that the assembler correctly resolves the numeric define.
### Test Matrix & Verification
- Compiled for all esp targets under both `gcc` and `clang` compilers.
- Tested successfully with Zephyr SDK 1.0.1 pre-installed LLVM (Clang 19.1.7) and host Clang 22.1.6 + Zephyr SDK 1.0.1 variants.