### PR TITLE
hal: wifi: esp32: enable WPA Enterprise supplicant support

### DIFF
--- a/components/esp_wifi/esp32/esp_adapter.c
+++ b/components/esp_wifi/esp32/esp_adapter.c
@@ -53,7 +53,10 @@ struct wifi_task {
     k_thread_stack_t *stack;
 };
 
-static void *wifi_msgq_buffer;
+struct wifi_adapter_msgq {
+    struct k_msgq msgq;
+    void *buffer;
+};
 
 #ifdef CONFIG_PM_ENABLE
 extern void wifi_apb80m_request(void);
@@ -116,20 +119,22 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
         return NULL;
     }
 
-    wifi_msgq_buffer = wifi_malloc(queue_len * item_size);
-    if (wifi_msgq_buffer == NULL) {
+    queue->storage = wifi_malloc(queue_len * item_size);
+    if (queue->storage == NULL) {
         LOG_ERR("msg buffer allocation failed");
+        esp_wifi_free(queue);
         return NULL;
     }
 
     queue->handle = wifi_malloc(sizeof(struct k_msgq));
     if (queue->handle == NULL) {
-        esp_wifi_free(wifi_msgq_buffer);
+        esp_wifi_free(queue->storage);
+        esp_wifi_free(queue);
         LOG_ERR("queue handle allocation failed");
         return NULL;
     }
 
-    k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
+    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
 }
@@ -138,6 +143,7 @@ void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
         esp_wifi_free(queue->handle);
+        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
     }
 }
@@ -245,22 +251,32 @@ static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-	struct k_queue *queue = (struct k_queue *) wifi_malloc(sizeof(struct k_queue));
+    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
 
-	if (queue == NULL) {
-		LOG_ERR("queue malloc failed");
-		return NULL;
-	}
+    if (queue == NULL) {
+        LOG_ERR("queue malloc failed");
+        return NULL;
+    }
 
-	k_msgq_init((struct k_msgq *)queue, wifi_msgq_buffer, item_size, queue_len);
+    queue->buffer = wifi_malloc(queue_len * item_size);
+    if (queue->buffer == NULL) {
+        LOG_ERR("queue buffer malloc failed");
+        esp_wifi_free(queue);
+        return NULL;
+    }
 
-	return (void *)queue;
+    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
+
+    return (void *)queue;
 }
 
 static void queue_delete_wrapper(void *handle)
 {
     if (handle != NULL) {
-        esp_wifi_free(handle);
+        struct wifi_adapter_msgq *queue = handle;
+
+        esp_wifi_free(queue->buffer);
+        esp_wifi_free(queue);
     }
 }
 
@@ -279,45 +295,93 @@ static void task_delete_wrapper(void *handle)
     esp_wifi_free(t);
 }
 
-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-	if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-		k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
-	} else {
-		k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
-	}
-	return 1;
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
 {
     int *hpt = (int *)hptw;
+    int ret;
 
-    k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
     if (hpt) {
         *hpt = 0;
     }
-    return 1;
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    return 0;
+    return queue_send_wrapper(handle, item, block_time_tick);
 }
 
-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    return 0;
-}
+    ARG_UNUSED(block_time_tick);
 
-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
-{
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
-    } else {
-        k_msgq_get((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
     }
-    return 1;
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put_front(&queue->msgq, item);
+
+    return ret == 0 ? 1 : 0;
+}
+
+static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
+{
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
+}
+
+static uint32_t queue_msg_waiting_wrapper(void *handle)
+{
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    return k_msgq_num_used_get(&queue->msgq);
 }
 
 static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
@@ -433,11 +497,6 @@ static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
     return k_calloc(1, size);
-}
-
-uint32_t uxQueueMessagesWaiting(void *queue)
-{
-    return 0;
 }
 
 void *xEventGroupCreate(void)
@@ -796,7 +855,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._queue_send_to_back = queue_send_to_back_wrapper,
     ._queue_send_to_front = queue_send_to_front_wrapper,
     ._queue_recv = queue_recv_wrapper,
-    ._queue_msg_waiting = (uint32_t(*)(void *))uxQueueMessagesWaiting,
+    ._queue_msg_waiting = queue_msg_waiting_wrapper,
     ._event_group_create = (void *(*)(void))xEventGroupCreate,
     ._event_group_delete = (void (*)(void *))vEventGroupDelete,
     ._event_group_set_bits = (uint32_t(*)(void *, uint32_t))xEventGroupSetBits,

--- a/components/esp_wifi/esp32c2/esp_adapter.c
+++ b/components/esp_wifi/esp32c2/esp_adapter.c
@@ -43,11 +43,14 @@ extern void intr_matrix_route(int intr_src, int intr_num);
 
 #define TAG "esp_adapter"
 
-static void *wifi_msgq_buffer;
-
 struct wifi_task {
     struct k_thread thread;
     k_thread_stack_t *stack;
+};
+
+struct wifi_adapter_msgq {
+    struct k_msgq msgq;
+    void *buffer;
 };
 
 IRAM_ATTR void *wifi_malloc(size_t size)
@@ -101,8 +104,8 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
         return NULL;
     }
 
-    wifi_msgq_buffer = wifi_malloc(queue_len * item_size);
-    if (wifi_msgq_buffer == NULL) {
+    queue->storage = wifi_malloc(queue_len * item_size);
+    if (queue->storage == NULL) {
         LOG_ERR("msg buffer allocation failed");
         esp_wifi_free(queue);
         return NULL;
@@ -110,13 +113,13 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 
     queue->handle = wifi_malloc(sizeof(struct k_msgq));
     if (queue->handle == NULL) {
-        esp_wifi_free(wifi_msgq_buffer);
+        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
         LOG_ERR("queue handle allocation failed");
         return NULL;
     }
 
-    k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
+    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
 }
@@ -125,6 +128,7 @@ void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
         esp_wifi_free(queue->handle);
+        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
     }
 }
@@ -239,28 +243,31 @@ static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-    struct k_msgq *queue = (struct k_msgq *)wifi_malloc(sizeof(struct k_msgq));
+    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
 
     if (queue == NULL) {
         LOG_ERR("queue malloc failed");
         return NULL;
     }
 
-    char *buffer = wifi_malloc(queue_len * item_size);
-    if (buffer == NULL) {
-        esp_wifi_free(queue);
+    queue->buffer = wifi_malloc(queue_len * item_size);
+    if (queue->buffer == NULL) {
         LOG_ERR("queue buffer malloc failed");
+        esp_wifi_free(queue);
         return NULL;
     }
 
-    k_msgq_init(queue, buffer, item_size, queue_len);
+    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
 
     return (void *)queue;
 }
 
-static void queue_delete_wrapper(void *queue)
+static void queue_delete_wrapper(void *handle)
 {
-    if (queue != NULL) {
+    if (handle != NULL) {
+        struct wifi_adapter_msgq *queue = handle;
+
+        esp_wifi_free(queue->buffer);
         esp_wifi_free(queue);
     }
 }
@@ -280,55 +287,93 @@ static void task_delete_wrapper(void *handle)
     esp_wifi_free(t);
 }
 
-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
-    } else {
-        k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
     }
-    return 1;
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
 {
     int *hpt = (int *)hptw;
+    int ret;
 
-    k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
     if (hpt) {
         *hpt = 0;
     }
-    return 1;
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    return queue_send_wrapper(queue, item, block_time_tick);
+    return queue_send_wrapper(handle, item, block_time_tick);
 }
 
-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    ARG_UNUSED(queue);
-    ARG_UNUSED(item);
     ARG_UNUSED(block_time_tick);
 
-    return 0;
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put_front(&queue->msgq, item);
+
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
     int ret;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
-    } else {
-        ret = k_msgq_get((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
     }
-    return (ret == 0) ? 1 : 0;
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
 }
 
-static uint32_t queue_msg_waiting_wrapper(void *queue)
+static uint32_t queue_msg_waiting_wrapper(void *handle)
 {
-    return k_msgq_num_used_get((struct k_msgq *)queue);
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    return k_msgq_num_used_get(&queue->msgq);
 }
 
 static void *event_group_create_wrapper(void)

--- a/components/esp_wifi/esp32c3/esp_adapter.c
+++ b/components/esp_wifi/esp32c3/esp_adapter.c
@@ -53,7 +53,10 @@ LOG_MODULE_REGISTER(esp32c3_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 static void esp_wifi_free(void *mem);
 
-static void *wifi_msgq_buffer;
+struct wifi_adapter_msgq {
+    struct k_msgq msgq;
+    void *buffer;
+};
 
 struct wifi_task {
     struct k_thread thread;
@@ -111,20 +114,22 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
         return NULL;
     }
 
-    wifi_msgq_buffer = wifi_malloc(queue_len * item_size);
-    if (wifi_msgq_buffer == NULL) {
+    queue->storage = wifi_malloc(queue_len * item_size);
+    if (queue->storage == NULL) {
         LOG_ERR("msg buffer allocation failed");
+        esp_wifi_free(queue);
         return NULL;
     }
 
     queue->handle = wifi_malloc(sizeof(struct k_msgq));
     if (queue->handle == NULL) {
-        esp_wifi_free(wifi_msgq_buffer);
+        esp_wifi_free(queue->storage);
+        esp_wifi_free(queue);
         LOG_ERR("queue handle allocation failed");
         return NULL;
     }
 
-    k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
+    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
 }
@@ -133,6 +138,7 @@ void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
         esp_wifi_free(queue->handle);
+        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
     }
 }
@@ -252,14 +258,21 @@ static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-    struct k_queue *queue = (struct k_queue *)wifi_malloc(sizeof(struct k_queue));
+    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
 
     if (queue == NULL) {
         LOG_ERR("queue malloc failed");
         return NULL;
     }
 
-    k_msgq_init((struct k_msgq *)queue, wifi_msgq_buffer, item_size, queue_len);
+    queue->buffer = wifi_malloc(queue_len * item_size);
+    if (queue->buffer == NULL) {
+        LOG_ERR("queue buffer malloc failed");
+        esp_wifi_free(queue);
+        return NULL;
+    }
+
+    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
 
     return (void *)queue;
 }
@@ -267,57 +280,100 @@ static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 static void queue_delete_wrapper(void *handle)
 {
     if (handle != NULL) {
-        esp_wifi_free(handle);
+        struct wifi_adapter_msgq *queue = handle;
+
+        esp_wifi_free(queue->buffer);
+        esp_wifi_free(queue);
     }
 }
 
-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
-    } else {
-        k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
     }
-    return 1;
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
 {
     int *hpt = (int *)hptw;
+    int ret;
 
-    k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
     if (hpt) {
         *hpt = 0;
     }
-    return 1;
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    ARG_UNUSED(queue);
-    ARG_UNUSED(item);
+    return queue_send_wrapper(handle, item, block_time_tick);
+}
+
+static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
+{
     ARG_UNUSED(block_time_tick);
 
-    return 0;
-}
+    int ret;
 
-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
-{
-    ARG_UNUSED(queue);
-    ARG_UNUSED(item);
-    ARG_UNUSED(block_time_tick);
-
-    return 0;
-}
-
-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
-{
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
-    } else {
-        k_msgq_get((struct k_msgq *)queue, item, K_MSEC(block_time_tick));
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
     }
-    return 1;
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put_front(&queue->msgq, item);
+
+    return ret == 0 ? 1 : 0;
+}
+
+static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
+{
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
+}
+
+static uint32_t queue_msg_waiting_wrapper(void *handle)
+{
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    return k_msgq_num_used_get(&queue->msgq);
 }
 
 static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
@@ -472,13 +528,6 @@ static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
     return k_calloc(1, size);
-}
-
-uint32_t uxQueueMessagesWaiting(void *queue)
-{
-    ARG_UNUSED(queue);
-
-    return 0;
 }
 
 void *xEventGroupCreate(void)
@@ -877,7 +926,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._queue_send_to_back = queue_send_to_back_wrapper,
     ._queue_send_to_front = queue_send_to_front_wrapper,
     ._queue_recv = queue_recv_wrapper,
-    ._queue_msg_waiting = (uint32_t (*)(void *))uxQueueMessagesWaiting,
+    ._queue_msg_waiting = queue_msg_waiting_wrapper,
     ._event_group_create = (void *(*)(void))xEventGroupCreate,
     ._event_group_delete = (void (*)(void *))vEventGroupDelete,
     ._event_group_set_bits = (uint32_t (*)(void *, uint32_t))xEventGroupSetBits,

--- a/components/esp_wifi/esp32c5/esp_adapter.c
+++ b/components/esp_wifi/esp32c5/esp_adapter.c
@@ -60,7 +60,10 @@ extern void intr_matrix_route(int intr_src, int intr_num);
 
 static void esp_wifi_free(void *mem);
 
-static void *wifi_msgq_buffer;
+struct wifi_adapter_msgq {
+    struct k_msgq msgq;
+    void *buffer;
+};
 
 struct wifi_task {
     struct k_thread thread;
@@ -118,20 +121,22 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
         return NULL;
     }
 
-    wifi_msgq_buffer = wifi_malloc(queue_len * item_size);
-    if (wifi_msgq_buffer == NULL) {
+    queue->storage = wifi_malloc(queue_len * item_size);
+    if (queue->storage == NULL) {
         LOG_ERR("msg buffer allocation failed");
+        esp_wifi_free(queue);
         return NULL;
     }
 
     queue->handle = wifi_malloc(sizeof(struct k_msgq));
     if (queue->handle == NULL) {
-        esp_wifi_free(wifi_msgq_buffer);
+        esp_wifi_free(queue->storage);
+        esp_wifi_free(queue);
         LOG_ERR("queue handle allocation failed");
         return NULL;
     }
 
-    k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
+    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
 }
@@ -140,6 +145,7 @@ void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
         esp_wifi_free(queue->handle);
+        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
     }
 }
@@ -259,14 +265,21 @@ static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-    struct k_queue *queue = (struct k_queue *)wifi_malloc(sizeof(struct k_queue));
+    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
 
     if (queue == NULL) {
         LOG_ERR("queue malloc failed");
         return NULL;
     }
 
-    k_msgq_init((struct k_msgq *)queue, wifi_msgq_buffer, item_size, queue_len);
+    queue->buffer = wifi_malloc(queue_len * item_size);
+    if (queue->buffer == NULL) {
+        LOG_ERR("queue buffer malloc failed");
+        esp_wifi_free(queue);
+        return NULL;
+    }
+
+    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
 
     return (void *)queue;
 }
@@ -274,57 +287,100 @@ static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 static void queue_delete_wrapper(void *handle)
 {
     if (handle != NULL) {
-        esp_wifi_free(handle);
+        struct wifi_adapter_msgq *queue = handle;
+
+        esp_wifi_free(queue->buffer);
+        esp_wifi_free(queue);
     }
 }
 
-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
-    } else {
-        k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
     }
-    return 1;
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
 {
     int *hpt = (int *)hptw;
+    int ret;
 
-    k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
     if (hpt) {
         *hpt = 0;
     }
-    return 1;
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    ARG_UNUSED(queue);
-    ARG_UNUSED(item);
+    return queue_send_wrapper(handle, item, block_time_tick);
+}
+
+static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
+{
     ARG_UNUSED(block_time_tick);
 
-    return 0;
-}
+    int ret;
 
-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
-{
-    ARG_UNUSED(queue);
-    ARG_UNUSED(item);
-    ARG_UNUSED(block_time_tick);
-
-    return 0;
-}
-
-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
-{
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
-    } else {
-        k_msgq_get((struct k_msgq *)queue, item, K_MSEC(block_time_tick));
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
     }
-    return 1;
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put_front(&queue->msgq, item);
+
+    return ret == 0 ? 1 : 0;
+}
+
+static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
+{
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
+}
+
+static uint32_t queue_msg_waiting_wrapper(void *handle)
+{
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    return k_msgq_num_used_get(&queue->msgq);
 }
 
 static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
@@ -465,13 +521,6 @@ static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
     return k_calloc(1, size);
-}
-
-uint32_t uxQueueMessagesWaiting(void *queue)
-{
-    ARG_UNUSED(queue);
-
-    return 0;
 }
 
 void *xEventGroupCreate(void)
@@ -882,7 +931,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._queue_send_to_back = queue_send_to_back_wrapper,
     ._queue_send_to_front = queue_send_to_front_wrapper,
     ._queue_recv = queue_recv_wrapper,
-    ._queue_msg_waiting = (uint32_t (*)(void *))uxQueueMessagesWaiting,
+    ._queue_msg_waiting = queue_msg_waiting_wrapper,
     ._event_group_create = (void *(*)(void))xEventGroupCreate,
     ._event_group_delete = (void (*)(void *))vEventGroupDelete,
     ._event_group_set_bits = (uint32_t (*)(void *, uint32_t))xEventGroupSetBits,

--- a/components/esp_wifi/esp32c6/esp_adapter.c
+++ b/components/esp_wifi/esp32c6/esp_adapter.c
@@ -60,7 +60,10 @@ extern void intr_matrix_route(int intr_src, int intr_num);
 
 static void esp_wifi_free(void *mem);
 
-static void *wifi_msgq_buffer;
+struct wifi_adapter_msgq {
+	struct k_msgq msgq;
+	void *buffer;
+};
 
 struct wifi_task {
     struct k_thread thread;
@@ -118,20 +121,22 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
         return NULL;
     }
 
-    wifi_msgq_buffer = wifi_malloc(queue_len * item_size);
-    if (wifi_msgq_buffer == NULL) {
+    queue->storage = wifi_malloc(queue_len * item_size);
+    if (queue->storage == NULL) {
         LOG_ERR("msg buffer allocation failed");
+        esp_wifi_free(queue);
         return NULL;
     }
 
     queue->handle = wifi_malloc(sizeof(struct k_msgq));
     if (queue->handle == NULL) {
-        esp_wifi_free(wifi_msgq_buffer);
+        esp_wifi_free(queue->storage);
+        esp_wifi_free(queue);
         LOG_ERR("queue handle allocation failed");
         return NULL;
     }
 
-    k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
+    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
 }
@@ -140,6 +145,7 @@ void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
         esp_wifi_free(queue->handle);
+        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
     }
 }
@@ -259,72 +265,123 @@ static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-    struct k_queue *queue = (struct k_queue *)wifi_malloc(sizeof(struct k_queue));
+    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
 
-    if (queue == NULL) {
+    if (!queue) {
         LOG_ERR("queue malloc failed");
         return NULL;
     }
 
-    k_msgq_init((struct k_msgq *)queue, wifi_msgq_buffer, item_size, queue_len);
+    queue->buffer = wifi_malloc(queue_len * item_size);
+    if (!queue->buffer) {
+        LOG_ERR("queue buffer malloc failed");
+        esp_wifi_free(queue);
+        return NULL;
+    }
+
+    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
 
     return (void *)queue;
 }
 
 static void queue_delete_wrapper(void *handle)
 {
-    if (handle != NULL) {
-        esp_wifi_free(handle);
+    if (handle) {
+        struct wifi_adapter_msgq *queue = handle;
+
+        esp_wifi_free(queue->buffer);
+        esp_wifi_free(queue);
     }
 }
 
-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
-    } else {
-        k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
     }
-    return 1;
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
 {
     int *hpt = (int *)hptw;
+    int ret;
 
-    k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
     if (hpt) {
         *hpt = 0;
     }
-    return 1;
+
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    ARG_UNUSED(queue);
-    ARG_UNUSED(item);
+    return queue_send_wrapper(handle, item, block_time_tick);
+}
+
+static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
+{
     ARG_UNUSED(block_time_tick);
 
-    return 0;
-}
+    int ret;
 
-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
-{
-    ARG_UNUSED(queue);
-    ARG_UNUSED(item);
-    ARG_UNUSED(block_time_tick);
-
-    return 0;
-}
-
-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
-{
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
-    } else {
-        k_msgq_get((struct k_msgq *)queue, item, K_MSEC(block_time_tick));
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
     }
-    return 1;
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put_front(&queue->msgq, item);
+
+    return ret == 0 ? 1 : 0;
+}
+
+static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
+{
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
+}
+
+static uint32_t queue_msg_waiting_wrapper(void *handle)
+{
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    return k_msgq_num_used_get(&queue->msgq);
 }
 
 static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
@@ -465,13 +522,6 @@ static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
     return k_calloc(1, size);
-}
-
-uint32_t uxQueueMessagesWaiting(void *queue)
-{
-    ARG_UNUSED(queue);
-
-    return 0;
 }
 
 void *xEventGroupCreate(void)
@@ -889,7 +939,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._queue_send_to_back = queue_send_to_back_wrapper,
     ._queue_send_to_front = queue_send_to_front_wrapper,
     ._queue_recv = queue_recv_wrapper,
-    ._queue_msg_waiting = (uint32_t (*)(void *))uxQueueMessagesWaiting,
+    ._queue_msg_waiting = queue_msg_waiting_wrapper,
     ._event_group_create = (void *(*)(void))xEventGroupCreate,
     ._event_group_delete = (void (*)(void *))vEventGroupDelete,
     ._event_group_set_bits = (uint32_t (*)(void *, uint32_t))xEventGroupSetBits,

--- a/components/esp_wifi/esp32s2/esp_adapter.c
+++ b/components/esp_wifi/esp32s2/esp_adapter.c
@@ -40,11 +40,14 @@ LOG_MODULE_REGISTER(esp32s2_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #define TAG "esp_adapter"
 
-static void *wifi_msgq_buffer;
-
 struct wifi_task {
     struct k_thread thread;
     k_thread_stack_t *stack;
+};
+
+struct wifi_adapter_msgq {
+    struct k_msgq msgq;
+    void *buffer;
 };
 
 IRAM_ATTR void *wifi_malloc(size_t size)
@@ -101,8 +104,8 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
         return NULL;
     }
 
-    wifi_msgq_buffer = wifi_malloc(queue_len * item_size);
-    if (wifi_msgq_buffer == NULL) {
+    queue->storage = wifi_malloc(queue_len * item_size);
+    if (queue->storage == NULL) {
         LOG_ERR("msg buffer allocation failed");
         esp_wifi_free(queue);
         return NULL;
@@ -110,13 +113,13 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 
     queue->handle = wifi_malloc(sizeof(struct k_msgq));
     if (queue->handle == NULL) {
-        esp_wifi_free(wifi_msgq_buffer);
+        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
         LOG_ERR("queue handle allocation failed");
         return NULL;
     }
 
-    k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
+    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
 }
@@ -125,6 +128,7 @@ void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
         esp_wifi_free(queue->handle);
+        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
     }
 }
@@ -233,28 +237,31 @@ static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-    struct k_msgq *queue = (struct k_msgq *)wifi_malloc(sizeof(struct k_msgq));
+    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
 
     if (queue == NULL) {
         LOG_ERR("queue malloc failed");
         return NULL;
     }
 
-    char *buffer = wifi_malloc(queue_len * item_size);
-    if (buffer == NULL) {
-        esp_wifi_free(queue);
+    queue->buffer = wifi_malloc(queue_len * item_size);
+    if (queue->buffer == NULL) {
         LOG_ERR("queue buffer malloc failed");
+        esp_wifi_free(queue);
         return NULL;
     }
 
-    k_msgq_init(queue, buffer, item_size, queue_len);
+    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
 
     return (void *)queue;
 }
 
-static void queue_delete_wrapper(void *queue)
+static void queue_delete_wrapper(void *handle)
 {
-    if (queue != NULL) {
+    if (handle != NULL) {
+        struct wifi_adapter_msgq *queue = handle;
+
+        esp_wifi_free(queue->buffer);
         esp_wifi_free(queue);
     }
 }
@@ -274,52 +281,93 @@ static void task_delete_wrapper(void *handle)
     esp_wifi_free(t);
 }
 
-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
-{
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
-    } else {
-        k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
-    }
-    return 1;
-}
-
-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
-{
-    int *hpt = (int *)hptw;
-
-    k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
-    if (hpt) {
-        *hpt = 0;
-    }
-    return 1;
-}
-
-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
-{
-    return queue_send_wrapper(queue, item, block_time_tick);
-}
-
-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
-{
-    return 0;
-}
-
-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
     int ret;
 
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
-    } else {
-        ret = k_msgq_get((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
     }
-    return (ret == 0) ? 1 : 0;
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
 }
 
-static uint32_t queue_msg_waiting_wrapper(void *queue)
+static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
 {
-    return k_msgq_num_used_get((struct k_msgq *)queue);
+    int *hpt = (int *)hptw;
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
+    if (hpt) {
+        *hpt = 0;
+    }
+    return ret == 0 ? 1 : 0;
+}
+
+static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
+{
+    return queue_send_wrapper(handle, item, block_time_tick);
+}
+
+static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
+{
+    ARG_UNUSED(block_time_tick);
+
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put_front(&queue->msgq, item);
+
+    return ret == 0 ? 1 : 0;
+}
+
+static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
+{
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
+}
+
+static uint32_t queue_msg_waiting_wrapper(void *handle)
+{
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    return k_msgq_num_used_get(&queue->msgq);
 }
 
 static void *event_group_create_wrapper(void)

--- a/components/esp_wifi/esp32s3/esp_adapter.c
+++ b/components/esp_wifi/esp32s3/esp_adapter.c
@@ -51,7 +51,10 @@ struct wifi_task {
 	k_thread_stack_t *stack;
 };
 
-static void *wifi_msgq_buffer;
+struct wifi_adapter_msgq {
+	struct k_msgq msgq;
+	void *buffer;
+};
 
 #ifdef CONFIG_PM_ENABLE
 extern void wifi_apb80m_request(void);
@@ -102,29 +105,31 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 {
 	wifi_static_queue_t *queue = NULL;
 
-	queue = (wifi_static_queue_t *)k_malloc(sizeof(wifi_static_queue_t));
+	queue = (wifi_static_queue_t *)wifi_malloc(sizeof(wifi_static_queue_t));
 
 	if (!queue) {
 		LOG_ERR("msg buffer allocation failed");
 		return NULL;
 	}
 
-	wifi_msgq_buffer = k_malloc(queue_len * item_size);
+	queue->storage = wifi_malloc(queue_len * item_size);
 
-	if (wifi_msgq_buffer == NULL) {
+	if (queue->storage == NULL) {
 		LOG_ERR("msg buffer allocation failed");
+		esp_wifi_free(queue);
 		return NULL;
 	}
 
-	queue->handle = k_malloc(sizeof(struct k_msgq));
+	queue->handle = wifi_malloc(sizeof(struct k_msgq));
 
 	if (queue->handle == NULL) {
-		k_free(wifi_msgq_buffer);
+		esp_wifi_free(queue->storage);
+		esp_wifi_free(queue);
 		LOG_ERR("queue handle allocation failed");
 		return NULL;
 	}
 
-	k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
+	k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
 	return queue;
 }
@@ -132,8 +137,9 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 void wifi_delete_queue(wifi_static_queue_t *queue)
 {
 	if (queue) {
-		k_free(queue->handle);
-		k_free(queue);
+		esp_wifi_free(queue->handle);
+		esp_wifi_free(queue->storage);
+		esp_wifi_free(queue);
 	}
 }
 
@@ -241,14 +247,21 @@ static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-	struct k_queue *queue = (struct k_queue *)wifi_malloc(sizeof(struct k_queue));
+	struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
 
 	if (queue == NULL) {
 		LOG_ERR("queue malloc failed");
 		return NULL;
 	}
 
-	k_msgq_init((struct k_msgq *)queue, wifi_msgq_buffer, item_size, queue_len);
+	queue->buffer = wifi_malloc(queue_len * item_size);
+	if (queue->buffer == NULL) {
+		LOG_ERR("queue buffer malloc failed");
+		esp_wifi_free(queue);
+		return NULL;
+	}
+
+	k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
 
 	return (void *)queue;
 }
@@ -256,7 +269,10 @@ static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 static void queue_delete_wrapper(void *handle)
 {
 	if (handle != NULL) {
-		esp_wifi_free(handle);
+		struct wifi_adapter_msgq *queue = handle;
+
+		esp_wifi_free(queue->buffer);
+		esp_wifi_free(queue);
 	}
 }
 
@@ -275,45 +291,93 @@ static void task_delete_wrapper(void *handle)
 	esp_wifi_free(t);
 }
 
-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-	if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-		k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
-	} else {
-		k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
-	}
-	return 1;
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
 {
-	int *hpt = (int *)hptw;
+    int *hpt = (int *)hptw;
+    int ret;
 
-	k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
-	if (hpt) {
-		*hpt = 0;
-	}
-	return 1;
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
+    if (hpt) {
+        *hpt = 0;
+    }
+    return ret == 0 ? 1 : 0;
 }
 
-int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-	return 0;
+    return queue_send_wrapper(handle, item, block_time_tick);
 }
 
-int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-	return 0;
+    ARG_UNUSED(block_time_tick);
+
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put_front(&queue->msgq, item);
+
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-	if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-		k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
-	} else {
-		k_msgq_get((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
-	}
-	return 1;
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
+    } else {
+        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
+    }
+
+    return ret == 0 ? 1 : 0;
+}
+
+static uint32_t queue_msg_waiting_wrapper(void *handle)
+{
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    return k_msgq_num_used_get(&queue->msgq);
 }
 
 static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
@@ -437,11 +501,6 @@ static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
 	return k_calloc(1, size);
-}
-
-uint32_t uxQueueMessagesWaiting(void *queue)
-{
-	return 0;
 }
 
 void *xEventGroupCreate(void)
@@ -805,7 +864,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
 	._queue_send_to_back = queue_send_to_back_wrapper,
 	._queue_send_to_front = queue_send_to_front_wrapper,
 	._queue_recv = queue_recv_wrapper,
-	._queue_msg_waiting = uxQueueMessagesWaiting,
+	._queue_msg_waiting = queue_msg_waiting_wrapper,
 	._event_group_create = (void *(*)(void))xEventGroupCreate,
 	._event_group_delete = (void (*)(void *))vEventGroupDelete,
 	._event_group_set_bits = xEventGroupSetBits,

--- a/components/mbedtls/port/include/mbedtls/esp_config.h
+++ b/components/mbedtls/port/include/mbedtls/esp_config.h
@@ -2604,7 +2604,7 @@
  *            on it, and considering stronger message digests instead.
  *
  */
-#if CONFIG_MBEDTLS_SHA1_C
+#if defined(CONFIG_MBEDTLS_SHA1_C) || defined(CONFIG_PSA_WANT_ALG_SHA_1)
 #define PSA_WANT_ALG_SHA_1 1
 #else
 #undef PSA_WANT_ALG_SHA_1
@@ -2643,7 +2643,7 @@
  *
  * This module adds support for SHA-384 and SHA-512.
  */
-#ifdef CONFIG_MBEDTLS_SHA512_C
+#if defined(CONFIG_MBEDTLS_SHA512_C) || defined(CONFIG_PSA_WANT_ALG_SHA_512)
 #define PSA_WANT_ALG_SHA_512 1
 #else
 #undef PSA_WANT_ALG_SHA_512
@@ -2664,7 +2664,7 @@
  *
  * Comment to disable SHA-384
  */
-#ifdef CONFIG_MBEDTLS_SHA384_C
+#if defined(CONFIG_MBEDTLS_SHA384_C) || defined(CONFIG_PSA_WANT_ALG_SHA_384)
 #define PSA_WANT_ALG_SHA_384 1
 #else
 #undef PSA_WANT_ALG_SHA_384
@@ -2688,11 +2688,19 @@
  */
 #ifdef CONFIG_MBEDTLS_SHA256_C
 #define MBEDTLS_SHA256_C
+#endif
+
+#if defined(CONFIG_MBEDTLS_SHA256_C) || defined(CONFIG_PSA_WANT_ALG_SHA_256)
 #define PSA_WANT_ALG_SHA_256 1
-#define PSA_WANT_ALG_SHA_224 1
 #else
 #undef PSA_WANT_ALG_SHA_256
 #undef MBEDTLS_PSA_ACCEL_ALG_SHA_256
+#endif
+
+#if defined(CONFIG_MBEDTLS_SHA224_C) || defined(CONFIG_MBEDTLS_SHA256_C) || \
+    defined(CONFIG_PSA_WANT_ALG_SHA_224)
+#define PSA_WANT_ALG_SHA_224 1
+#else
 #undef PSA_WANT_ALG_SHA_224
 #undef MBEDTLS_PSA_ACCEL_ALG_SHA_224
 #endif

--- a/components/mbedtls/port/include/mbedtls/esp_config.h
+++ b/components/mbedtls/port/include/mbedtls/esp_config.h
@@ -190,7 +190,7 @@
 #ifdef CONFIG_MBEDTLS_HARDWARE_SHA
     #define ESP_SHA_DRIVER_ENABLED
     #define MBEDTLS_PSA_ACCEL_ALG_HMAC
-    #define MBEDTLS_PSA_BUILTIN_ALG_HMAC
+    #define MBEDTLS_PSA_BUILTIN_ALG_HMAC 1
     #if SOC_SHA_SUPPORT_SHA1
         #define MBEDTLS_PSA_ACCEL_ALG_SHA_1
         #undef MBEDTLS_PSA_BUILTIN_ALG_SHA_1
@@ -233,7 +233,7 @@
 #else
 #if !defined(MBEDTLS_PSA_BUILTIN_ALG_HMAC)
     /* If ROM MD5 is not enabled, use the builtin HMAC algorithm for HMAC(MD5) operations */
-    #define MBEDTLS_PSA_BUILTIN_ALG_HMAC
+    #define MBEDTLS_PSA_BUILTIN_ALG_HMAC 1
 #endif
 #endif /* MBEDTLS_PSA_BUILTIN_ALG_HMAC */
 
@@ -2737,7 +2737,7 @@
 #define PSA_WANT_ALG_SHA3_512 1
 #if !defined(MBEDTLS_PSA_BUILTIN_ALG_HMAC)
     /* If SHA3 is enabled, use the builtin HMAC algorithm for HMAC(SHA3) operations */
-    #define MBEDTLS_PSA_BUILTIN_ALG_HMAC
+    #define MBEDTLS_PSA_BUILTIN_ALG_HMAC 1
 #endif /* MBEDTLS_PSA_BUILTIN_ALG_HMAC */
 #else
 #undef PSA_WANT_ALG_SHA3_224

--- a/tools/sync/patches/esp_wifi.patch
+++ b/tools/sync/patches/esp_wifi.patch
@@ -1,6 +1,6 @@
 --- a/components/esp_wifi/esp32c2/esp_adapter.c
 +++ b/components/esp_wifi/esp32c2/esp_adapter.c
-@@ -4,101 +4,132 @@
+@@ -4,101 +4,136 @@
   * SPDX-License-Identifier: Apache-2.0
   */
  
@@ -70,11 +70,14 @@
 -extern void wifi_apb80m_request(void);
 -extern void wifi_apb80m_release(void);
 -#endif
-+static void *wifi_msgq_buffer;
-+
 +struct wifi_task {
 +    struct k_thread thread;
 +    k_thread_stack_t *stack;
++};
++
++struct wifi_adapter_msgq {
++    struct k_msgq msgq;
++    void *buffer;
 +};
  
  IRAM_ATTR void *wifi_malloc(size_t size)
@@ -109,18 +112,18 @@
 +    }
 +
 +    return ptr;
-+}
-+
-+static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
-+{
-+    return wifi_calloc(1, size);
  }
  
 -static void * IRAM_ATTR wifi_zalloc_wrapper(size_t size)
-+static void esp_wifi_free(void *mem)
++static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
  {
 -    void *ptr = wifi_calloc(1, size);
 -    return ptr;
++    return wifi_calloc(1, size);
++}
++
++static void esp_wifi_free(void *mem)
++{
 +    esp_wifi_free_func(mem);
  }
  
@@ -133,12 +136,11 @@
 +    queue = (wifi_static_queue_t *)wifi_malloc(sizeof(wifi_static_queue_t));
      if (!queue) {
 +        LOG_ERR("msg buffer allocation failed");
-         return NULL;
-     }
- 
--    queue->handle = xQueueCreate(queue_len, item_size);
-+    wifi_msgq_buffer = wifi_malloc(queue_len * item_size);
-+    if (wifi_msgq_buffer == NULL) {
++        return NULL;
++    }
++
++    queue->storage = wifi_malloc(queue_len * item_size);
++    if (queue->storage == NULL) {
 +        LOG_ERR("msg buffer allocation failed");
 +        esp_wifi_free(queue);
 +        return NULL;
@@ -146,13 +148,14 @@
 +
 +    queue->handle = wifi_malloc(sizeof(struct k_msgq));
 +    if (queue->handle == NULL) {
-+        esp_wifi_free(wifi_msgq_buffer);
++        esp_wifi_free(queue->storage);
 +        esp_wifi_free(queue);
 +        LOG_ERR("queue handle allocation failed");
-+        return NULL;
-+    }
-+
-+    k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
+         return NULL;
+     }
+ 
+-    queue->handle = xQueueCreate(queue_len, item_size);
++    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 +
      return queue;
  }
@@ -163,6 +166,7 @@
 -        vQueueDelete(queue->handle);
 -        free(queue);
 +        esp_wifi_free(queue->handle);
++        esp_wifi_free(queue->storage);
 +        esp_wifi_free(queue);
      }
  }
@@ -172,7 +176,7 @@
  {
      return wifi_create_queue(queue_len, item_size);
  }
-@@ -110,6 +141,8 @@
+@@ -110,6 +145,8 @@
  
  static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source, uint32_t intr_num, int32_t intr_prio)
  {
@@ -181,7 +185,7 @@
      esp_rom_route_intr_matrix(cpu_no, intr_source, intr_num);
      esprv_int_set_priority(intr_num, intr_prio);
      esprv_int_set_type(intr_num, INTR_TYPE_LEVEL);
-@@ -117,163 +150,282 @@
+@@ -117,163 +154,323 @@
  
  static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
  {
@@ -313,30 +317,33 @@
 +static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
  {
 -    return (int32_t)xSemaphoreTakeRecursive(mutex, portMAX_DELAY);
-+    struct k_msgq *queue = (struct k_msgq *)wifi_malloc(sizeof(struct k_msgq));
++    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
 +
 +    if (queue == NULL) {
 +        LOG_ERR("queue malloc failed");
 +        return NULL;
 +    }
 +
-+    char *buffer = wifi_malloc(queue_len * item_size);
-+    if (buffer == NULL) {
-+        esp_wifi_free(queue);
++    queue->buffer = wifi_malloc(queue_len * item_size);
++    if (queue->buffer == NULL) {
 +        LOG_ERR("queue buffer malloc failed");
++        esp_wifi_free(queue);
 +        return NULL;
 +    }
 +
-+    k_msgq_init(queue, buffer, item_size, queue_len);
++    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
 +
 +    return (void *)queue;
  }
  
 -static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
-+static void queue_delete_wrapper(void *queue)
++static void queue_delete_wrapper(void *handle)
  {
 -    return (int32_t)xSemaphoreGiveRecursive(mutex);
-+    if (queue != NULL) {
++    if (handle != NULL) {
++        struct wifi_adapter_msgq *queue = handle;
++
++        esp_wifi_free(queue->buffer);
 +        esp_wifi_free(queue);
 +    }
  }
@@ -358,62 +365,110 @@
 +    esp_wifi_free(t);
  }
  
- static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
      if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueSend(queue, item, portMAX_DELAY);
-+        k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
++        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
      } else {
 -        return (int32_t)xQueueSend(queue, item, block_time_tick);
-+        k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
++        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
      }
-+    return 1;
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
++static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
  {
 -    return (int32_t)xQueueSendFromISR(queue, item, hptw);
 +    int *hpt = (int *)hptw;
++    int ret;
 +
-+    k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
 +    if (hpt) {
 +        *hpt = 0;
 +    }
-+    return 1;
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_BACK);
-+    return queue_send_wrapper(queue, item, block_time_tick);
++    return queue_send_wrapper(handle, item, block_time_tick);
  }
  
- static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_FRONT);
-+    ARG_UNUSED(queue);
-+    ARG_UNUSED(item);
 +    ARG_UNUSED(block_time_tick);
 +
-+    return 0;
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put_front(&queue->msgq, item);
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 +    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
      if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueReceive(queue, item, portMAX_DELAY);
-+        ret = k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
++        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
      } else {
 -        return (int32_t)xQueueReceive(queue, item, block_time_tick);
-+        ret = k_msgq_get((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
++        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
      }
-+    return (ret == 0) ? 1 : 0;
-+}
 +
-+static uint32_t queue_msg_waiting_wrapper(void *queue)
-+{
-+    return k_msgq_num_used_get((struct k_msgq *)queue);
++    return ret == 0 ? 1 : 0;
+ }
+ 
+-static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++static uint32_t queue_msg_waiting_wrapper(void *handle)
+ {
+-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+-        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, portMAX_DELAY);
+-    } else {
+-        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, block_time_tick);
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
+     }
++
++    struct wifi_adapter_msgq *queue = handle;
++    return k_msgq_num_used_get(&queue->msgq);
 +}
 +
 +static void *event_group_create_wrapper(void)
@@ -441,15 +496,10 @@
 +    ARG_UNUSED(bits);
 +
 +    return 0;
- }
- 
- static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
- {
--    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
--        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, portMAX_DELAY);
--    } else {
--        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, block_time_tick);
--    }
++}
++
++static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++{
 +    ARG_UNUSED(event);
 +    ARG_UNUSED(bits_to_wait_for);
 +    ARG_UNUSED(clear_on_exit);
@@ -529,12 +579,13 @@
  }
  
  static void IRAM_ATTR wifi_apb80m_request_wrapper(void)
-@@ -315,43 +467,29 @@
+@@ -315,43 +512,29 @@
      return os_get_time(t);
  }
  
 -static void * IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
--{
++static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
+ {
 -    return heap_caps_realloc(ptr, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
 -}
 -
@@ -542,16 +593,15 @@
 -{
 -    return heap_caps_calloc(n, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
 -}
--
--static void * IRAM_ATTR zalloc_internal_wrapper(size_t size)
-+static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
- {
--    void *ptr = heap_caps_calloc(1, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
--    return ptr;
--}
 +    ARG_UNUSED(ptr);
 +    ARG_UNUSED(size);
  
+-static void * IRAM_ATTR zalloc_internal_wrapper(size_t size)
+-{
+-    void *ptr = heap_caps_calloc(1, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+-    return ptr;
+-}
+-
 -static esp_err_t nvs_open_wrapper(const char* name, unsigned int open_mode, nvs_handle_t *out_handle)
 -{
 -    return nvs_open(name, (nvs_open_mode_t)open_mode, out_handle);
@@ -585,7 +635,7 @@
  }
  
  static int coex_init_wrapper(void)
-@@ -481,7 +619,7 @@
+@@ -481,7 +664,7 @@
  #endif
  }
  
@@ -594,7 +644,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_schm_curr_phase_get();
-@@ -490,7 +628,7 @@
+@@ -490,7 +673,7 @@
  #endif
  }
  
@@ -603,7 +653,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_register_start_cb(cb);
-@@ -535,7 +673,7 @@
+@@ -535,7 +718,7 @@
  #endif
  }
  
@@ -612,7 +662,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_schm_get_phase_by_idx(phase_idx);
-@@ -546,7 +684,6 @@
+@@ -546,7 +729,6 @@
  
  static void IRAM_ATTR esp_empty_wrapper(void)
  {
@@ -620,7 +670,7 @@
  }
  
  static void esp_phy_enable_wrapper(void)
-@@ -561,6 +698,116 @@
+@@ -561,6 +743,116 @@
      esp_phy_disable(PHY_MODEM_WIFI);
  }
  
@@ -737,7 +787,7 @@
  wifi_osi_funcs_t g_wifi_osi_funcs = {
      ._version = ESP_WIFI_OS_ADAPTER_VERSION,
      ._env_is_chip = esp_coex_common_env_is_chip_wrapper,
-@@ -569,9 +816,9 @@
+@@ -569,9 +861,9 @@
      ._set_isr = set_isr_wrapper,
      ._ints_on = enable_intr_wrapper,
      ._ints_off = disable_intr_wrapper,
@@ -749,7 +799,7 @@
      ._wifi_int_disable = esp_coex_common_int_disable_wrapper,
      ._wifi_int_restore = esp_coex_common_int_restore_wrapper,
      ._task_yield_from_isr = esp_coex_common_task_yield_from_isr_wrapper,
-@@ -586,30 +833,30 @@
+@@ -586,30 +878,30 @@
      ._mutex_lock = mutex_lock_wrapper,
      ._mutex_unlock = mutex_unlock_wrapper,
      ._queue_create = queue_create_wrapper,
@@ -793,7 +843,7 @@
      ._dport_access_stall_other_cpu_start_wrap = esp_empty_wrapper,
      ._dport_access_stall_other_cpu_end_wrap = esp_empty_wrapper,
      ._wifi_apb80m_request = wifi_apb80m_request_wrapper,
-@@ -617,7 +864,7 @@
+@@ -617,7 +909,7 @@
      ._phy_disable = esp_phy_disable_wrapper,
      ._phy_enable = esp_phy_enable_wrapper,
      ._phy_update_country_info = esp_phy_update_country_info,
@@ -802,7 +852,7 @@
      ._timer_arm = timer_arm_wrapper,
      ._timer_disarm = esp_coex_common_timer_disarm_wrapper,
      ._timer_done = esp_coex_common_timer_done_wrapper,
-@@ -647,8 +894,8 @@
+@@ -647,8 +939,8 @@
      ._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
      ._log_write = esp_log_write_wrapper,
      ._log_writev = esp_log_writev_wrapper,
@@ -862,7 +912,7 @@
  #include "phy_init_data.h"
  #endif
  #include "soc/rtc_cntl_reg.h"
-@@ -41,67 +36,108 @@
+@@ -41,67 +36,114 @@
  #include "soc/system_reg.h"
  #include "esp_private/periph_ctrl.h"
  #include "esp_private/esp_clk.h"
@@ -890,7 +940,10 @@
 -extern void wifi_apb80m_request(void);
 -extern void wifi_apb80m_release(void);
 -#endif
-+static void *wifi_msgq_buffer;
++struct wifi_adapter_msgq {
++    struct k_msgq msgq;
++    void *buffer;
++};
 +
 +struct wifi_task {
 +    struct k_thread thread;
@@ -929,18 +982,18 @@
 +    }
 +
 +    return ptr;
++}
++
++static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
++{
++    return wifi_calloc(1, size);
  }
  
 -static void * IRAM_ATTR wifi_zalloc_wrapper(size_t size)
-+static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
++static void esp_wifi_free(void *mem)
  {
 -    void *ptr = wifi_calloc(1, size);
 -    return ptr;
-+    return wifi_calloc(1, size);
-+}
-+
-+static void esp_wifi_free(void *mem)
-+{
 +    esp_wifi_free_func(mem);
  }
  
@@ -953,24 +1006,26 @@
 +    queue = (wifi_static_queue_t *)wifi_malloc(sizeof(wifi_static_queue_t));
      if (!queue) {
 +        LOG_ERR("msg buffer allocation failed");
-+        return NULL;
-+    }
-+
-+    wifi_msgq_buffer = wifi_malloc(queue_len * item_size);
-+    if (wifi_msgq_buffer == NULL) {
+         return NULL;
+     }
+ 
+-    queue->handle = xQueueCreate(queue_len, item_size);
++    queue->storage = wifi_malloc(queue_len * item_size);
++    if (queue->storage == NULL) {
 +        LOG_ERR("msg buffer allocation failed");
++        esp_wifi_free(queue);
 +        return NULL;
 +    }
 +
 +    queue->handle = wifi_malloc(sizeof(struct k_msgq));
 +    if (queue->handle == NULL) {
-+        esp_wifi_free(wifi_msgq_buffer);
++        esp_wifi_free(queue->storage);
++        esp_wifi_free(queue);
 +        LOG_ERR("queue handle allocation failed");
-         return NULL;
-     }
- 
--    queue->handle = xQueueCreate(queue_len, item_size);
-+    k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
++        return NULL;
++    }
++
++    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 +
      return queue;
  }
@@ -981,6 +1036,7 @@
 -        vQueueDelete(queue->handle);
 -        free(queue);
 +        esp_wifi_free(queue->handle);
++        esp_wifi_free(queue->storage);
 +        esp_wifi_free(queue);
      }
  }
@@ -990,7 +1046,7 @@
  {
      return wifi_create_queue(queue_len, item_size);
  }
-@@ -113,6 +149,8 @@
+@@ -113,6 +155,8 @@
  
  static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source, uint32_t intr_num, int32_t intr_prio)
  {
@@ -999,7 +1055,7 @@
      esp_rom_route_intr_matrix(cpu_no, intr_source, intr_num);
      esprv_int_set_priority(intr_num, intr_prio);
      esprv_int_set_type(intr_num, INTR_TYPE_LEVEL);
-@@ -120,12 +158,15 @@
+@@ -120,12 +164,15 @@
  
  static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
  {
@@ -1017,7 +1073,7 @@
  }
  
  static void enable_intr_wrapper(uint32_t intr_mask)
-@@ -140,143 +181,225 @@
+@@ -140,143 +187,275 @@
  
  static bool IRAM_ATTR is_from_isr_wrapper(void)
  {
@@ -1127,88 +1183,143 @@
 +static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
  {
 -    return (void *)xQueueCreate(queue_len, item_size);
-+    struct k_queue *queue = (struct k_queue *)wifi_malloc(sizeof(struct k_queue));
++    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
 +
 +    if (queue == NULL) {
 +        LOG_ERR("queue malloc failed");
 +        return NULL;
 +    }
 +
-+    k_msgq_init((struct k_msgq *)queue, wifi_msgq_buffer, item_size, queue_len);
++    queue->buffer = wifi_malloc(queue_len * item_size);
++    if (queue->buffer == NULL) {
++        LOG_ERR("queue buffer malloc failed");
++        esp_wifi_free(queue);
++        return NULL;
++    }
++
++    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
 +
 +    return (void *)queue;
+ }
+ 
+-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static void queue_delete_wrapper(void *handle)
+ {
++    if (handle != NULL) {
++        struct wifi_adapter_msgq *queue = handle;
++
++        esp_wifi_free(queue->buffer);
++        esp_wifi_free(queue);
++    }
 +}
 +
-+static void queue_delete_wrapper(void *handle)
++static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
 +{
-+    if (handle != NULL) {
-+        esp_wifi_free(handle);
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
 +    }
- }
- 
- static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
- {
++
++    struct wifi_adapter_msgq *queue = handle;
      if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueSend(queue, item, portMAX_DELAY);
-+        k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
++        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
      } else {
 -        return (int32_t)xQueueSend(queue, item, block_time_tick);
-+        k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
++        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
      }
-+    return 1;
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
++static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
  {
 -    return (int32_t)xQueueSendFromISR(queue, item, hptw);
 +    int *hpt = (int *)hptw;
++    int ret;
 +
-+    k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
 +    if (hpt) {
 +        *hpt = 0;
 +    }
-+    return 1;
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_BACK);
-+    ARG_UNUSED(queue);
-+    ARG_UNUSED(item);
-+    ARG_UNUSED(block_time_tick);
-+
-+    return 0;
++    return queue_send_wrapper(handle, item, block_time_tick);
  }
  
- static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_FRONT);
-+    ARG_UNUSED(queue);
-+    ARG_UNUSED(item);
 +    ARG_UNUSED(block_time_tick);
 +
-+    return 0;
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put_front(&queue->msgq, item);
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
      if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueReceive(queue, item, portMAX_DELAY);
-+        k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
++        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
      } else {
 -        return (int32_t)xQueueReceive(queue, item, block_time_tick);
-+        k_msgq_get((struct k_msgq *)queue, item, K_MSEC(block_time_tick));
++        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
      }
-+    return 1;
++
++    return ret == 0 ? 1 : 0;
  }
  
- static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
+-static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++static uint32_t queue_msg_waiting_wrapper(void *handle)
  {
 -    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, portMAX_DELAY);
 -    } else {
 -        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, block_time_tick);
--    }
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
+     }
++
++    struct wifi_adapter_msgq *queue = handle;
++    return k_msgq_num_used_get(&queue->msgq);
++}
++
++static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++{
 +    ARG_UNUSED(event);
 +    ARG_UNUSED(bits_to_wait_for);
 +    ARG_UNUSED(clear_on_exit);
@@ -1300,7 +1411,7 @@
  }
  
  static void IRAM_ATTR wifi_apb80m_request_wrapper(void)
-@@ -332,43 +455,189 @@
+@@ -332,43 +511,182 @@
      return os_get_time(t);
  }
  
@@ -1328,17 +1439,12 @@
 -    void *ptr = heap_caps_calloc(1, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
 -    return ptr;
 +    return k_calloc(1, size);
-+}
-+
-+uint32_t uxQueueMessagesWaiting(void *queue)
-+{
-+    ARG_UNUSED(queue);
-+
-+    return 0;
-+}
-+
+ }
+ 
+-static esp_err_t nvs_open_wrapper(const char* name, unsigned int open_mode, nvs_handle_t *out_handle)
 +void *xEventGroupCreate(void)
-+{
+ {
+-    return nvs_open(name, (nvs_open_mode_t)open_mode, out_handle);
 +    LOG_ERR("EventGroup not supported!");
 +    return NULL;
 +}
@@ -1346,18 +1452,21 @@
 +void vEventGroupDelete(void *grp)
 +{
 +    ARG_UNUSED(grp);
-+}
-+
+ }
+ 
+-static void esp_log_writev_wrapper(unsigned int level, const char *tag, const char *format, va_list args)
 +uint32_t xEventGroupSetBits(void *ptr, uint32_t data)
-+{
+ {
+-    return esp_log_writev((esp_log_level_t)level, tag, format, args);
 +    ARG_UNUSED(ptr);
 +    ARG_UNUSED(data);
 +
 +    return 0;
-+}
-+
+ }
+ 
+-static void esp_log_write_wrapper(unsigned int level, const char *tag, const char *format, ...)
 +uint32_t xEventGroupClearBits(void *ptr, uint32_t data)
-+{
+ {
 +    ARG_UNUSED(ptr);
 +    ARG_UNUSED(data);
 +
@@ -1430,19 +1539,15 @@
 +    ARG_UNUSED(out_handle);
 +
 +    return 0;
- }
- 
--static esp_err_t nvs_open_wrapper(const char* name, unsigned int open_mode, nvs_handle_t *out_handle)
++}
++
 +void nvs_close(uint32_t handle)
- {
--    return nvs_open(name, (nvs_open_mode_t)open_mode, out_handle);
++{
 +    ARG_UNUSED(handle);
- }
- 
--static void esp_log_writev_wrapper(unsigned int level, const char *tag, const char *format, va_list args)
++}
++
 +int32_t nvs_commit(uint32_t handle)
- {
--    return esp_log_writev((esp_log_level_t)level, tag, format, args);
++{
 +    ARG_UNUSED(handle);
 +
 +    return 0;
@@ -1466,11 +1571,10 @@
 +    ARG_UNUSED(length);
 +
 +    return 0;
- }
- 
--static void esp_log_write_wrapper(unsigned int level, const char *tag, const char *format, ...)
++}
++
 +int32_t nvs_erase_key(uint32_t handle, const char *key)
- {
++{
 +    ARG_UNUSED(handle);
 +    ARG_UNUSED(key);
 +
@@ -1504,7 +1608,7 @@
  }
  
  static int coex_init_wrapper(void)
-@@ -498,7 +767,7 @@
+@@ -498,7 +816,7 @@
  #endif
  }
  
@@ -1513,7 +1617,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_schm_curr_phase_get();
-@@ -507,7 +776,7 @@
+@@ -507,7 +825,7 @@
  #endif
  }
  
@@ -1522,7 +1626,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_register_start_cb(cb);
-@@ -525,7 +794,7 @@
+@@ -525,7 +843,7 @@
  #endif
  }
  
@@ -1531,7 +1635,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_schm_register_callback(type, cb);
-@@ -552,7 +821,7 @@
+@@ -552,7 +870,7 @@
  #endif
  }
  
@@ -1540,7 +1644,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_schm_get_phase_by_idx(phase_idx);
-@@ -563,7 +832,6 @@
+@@ -563,7 +881,6 @@
  
  static void IRAM_ATTR esp_empty_wrapper(void)
  {
@@ -1548,7 +1652,7 @@
  }
  
  static void esp_phy_enable_wrapper(void)
-@@ -588,7 +856,7 @@
+@@ -588,7 +905,7 @@
      ._ints_off = disable_intr_wrapper,
      ._is_from_isr = is_from_isr_wrapper,
      ._spin_lock_create = esp_coex_common_spin_lock_create_wrapper,
@@ -1557,7 +1661,7 @@
      ._wifi_int_disable = esp_coex_common_int_disable_wrapper,
      ._wifi_int_restore = esp_coex_common_int_restore_wrapper,
      ._task_yield_from_isr = esp_coex_common_task_yield_from_isr_wrapper,
-@@ -603,30 +871,30 @@
+@@ -603,30 +920,30 @@
      ._mutex_lock = mutex_lock_wrapper,
      ._mutex_unlock = mutex_unlock_wrapper,
      ._queue_create = queue_create_wrapper,
@@ -1569,7 +1673,7 @@
      ._queue_send_to_front = queue_send_to_front_wrapper,
      ._queue_recv = queue_recv_wrapper,
 -    ._queue_msg_waiting = (uint32_t(*)(void *))uxQueueMessagesWaiting,
-+    ._queue_msg_waiting = (uint32_t (*)(void *))uxQueueMessagesWaiting,
++    ._queue_msg_waiting = queue_msg_waiting_wrapper,
      ._event_group_create = (void *(*)(void))xEventGroupCreate,
 -    ._event_group_delete = (void(*)(void *))vEventGroupDelete,
 -    ._event_group_set_bits = (uint32_t(*)(void *, uint32_t))xEventGroupSetBits,
@@ -1600,7 +1704,7 @@
      ._dport_access_stall_other_cpu_start_wrap = esp_empty_wrapper,
      ._dport_access_stall_other_cpu_end_wrap = esp_empty_wrapper,
      ._wifi_apb80m_request = wifi_apb80m_request_wrapper,
-@@ -634,7 +902,7 @@
+@@ -634,7 +951,7 @@
      ._phy_disable = esp_phy_disable_wrapper,
      ._phy_enable = esp_phy_enable_wrapper,
      ._phy_update_country_info = esp_phy_update_country_info,
@@ -1609,7 +1713,7 @@
      ._timer_arm = timer_arm_wrapper,
      ._timer_disarm = esp_coex_common_timer_disarm_wrapper,
      ._timer_done = esp_coex_common_timer_done_wrapper,
-@@ -664,8 +932,8 @@
+@@ -664,8 +981,8 @@
      ._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
      ._log_write = esp_log_write_wrapper,
      ._log_writev = esp_log_writev_wrapper,
@@ -1688,7 +1792,7 @@
  
  #if SOC_PM_MODEM_RETENTION_BY_REGDMA
  #include "esp_private/esp_regdma.h"
-@@ -56,95 +58,89 @@
+@@ -56,95 +58,95 @@
  
  #define TAG "esp_adapter"
  
@@ -1698,7 +1802,10 @@
 -#endif
 +static void esp_wifi_free(void *mem);
 +
-+static void *wifi_msgq_buffer;
++struct wifi_adapter_msgq {
++    struct k_msgq msgq;
++    void *buffer;
++};
 +
 +struct wifi_task {
 +    struct k_thread thread;
@@ -1780,9 +1887,10 @@
 -    queue->storage = heap_caps_calloc(1, sizeof(StaticQueue_t) + (queue_len * item_size), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
 -    if (!queue->storage) {
 -        goto _error;
-+    wifi_msgq_buffer = wifi_malloc(queue_len * item_size);
-+    if (wifi_msgq_buffer == NULL) {
++    queue->storage = wifi_malloc(queue_len * item_size);
++    if (queue->storage == NULL) {
 +        LOG_ERR("msg buffer allocation failed");
++        esp_wifi_free(queue);
 +        return NULL;
      }
  
@@ -1792,7 +1900,8 @@
 -        goto _error;
 +    queue->handle = wifi_malloc(sizeof(struct k_msgq));
 +    if (queue->handle == NULL) {
-+        esp_wifi_free(wifi_msgq_buffer);
++        esp_wifi_free(queue->storage);
++        esp_wifi_free(queue);
 +        LOG_ERR("queue handle allocation failed");
 +        return NULL;
      }
@@ -1804,11 +1913,11 @@
 -        if (queue->storage) {
 -            free(queue->storage);
 -        }
--
++    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
+ 
 -        free(queue);
 -    }
-+    k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
- 
+-
 -    return NULL;
 -#else
 -    queue->handle = xQueueCreate(queue_len, item_size);
@@ -1827,11 +1936,12 @@
 -#endif
 -        free(queue);
 +        esp_wifi_free(queue->handle);
++        esp_wifi_free(queue->storage);
 +        esp_wifi_free(queue);
      }
  }
  
-@@ -160,6 +156,8 @@
+@@ -160,6 +162,8 @@
  
  static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source, uint32_t intr_num, int32_t intr_prio)
  {
@@ -1840,7 +1950,7 @@
      esp_rom_route_intr_matrix(cpu_no, intr_source, intr_num);
      esprv_int_set_priority(intr_num, intr_prio);
      esprv_int_set_type(intr_num, INTR_TYPE_LEVEL);
-@@ -167,12 +165,15 @@
+@@ -167,12 +171,15 @@
  
  static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
  {
@@ -1858,7 +1968,7 @@
  }
  
  static void enable_intr_wrapper(uint32_t intr_mask)
-@@ -187,168 +188,225 @@
+@@ -187,168 +194,275 @@
  
  static bool IRAM_ATTR is_from_isr_wrapper(void)
  {
@@ -1880,15 +1990,15 @@
 -    static bool s_wifi_thread_sem_key_init = false;
 -    static pthread_key_t s_wifi_thread_sem_key;
 -    SemaphoreHandle_t sem = NULL;
-+    struct k_sem *sem = NULL;
- 
+-
 -    if (s_wifi_thread_sem_key_init == false) {
 -        if (0 != pthread_key_create(&s_wifi_thread_sem_key, wifi_thread_semphr_free)) {
 -            return NULL;
 -        }
 -        s_wifi_thread_sem_key_init = true;
 -    }
--
++    struct k_sem *sem = NULL;
+ 
 -    sem = pthread_getspecific(s_wifi_thread_sem_key);
 +    sem = k_thread_custom_data_get();
      if (!sem) {
@@ -1969,21 +2079,26 @@
 -                                                          MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM,
 -                                                          MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL);
 -    if (!queue_buffer) {
--        return NULL;
--    }
--    QueueHandle_t queue_handle = xQueueCreateStatic(queue_len, item_size, (uint8_t *)queue_buffer + sizeof(StaticQueue_t),
--                                                    queue_buffer);
--    if (!queue_handle) {
--        free(queue_buffer);
-+    struct k_queue *queue = (struct k_queue *)wifi_malloc(sizeof(struct k_queue));
++    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
 +
 +    if (queue == NULL) {
 +        LOG_ERR("queue malloc failed");
          return NULL;
      }
+-    QueueHandle_t queue_handle = xQueueCreateStatic(queue_len, item_size, (uint8_t *)queue_buffer + sizeof(StaticQueue_t),
+-                                                    queue_buffer);
+-    if (!queue_handle) {
+-        free(queue_buffer);
++
++    queue->buffer = wifi_malloc(queue_len * item_size);
++    if (queue->buffer == NULL) {
++        LOG_ERR("queue buffer malloc failed");
++        esp_wifi_free(queue);
+         return NULL;
+     }
  
 -    return (void *)queue_handle;
-+    k_msgq_init((struct k_msgq *)queue, wifi_msgq_buffer, item_size, queue_len);
++    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
 +
 +    return (void *)queue;
  }
@@ -1999,73 +2114,121 @@
 -            free(queue_buffer);
 -        }
 +    if (handle != NULL) {
-+        esp_wifi_free(handle);
++        struct wifi_adapter_msgq *queue = handle;
++
++        esp_wifi_free(queue->buffer);
++        esp_wifi_free(queue);
      }
  }
  
- static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
      if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueSend(queue, item, portMAX_DELAY);
-+        k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
++        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
      } else {
 -        return (int32_t)xQueueSend(queue, item, block_time_tick);
-+        k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
++        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
      }
-+    return 1;
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
++static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
  {
 -    return (int32_t)xQueueSendFromISR(queue, item, hptw);
 +    int *hpt = (int *)hptw;
++    int ret;
 +
-+    k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
 +    if (hpt) {
 +        *hpt = 0;
 +    }
-+    return 1;
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_BACK);
-+    ARG_UNUSED(queue);
-+    ARG_UNUSED(item);
-+    ARG_UNUSED(block_time_tick);
-+
-+    return 0;
++    return queue_send_wrapper(handle, item, block_time_tick);
  }
  
- static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_FRONT);
-+    ARG_UNUSED(queue);
-+    ARG_UNUSED(item);
 +    ARG_UNUSED(block_time_tick);
 +
-+    return 0;
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put_front(&queue->msgq, item);
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
      if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueReceive(queue, item, portMAX_DELAY);
-+        k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
++        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
      } else {
 -        return (int32_t)xQueueReceive(queue, item, block_time_tick);
-+        k_msgq_get((struct k_msgq *)queue, item, K_MSEC(block_time_tick));
++        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
      }
-+    return 1;
++
++    return ret == 0 ? 1 : 0;
  }
  
- static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
+-static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++static uint32_t queue_msg_waiting_wrapper(void *handle)
  {
 -    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, portMAX_DELAY);
 -    } else {
 -        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, block_time_tick);
--    }
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
+     }
++
++    struct wifi_adapter_msgq *queue = handle;
++    return k_msgq_num_used_get(&queue->msgq);
++}
++
++static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++{
 +    ARG_UNUSED(event);
 +    ARG_UNUSED(bits_to_wait_for);
 +    ARG_UNUSED(clear_on_exit);
@@ -2156,7 +2319,7 @@
  }
  
  static void IRAM_ATTR wifi_apb80m_request_wrapper(void)
-@@ -392,41 +450,187 @@
+@@ -392,41 +506,180 @@
  
  static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
  {
@@ -2179,13 +2342,6 @@
 -    void *ptr = heap_caps_calloc(1, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
 -    return ptr;
 +    return k_calloc(1, size);
-+}
-+
-+uint32_t uxQueueMessagesWaiting(void *queue)
-+{
-+    ARG_UNUSED(queue);
-+
-+    return 0;
 +}
 +
 +void *xEventGroupCreate(void)
@@ -2245,12 +2401,10 @@
 +    ARG_UNUSED(value);
 +
 +    return 0;
- }
- 
--static esp_err_t nvs_open_wrapper(const char *name, unsigned int open_mode, nvs_handle_t *out_handle)
++}
++
 +int32_t nvs_get_u8(uint32_t handle, const char *key, uint8_t *out_value)
- {
--    return nvs_open(name, (nvs_open_mode_t)open_mode, out_handle);
++{
 +    ARG_UNUSED(handle);
 +    ARG_UNUSED(key);
 +    ARG_UNUSED(out_value);
@@ -2305,38 +2459,40 @@
 +    ARG_UNUSED(length);
 +
 +    return 0;
-+}
-+
+ }
+ 
+-static esp_err_t nvs_open_wrapper(const char *name, unsigned int open_mode, nvs_handle_t *out_handle)
 +int32_t nvs_get_blob(uint32_t handle, const char *key, void *out_value, size_t *length)
-+{
+ {
+-    return nvs_open(name, (nvs_open_mode_t)open_mode, out_handle);
 +    ARG_UNUSED(handle);
 +    ARG_UNUSED(key);
 +    ARG_UNUSED(out_value);
 +    ARG_UNUSED(length);
 +
 +    return 0;
-+}
-+
+ }
+ 
+-static void esp_log_writev_wrapper(unsigned int level, const char *tag, const char *format, va_list args)
 +int32_t nvs_erase_key(uint32_t handle, const char *key)
-+{
+ {
+-    return esp_log_writev((esp_log_level_t)level, tag, format, args);
 +    ARG_UNUSED(handle);
 +    ARG_UNUSED(key);
 +
 +    return 0;
  }
  
--static void esp_log_writev_wrapper(unsigned int level, const char *tag, const char *format, va_list args)
+-static void esp_log_write_wrapper(unsigned int level, const char *tag, const char *format, ...)
 +static void esp_log_writev_wrapper(uint32_t level, const char *tag, const char *format, va_list args)
  {
--    return esp_log_writev((esp_log_level_t)level, tag, format, args);
 +#if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
 +    esp_log_writev((esp_log_level_t)level, tag, format, args);
 +#endif
- }
- 
--static void esp_log_write_wrapper(unsigned int level, const char *tag, const char *format, ...)
++}
++
 +static void esp_log_write_wrapper(uint32_t level, const char *tag, const char *format, ...)
- {
++{
 +#if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
      va_list list;
      va_start(list, format);
@@ -2355,7 +2511,7 @@
  }
  
  static int coex_init_wrapper(void)
-@@ -565,7 +769,7 @@
+@@ -565,7 +818,7 @@
  #endif
  }
  
@@ -2364,7 +2520,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_register_start_cb(cb);
-@@ -583,7 +787,7 @@
+@@ -583,7 +836,7 @@
  #endif
  }
  
@@ -2373,7 +2529,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_schm_register_callback(type, cb);
-@@ -610,7 +814,7 @@
+@@ -610,7 +863,7 @@
  #endif
  }
  
@@ -2382,7 +2538,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_schm_get_phase_by_idx(phase_idx);
-@@ -621,18 +825,12 @@
+@@ -621,18 +874,12 @@
  
  static void IRAM_ATTR esp_empty_wrapper(void)
  {
@@ -2401,7 +2557,7 @@
  }
  
  static void esp_phy_disable_wrapper(void)
-@@ -641,6 +839,18 @@
+@@ -641,6 +888,18 @@
      esp_phy_disable(PHY_MODEM_WIFI);
  }
  
@@ -2420,7 +2576,7 @@
  wifi_osi_funcs_t g_wifi_osi_funcs = {
      ._version = ESP_WIFI_OS_ADAPTER_VERSION,
      ._env_is_chip = esp_coex_common_env_is_chip_wrapper,
-@@ -651,7 +861,7 @@
+@@ -651,7 +910,7 @@
      ._ints_off = disable_intr_wrapper,
      ._is_from_isr = is_from_isr_wrapper,
      ._spin_lock_create = esp_coex_common_spin_lock_create_wrapper,
@@ -2429,12 +2585,12 @@
      ._wifi_int_disable = esp_coex_common_int_disable_wrapper,
      ._wifi_int_restore = esp_coex_common_int_restore_wrapper,
      ._task_yield_from_isr = esp_coex_common_task_yield_from_isr_wrapper,
-@@ -672,24 +882,24 @@
+@@ -672,24 +931,24 @@
      ._queue_send_to_back = queue_send_to_back_wrapper,
      ._queue_send_to_front = queue_send_to_front_wrapper,
      ._queue_recv = queue_recv_wrapper,
 -    ._queue_msg_waiting = (uint32_t(*)(void *))uxQueueMessagesWaiting,
-+    ._queue_msg_waiting = (uint32_t (*)(void *))uxQueueMessagesWaiting,
++    ._queue_msg_waiting = queue_msg_waiting_wrapper,
      ._event_group_create = (void *(*)(void))xEventGroupCreate,
 -    ._event_group_delete = (void(*)(void *))vEventGroupDelete,
 -    ._event_group_set_bits = (uint32_t(*)(void *, uint32_t))xEventGroupSetBits,
@@ -2465,7 +2621,7 @@
      ._dport_access_stall_other_cpu_start_wrap = esp_empty_wrapper,
      ._dport_access_stall_other_cpu_end_wrap = esp_empty_wrapper,
      ._wifi_apb80m_request = wifi_apb80m_request_wrapper,
-@@ -697,7 +907,7 @@
+@@ -697,7 +956,7 @@
      ._phy_disable = esp_phy_disable_wrapper,
      ._phy_enable = esp_phy_enable_wrapper,
      ._phy_update_country_info = esp_phy_update_country_info,
@@ -2474,7 +2630,7 @@
      ._timer_arm = timer_arm_wrapper,
      ._timer_disarm = esp_coex_common_timer_disarm_wrapper,
      ._timer_done = esp_coex_common_timer_done_wrapper,
-@@ -727,8 +937,8 @@
+@@ -727,8 +986,8 @@
      ._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
      ._log_write = esp_log_write_wrapper,
      ._log_writev = esp_log_writev_wrapper,
@@ -2485,7 +2641,7 @@
      ._realloc_internal = realloc_internal_wrapper,
      ._calloc_internal = calloc_internal_wrapper,
      ._zalloc_internal = zalloc_internal_wrapper,
-@@ -756,8 +966,8 @@
+@@ -756,8 +1015,8 @@
      ._coex_schm_curr_phase_get = coex_schm_curr_phase_get_wrapper,
      ._coex_register_start_cb = coex_register_start_cb_wrapper,
  #if SOC_PM_MODEM_RETENTION_BY_REGDMA
@@ -2565,7 +2721,7 @@
  
  #if SOC_PM_MODEM_RETENTION_BY_REGDMA
  #include "esp_private/esp_regdma.h"
-@@ -57,50 +58,89 @@
+@@ -57,50 +58,95 @@
  
  #define TAG "esp_adapter"
  
@@ -2575,7 +2731,10 @@
 -#endif
 +static void esp_wifi_free(void *mem);
 +
-+static void *wifi_msgq_buffer;
++struct wifi_adapter_msgq {
++	struct k_msgq msgq;
++	void *buffer;
++};
 +
 +struct wifi_task {
 +    struct k_thread thread;
@@ -2636,24 +2795,26 @@
 +    queue = (wifi_static_queue_t *)wifi_malloc(sizeof(wifi_static_queue_t));
      if (!queue) {
 +        LOG_ERR("msg buffer allocation failed");
++        return NULL;
++    }
++
++    queue->storage = wifi_malloc(queue_len * item_size);
++    if (queue->storage == NULL) {
++        LOG_ERR("msg buffer allocation failed");
++        esp_wifi_free(queue);
          return NULL;
      }
  
 -    queue->handle = xQueueCreate(queue_len, item_size);
-+    wifi_msgq_buffer = wifi_malloc(queue_len * item_size);
-+    if (wifi_msgq_buffer == NULL) {
-+        LOG_ERR("msg buffer allocation failed");
-+        return NULL;
-+    }
-+
 +    queue->handle = wifi_malloc(sizeof(struct k_msgq));
 +    if (queue->handle == NULL) {
-+        esp_wifi_free(wifi_msgq_buffer);
++        esp_wifi_free(queue->storage);
++        esp_wifi_free(queue);
 +        LOG_ERR("queue handle allocation failed");
 +        return NULL;
 +    }
 +
-+    k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
++    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 +
      return queue;
  }
@@ -2664,11 +2825,12 @@
 -        vQueueDelete(queue->handle);
 -        free(queue);
 +        esp_wifi_free(queue->handle);
++        esp_wifi_free(queue->storage);
 +        esp_wifi_free(queue);
      }
  }
  
-@@ -116,6 +156,8 @@
+@@ -116,6 +162,8 @@
  
  static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source, uint32_t intr_num, int32_t intr_prio)
  {
@@ -2677,7 +2839,7 @@
      esp_rom_route_intr_matrix(cpu_no, intr_source, intr_num);
      esprv_int_set_priority(intr_num, intr_prio);
      esprv_int_set_type(intr_num, INTR_TYPE_LEVEL);
-@@ -123,12 +165,15 @@
+@@ -123,12 +171,15 @@
  
  static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
  {
@@ -2695,7 +2857,7 @@
  }
  
  static void enable_intr_wrapper(uint32_t intr_mask)
-@@ -143,143 +188,225 @@
+@@ -143,143 +194,276 @@
  
  static bool IRAM_ATTR is_from_isr_wrapper(void)
  {
@@ -2803,88 +2965,144 @@
  static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
  {
 -    return (void *)xQueueCreate(queue_len, item_size);
-+    struct k_queue *queue = (struct k_queue *)wifi_malloc(sizeof(struct k_queue));
++    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
 +
-+    if (queue == NULL) {
++    if (!queue) {
 +        LOG_ERR("queue malloc failed");
 +        return NULL;
 +    }
 +
-+    k_msgq_init((struct k_msgq *)queue, wifi_msgq_buffer, item_size, queue_len);
++    queue->buffer = wifi_malloc(queue_len * item_size);
++    if (!queue->buffer) {
++        LOG_ERR("queue buffer malloc failed");
++        esp_wifi_free(queue);
++        return NULL;
++    }
++
++    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
 +
 +    return (void *)queue;
 +}
 +
 +static void queue_delete_wrapper(void *handle)
 +{
-+    if (handle != NULL) {
-+        esp_wifi_free(handle);
++    if (handle) {
++        struct wifi_adapter_msgq *queue = handle;
++
++        esp_wifi_free(queue->buffer);
++        esp_wifi_free(queue);
 +    }
  }
  
- static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
      if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueSend(queue, item, portMAX_DELAY);
-+        k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
++        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
      } else {
 -        return (int32_t)xQueueSend(queue, item, block_time_tick);
-+        k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
++        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
      }
-+    return 1;
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
++static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
  {
 -    return (int32_t)xQueueSendFromISR(queue, item, hptw);
 +    int *hpt = (int *)hptw;
++    int ret;
 +
-+    k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
 +    if (hpt) {
 +        *hpt = 0;
 +    }
-+    return 1;
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_BACK);
-+    ARG_UNUSED(queue);
-+    ARG_UNUSED(item);
-+    ARG_UNUSED(block_time_tick);
-+
-+    return 0;
++    return queue_send_wrapper(handle, item, block_time_tick);
  }
  
- static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_FRONT);
-+    ARG_UNUSED(queue);
-+    ARG_UNUSED(item);
 +    ARG_UNUSED(block_time_tick);
 +
-+    return 0;
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put_front(&queue->msgq, item);
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
      if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueReceive(queue, item, portMAX_DELAY);
-+        k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
++        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
      } else {
 -        return (int32_t)xQueueReceive(queue, item, block_time_tick);
-+        k_msgq_get((struct k_msgq *)queue, item, K_MSEC(block_time_tick));
++        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
      }
-+    return 1;
++
++    return ret == 0 ? 1 : 0;
  }
  
- static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
+-static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++static uint32_t queue_msg_waiting_wrapper(void *handle)
  {
 -    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, portMAX_DELAY);
 -    } else {
 -        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, block_time_tick);
--    }
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
+     }
++
++    struct wifi_adapter_msgq *queue = handle;
++    return k_msgq_num_used_get(&queue->msgq);
++}
++
++static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++{
 +    ARG_UNUSED(event);
 +    ARG_UNUSED(bits_to_wait_for);
 +    ARG_UNUSED(clear_on_exit);
@@ -2975,7 +3193,7 @@
  }
  
  static void IRAM_ATTR wifi_apb80m_request_wrapper(void)
-@@ -323,41 +450,187 @@
+@@ -323,41 +507,180 @@
  
  static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
  {
@@ -2998,13 +3216,6 @@
 -    void *ptr = heap_caps_calloc(1, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
 -    return ptr;
 +    return k_calloc(1, size);
-+}
-+
-+uint32_t uxQueueMessagesWaiting(void *queue)
-+{
-+    ARG_UNUSED(queue);
-+
-+    return 0;
 +}
 +
 +void *xEventGroupCreate(void)
@@ -3055,10 +3266,12 @@
 +    ARG_UNUSED(out_value);
 +
 +    return 0;
-+}
-+
+ }
+ 
+-static esp_err_t nvs_open_wrapper(const char *name, unsigned int open_mode, nvs_handle_t *out_handle)
 +int32_t nvs_set_u8(uint32_t handle, const char *key, uint8_t value)
-+{
+ {
+-    return nvs_open(name, (nvs_open_mode_t)open_mode, out_handle);
 +    ARG_UNUSED(handle);
 +    ARG_UNUSED(key);
 +    ARG_UNUSED(value);
@@ -3091,19 +3304,22 @@
 +    ARG_UNUSED(out_value);
 +
 +    return 0;
-+}
-+
+ }
+ 
+-static void esp_log_writev_wrapper(unsigned int level, const char *tag, const char *format, va_list args)
 +int32_t nvs_open_wrapper(const char *name, uint32_t open_mode, uint32_t *out_handle)
-+{
+ {
+-    return esp_log_writev((esp_log_level_t)level, tag, format, args);
 +    ARG_UNUSED(name);
 +    ARG_UNUSED(open_mode);
 +    ARG_UNUSED(out_handle);
 +
 +    return 0;
-+}
-+
+ }
+ 
+-static void esp_log_write_wrapper(unsigned int level, const char *tag, const char *format, ...)
 +void nvs_close(uint32_t handle)
-+{
+ {
 +    ARG_UNUSED(handle);
 +}
 +
@@ -3132,30 +3348,25 @@
 +    ARG_UNUSED(length);
 +
 +    return 0;
- }
- 
--static esp_err_t nvs_open_wrapper(const char *name, unsigned int open_mode, nvs_handle_t *out_handle)
++}
++
 +int32_t nvs_erase_key(uint32_t handle, const char *key)
- {
--    return nvs_open(name, (nvs_open_mode_t)open_mode, out_handle);
++{
 +    ARG_UNUSED(handle);
 +    ARG_UNUSED(key);
 +
 +    return 0;
- }
- 
--static void esp_log_writev_wrapper(unsigned int level, const char *tag, const char *format, va_list args)
++}
++
 +static void esp_log_writev_wrapper(uint32_t level, const char *tag, const char *format, va_list args)
- {
--    return esp_log_writev((esp_log_level_t)level, tag, format, args);
++{
 +#if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
 +    esp_log_writev((esp_log_level_t)level, tag, format, args);
 +#endif
- }
- 
--static void esp_log_write_wrapper(unsigned int level, const char *tag, const char *format, ...)
++}
++
 +static void esp_log_write_wrapper(uint32_t level, const char *tag, const char *format, ...)
- {
++{
 +#if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
      va_list list;
      va_start(list, format);
@@ -3174,7 +3385,7 @@
  }
  
  static int coex_init_wrapper(void)
-@@ -401,6 +674,13 @@
+@@ -401,6 +724,13 @@
  #endif
  }
  
@@ -3188,7 +3399,7 @@
  static int coex_wifi_request_wrapper(uint32_t event, uint32_t latency, uint32_t duration)
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
-@@ -496,7 +776,7 @@
+@@ -496,7 +826,7 @@
  #endif
  }
  
@@ -3197,7 +3408,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_register_start_cb(cb);
-@@ -514,7 +794,7 @@
+@@ -514,7 +844,7 @@
  #endif
  }
  
@@ -3206,7 +3417,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_schm_register_callback(type, cb);
-@@ -541,7 +821,7 @@
+@@ -541,7 +871,7 @@
  #endif
  }
  
@@ -3215,7 +3426,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
      return coex_schm_get_phase_by_idx(phase_idx);
-@@ -552,7 +832,6 @@
+@@ -552,7 +882,6 @@
  
  static void IRAM_ATTR esp_empty_wrapper(void)
  {
@@ -3223,7 +3434,7 @@
  }
  
  static void esp_phy_enable_wrapper(void)
-@@ -589,7 +868,7 @@
+@@ -589,7 +918,7 @@
      ._ints_off = disable_intr_wrapper,
      ._is_from_isr = is_from_isr_wrapper,
      ._spin_lock_create = esp_coex_common_spin_lock_create_wrapper,
@@ -3232,7 +3443,7 @@
      ._wifi_int_disable = esp_coex_common_int_disable_wrapper,
      ._wifi_int_restore = esp_coex_common_int_restore_wrapper,
      ._task_yield_from_isr = esp_coex_common_task_yield_from_isr_wrapper,
-@@ -604,30 +883,30 @@
+@@ -604,30 +933,30 @@
      ._mutex_lock = mutex_lock_wrapper,
      ._mutex_unlock = mutex_unlock_wrapper,
      ._queue_create = queue_create_wrapper,
@@ -3244,7 +3455,7 @@
      ._queue_send_to_front = queue_send_to_front_wrapper,
      ._queue_recv = queue_recv_wrapper,
 -    ._queue_msg_waiting = (uint32_t(*)(void *))uxQueueMessagesWaiting,
-+    ._queue_msg_waiting = (uint32_t (*)(void *))uxQueueMessagesWaiting,
++    ._queue_msg_waiting = queue_msg_waiting_wrapper,
      ._event_group_create = (void *(*)(void))xEventGroupCreate,
 -    ._event_group_delete = (void(*)(void *))vEventGroupDelete,
 -    ._event_group_set_bits = (uint32_t(*)(void *, uint32_t))xEventGroupSetBits,
@@ -3275,7 +3486,7 @@
      ._dport_access_stall_other_cpu_start_wrap = esp_empty_wrapper,
      ._dport_access_stall_other_cpu_end_wrap = esp_empty_wrapper,
      ._wifi_apb80m_request = wifi_apb80m_request_wrapper,
-@@ -635,7 +914,7 @@
+@@ -635,7 +964,7 @@
      ._phy_disable = esp_phy_disable_wrapper,
      ._phy_enable = esp_phy_enable_wrapper,
      ._phy_update_country_info = esp_phy_update_country_info,
@@ -3284,7 +3495,7 @@
      ._timer_arm = timer_arm_wrapper,
      ._timer_disarm = esp_coex_common_timer_disarm_wrapper,
      ._timer_done = esp_coex_common_timer_done_wrapper,
-@@ -665,8 +944,8 @@
+@@ -665,8 +994,8 @@
      ._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
      ._log_write = esp_log_write_wrapper,
      ._log_writev = esp_log_writev_wrapper,
@@ -3295,7 +3506,7 @@
      ._realloc_internal = realloc_internal_wrapper,
      ._calloc_internal = calloc_internal_wrapper,
      ._zalloc_internal = zalloc_internal_wrapper,
-@@ -681,6 +960,7 @@
+@@ -681,6 +1010,7 @@
      ._coex_enable = coex_enable_wrapper,
      ._coex_disable = coex_disable_wrapper,
      ._coex_status_get = coex_status_get_wrapper,
@@ -3333,7 +3544,7 @@
  #include "esp_intr_alloc.h"
  #include "esp_attr.h"
  #include "esp_log.h"
-@@ -32,29 +31,30 @@
+@@ -32,29 +31,33 @@
  #include "esp_cpu.h"
  #include "esp_private/wifi_os_adapter.h"
  #include "esp_private/wifi.h"
@@ -3369,12 +3580,15 @@
 +    k_thread_stack_t *stack;
 +};
 +
-+static void *wifi_msgq_buffer;
++struct wifi_adapter_msgq {
++    struct k_msgq msgq;
++    void *buffer;
++};
 +
  #ifdef CONFIG_PM_ENABLE
  extern void wifi_apb80m_request(void);
  extern void wifi_apb80m_release(void);
-@@ -62,116 +62,87 @@
+@@ -62,116 +65,90 @@
  
  static void IRAM_ATTR s_esp_dport_access_stall_other_cpu_start(void)
  {
@@ -3472,9 +3686,10 @@
 -    queue->storage = heap_caps_calloc(1, sizeof(StaticQueue_t) + (queue_len * item_size), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
 -    if (!queue->storage) {
 -        goto _error;
-+    wifi_msgq_buffer = wifi_malloc(queue_len * item_size);
-+    if (wifi_msgq_buffer == NULL) {
++    queue->storage = wifi_malloc(queue_len * item_size);
++    if (queue->storage == NULL) {
 +        LOG_ERR("msg buffer allocation failed");
++        esp_wifi_free(queue);
 +        return NULL;
      }
  
@@ -3484,13 +3699,14 @@
 -        goto _error;
 +    queue->handle = wifi_malloc(sizeof(struct k_msgq));
 +    if (queue->handle == NULL) {
-+        esp_wifi_free(wifi_msgq_buffer);
++        esp_wifi_free(queue->storage);
++        esp_wifi_free(queue);
 +        LOG_ERR("queue handle allocation failed");
 +        return NULL;
      }
  
 -    return queue;
-+    k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
++    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
  
 -_error:
 -    if (queue) {
@@ -3521,6 +3737,7 @@
 -
 -        free(queue);
 +        esp_wifi_free(queue->handle);
++        esp_wifi_free(queue->storage);
 +        esp_wifi_free(queue);
      }
  }
@@ -3530,7 +3747,7 @@
  {
      return wifi_create_queue(queue_len, item_size);
  }
-@@ -188,178 +159,220 @@
+@@ -188,178 +165,278 @@
  
  static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
  {
@@ -3660,25 +3877,28 @@
 -                                                          MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM,
 -                                                          MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL);
 -    if (!queue_buffer) {
--        return NULL;
--    }
++    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
++
++    if (queue == NULL) {
++        LOG_ERR("queue malloc failed");
+         return NULL;
+     }
 -    QueueHandle_t queue_handle = xQueueCreateStatic(queue_len, item_size, (uint8_t *)queue_buffer + sizeof(StaticQueue_t),
 -                                                    queue_buffer);
 -    if (!queue_handle) {
 -        free(queue_buffer);
--        return NULL;
--    }
-+	struct k_queue *queue = (struct k_queue *) wifi_malloc(sizeof(struct k_queue));
 +
-+	if (queue == NULL) {
-+		LOG_ERR("queue malloc failed");
-+		return NULL;
-+	}
++    queue->buffer = wifi_malloc(queue_len * item_size);
++    if (queue->buffer == NULL) {
++        LOG_ERR("queue buffer malloc failed");
++        esp_wifi_free(queue);
+         return NULL;
+     }
  
 -    return (void *)queue_handle;
-+	k_msgq_init((struct k_msgq *)queue, wifi_msgq_buffer, item_size, queue_len);
++    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
 +
-+	return (void *)queue;
++    return (void *)queue;
  }
  
 -static void queue_delete_wrapper(void *queue)
@@ -3692,20 +3912,19 @@
 -            free(queue_buffer);
 -        }
 +    if (handle != NULL) {
-+        esp_wifi_free(handle);
++        struct wifi_adapter_msgq *queue = handle;
++
++        esp_wifi_free(queue->buffer);
++        esp_wifi_free(queue);
      }
  }
  
 -static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
 +static void task_delete_wrapper(void *handle)
  {
--    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
--        return (int32_t)xQueueSend(queue, item, portMAX_DELAY);
--    } else {
--        return (int32_t)xQueueSend(queue, item, block_time_tick);
 +    if (handle == NULL) {
 +        return;
-     }
++    }
 +
 +    k_tid_t tid = (k_tid_t)handle;
 +    struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
@@ -3716,59 +3935,113 @@
 +    esp_wifi_free(t);
 +}
 +
-+static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
 +{
-+	if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-+		k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
-+	} else {
-+		k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
-+	}
-+	return 1;
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
+     if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+-        return (int32_t)xQueueSend(queue, item, portMAX_DELAY);
++        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
+     } else {
+-        return (int32_t)xQueueSend(queue, item, block_time_tick);
++        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
+     }
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
++static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
  {
 -    return (int32_t)xQueueSendFromISR(queue, item, hptw);
 +    int *hpt = (int *)hptw;
++    int ret;
 +
-+    k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
 +    if (hpt) {
 +        *hpt = 0;
 +    }
-+    return 1;
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_BACK);
-+    return 0;
++    return queue_send_wrapper(handle, item, block_time_tick);
  }
  
- static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_FRONT);
-+    return 0;
++    ARG_UNUSED(block_time_tick);
++
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put_front(&queue->msgq, item);
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
      if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueReceive(queue, item, portMAX_DELAY);
-+        k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
++        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
      } else {
 -        return (int32_t)xQueueReceive(queue, item, block_time_tick);
-+        k_msgq_get((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
++        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
      }
-+    return 1;
++
++    return ret == 0 ? 1 : 0;
  }
  
- static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
+-static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++static uint32_t queue_msg_waiting_wrapper(void *handle)
  {
 -    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, portMAX_DELAY);
 -    } else {
 -        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, block_time_tick);
--    }
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
+     }
++
++    struct wifi_adapter_msgq *queue = handle;
++    return k_msgq_num_used_get(&queue->msgq);
++}
++
++static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++{
 +    /* TODO: implement properly using Zephyr event objects */
 +    return 0;
  }
@@ -3833,7 +4106,7 @@
  }
  
  static void IRAM_ATTR wifi_apb80m_request_wrapper(void)
-@@ -401,20 +414,129 @@
+@@ -401,20 +478,124 @@
      return os_get_time(t);
  }
  
@@ -3863,11 +4136,6 @@
 +static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 +{
 +    return k_calloc(1, size);
-+}
-+
-+uint32_t uxQueueMessagesWaiting(void *queue)
-+{
-+    return 0;
 +}
 +
 +void *xEventGroupCreate(void)
@@ -3970,7 +4238,7 @@
  }
  
  static int coex_init_wrapper(void)
-@@ -458,6 +580,13 @@
+@@ -458,6 +639,13 @@
  #endif
  }
  
@@ -3984,7 +4252,7 @@
  static int coex_wifi_request_wrapper(uint32_t event, uint32_t latency, uint32_t duration)
  {
  #if CONFIG_SW_COEXIST_ENABLE
-@@ -540,7 +669,7 @@
+@@ -540,7 +728,7 @@
  #endif
  }
  
@@ -3993,7 +4261,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE
      return coex_schm_curr_phase_get();
-@@ -549,7 +678,7 @@
+@@ -549,7 +737,7 @@
  #endif
  }
  
@@ -4002,7 +4270,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE
      return coex_register_start_cb(cb);
-@@ -567,7 +696,7 @@
+@@ -567,7 +755,7 @@
  #endif
  }
  
@@ -4011,7 +4279,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE
      return coex_schm_register_callback(type, cb);
-@@ -594,7 +723,7 @@
+@@ -594,7 +782,7 @@
  #endif
  }
  
@@ -4020,7 +4288,7 @@
  {
  #if CONFIG_SW_COEXIST_ENABLE
      return coex_schm_get_phase_by_idx(phase_idx);
-@@ -605,7 +734,6 @@
+@@ -605,7 +793,6 @@
  
  static void IRAM_ATTR esp_empty_wrapper(void)
  {
@@ -4028,7 +4296,7 @@
  }
  
  static void esp_phy_enable_wrapper(void)
-@@ -620,17 +748,34 @@
+@@ -620,17 +807,34 @@
      esp_phy_disable(PHY_MODEM_WIFI);
  }
  
@@ -4067,9 +4335,12 @@
      ._wifi_int_disable = esp_coex_common_int_disable_wrapper,
      ._wifi_int_restore = esp_coex_common_int_restore_wrapper,
      ._task_yield_from_isr = esp_coex_common_task_yield_from_isr_wrapper,
-@@ -653,22 +798,22 @@
+@@ -651,24 +855,24 @@
+     ._queue_send_to_back = queue_send_to_back_wrapper,
+     ._queue_send_to_front = queue_send_to_front_wrapper,
      ._queue_recv = queue_recv_wrapper,
-     ._queue_msg_waiting = (uint32_t(*)(void *))uxQueueMessagesWaiting,
+-    ._queue_msg_waiting = (uint32_t(*)(void *))uxQueueMessagesWaiting,
++    ._queue_msg_waiting = queue_msg_waiting_wrapper,
      ._event_group_create = (void *(*)(void))xEventGroupCreate,
 -    ._event_group_delete = (void(*)(void *))vEventGroupDelete,
 +    ._event_group_delete = (void (*)(void *))vEventGroupDelete,
@@ -4098,7 +4369,7 @@
      ._dport_access_stall_other_cpu_start_wrap = s_esp_dport_access_stall_other_cpu_start,
      ._dport_access_stall_other_cpu_end_wrap = s_esp_dport_access_stall_other_cpu_end,
      ._wifi_apb80m_request = wifi_apb80m_request_wrapper,
-@@ -689,7 +834,7 @@
+@@ -689,7 +893,7 @@
      ._wifi_clock_disable = wifi_clock_disable_wrapper,
      ._wifi_rtc_enable_iso = esp_empty_wrapper,
      ._wifi_rtc_disable_iso = esp_empty_wrapper,
@@ -4107,7 +4378,7 @@
      ._nvs_set_i8 = nvs_set_i8,
      ._nvs_get_i8 = nvs_get_i8,
      ._nvs_set_u8 = nvs_set_u8,
-@@ -704,11 +849,11 @@
+@@ -704,11 +908,11 @@
      ._nvs_erase_key = nvs_erase_key,
      ._get_random = os_get_random,
      ._get_time = get_time_wrapper,
@@ -4124,7 +4395,7 @@
      ._realloc_internal = realloc_internal_wrapper,
      ._calloc_internal = calloc_internal_wrapper,
      ._zalloc_internal = zalloc_internal_wrapper,
-@@ -723,6 +868,7 @@
+@@ -723,6 +927,7 @@
      ._coex_enable = coex_enable_wrapper,
      ._coex_disable = coex_disable_wrapper,
      ._coex_status_get = coex_status_get_wrapper,
@@ -4132,7 +4403,7 @@
      ._coex_wifi_request = coex_wifi_request_wrapper,
      ._coex_wifi_release = coex_wifi_release_wrapper,
      ._coex_wifi_channel_set = coex_wifi_channel_set_wrapper,
-@@ -734,9 +880,9 @@
+@@ -734,9 +939,9 @@
      ._coex_schm_interval_get = coex_schm_interval_get_wrapper,
      ._coex_schm_curr_period_get = coex_schm_curr_period_get_wrapper,
      ._coex_schm_curr_phase_get = coex_schm_curr_phase_get_wrapper,
@@ -4145,7 +4416,7 @@
      ._coex_schm_get_phase_by_idx = coex_schm_get_phase_by_idx_wrapper,
 --- a/components/esp_wifi/esp32s2/esp_adapter.c
 +++ b/components/esp_wifi/esp32s2/esp_adapter.c
-@@ -4,165 +4,132 @@
+@@ -4,165 +4,136 @@
   * SPDX-License-Identifier: Apache-2.0
   */
  
@@ -4216,11 +4487,14 @@
 -extern void wifi_apb80m_request(void);
 -extern void wifi_apb80m_release(void);
 -#endif
-+static void *wifi_msgq_buffer;
-+
 +struct wifi_task {
 +    struct k_thread thread;
 +    k_thread_stack_t *stack;
++};
++
++struct wifi_adapter_msgq {
++    struct k_msgq msgq;
++    void *buffer;
 +};
  
 -/*
@@ -4314,8 +4588,8 @@
 -    queue->storage = heap_caps_calloc(1, sizeof(StaticQueue_t) + (queue_len * item_size), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
 -    if (!queue->storage) {
 -        goto _error;
-+    wifi_msgq_buffer = wifi_malloc(queue_len * item_size);
-+    if (wifi_msgq_buffer == NULL) {
++    queue->storage = wifi_malloc(queue_len * item_size);
++    if (queue->storage == NULL) {
 +        LOG_ERR("msg buffer allocation failed");
 +        esp_wifi_free(queue);
 +        return NULL;
@@ -4327,7 +4601,7 @@
 -        goto _error;
 +    queue->handle = wifi_malloc(sizeof(struct k_msgq));
 +    if (queue->handle == NULL) {
-+        esp_wifi_free(wifi_msgq_buffer);
++        esp_wifi_free(queue->storage);
 +        esp_wifi_free(queue);
 +        LOG_ERR("queue handle allocation failed");
 +        return NULL;
@@ -4340,11 +4614,11 @@
 -        if (queue->storage) {
 -            free(queue->storage);
 -        }
--
++    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
+ 
 -        free(queue);
 -    }
-+    k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
- 
+-
 -    return NULL;
 -#else
 -    queue->handle = xQueueCreate(queue_len, item_size);
@@ -4365,6 +4639,7 @@
 -
 -        free(queue);
 +        esp_wifi_free(queue->handle);
++        esp_wifi_free(queue->storage);
 +        esp_wifi_free(queue);
      }
  }
@@ -4374,7 +4649,7 @@
  {
      return wifi_create_queue(queue_len, item_size);
  }
-@@ -179,178 +146,264 @@
+@@ -179,178 +150,308 @@
  
  static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
  {
@@ -4505,7 +4780,7 @@
 -                                                          MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM,
 -                                                          MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL);
 -    if (!queue_buffer) {
-+    struct k_msgq *queue = (struct k_msgq *)wifi_malloc(sizeof(struct k_msgq));
++    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
 +
 +    if (queue == NULL) {
 +        LOG_ERR("queue malloc failed");
@@ -4516,20 +4791,21 @@
 -    if (!queue_handle) {
 -        free(queue_buffer);
 +
-+    char *buffer = wifi_malloc(queue_len * item_size);
-+    if (buffer == NULL) {
-+        esp_wifi_free(queue);
++    queue->buffer = wifi_malloc(queue_len * item_size);
++    if (queue->buffer == NULL) {
 +        LOG_ERR("queue buffer malloc failed");
++        esp_wifi_free(queue);
          return NULL;
      }
  
 -    return (void *)queue_handle;
-+    k_msgq_init(queue, buffer, item_size, queue_len);
++    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
 +
 +    return (void *)queue;
  }
  
- static void queue_delete_wrapper(void *queue)
+-static void queue_delete_wrapper(void *queue)
++static void queue_delete_wrapper(void *handle)
  {
 -    if (queue) {
 -        StaticQueue_t *queue_buffer = NULL;
@@ -4538,16 +4814,20 @@
 -        if (queue_buffer) {
 -            free(queue_buffer);
 -        }
-+    if (queue != NULL) {
-+        esp_wifi_free(queue);
-+    }
-+}
++    if (handle != NULL) {
++        struct wifi_adapter_msgq *queue = handle;
 +
++        esp_wifi_free(queue->buffer);
++        esp_wifi_free(queue);
+     }
+ }
+ 
+-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
 +static void task_delete_wrapper(void *handle)
-+{
+ {
 +    if (handle == NULL) {
 +        return;
-     }
++    }
 +
 +    k_tid_t tid = (k_tid_t)handle;
 +    struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
@@ -4556,61 +4836,111 @@
 +    k_thread_stack_free(t->stack);
 +    k_object_release(tid);
 +    esp_wifi_free(t);
- }
- 
- static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
- {
++}
++
++static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
++{
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
      if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueSend(queue, item, portMAX_DELAY);
-+        k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
++        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
      } else {
 -        return (int32_t)xQueueSend(queue, item, block_time_tick);
-+        k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
++        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
      }
-+    return 1;
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
++static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
  {
 -    return (int32_t)xQueueSendFromISR(queue, item, hptw);
 +    int *hpt = (int *)hptw;
++    int ret;
 +
-+    k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
 +    if (hpt) {
 +        *hpt = 0;
 +    }
-+    return 1;
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_BACK);
-+    return queue_send_wrapper(queue, item, block_time_tick);
++    return queue_send_wrapper(handle, item, block_time_tick);
  }
  
- static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_FRONT);
-+    return 0;
++    ARG_UNUSED(block_time_tick);
++
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put_front(&queue->msgq, item);
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 +    int ret;
 +
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
      if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueReceive(queue, item, portMAX_DELAY);
-+        ret = k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
++        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
      } else {
 -        return (int32_t)xQueueReceive(queue, item, block_time_tick);
-+        ret = k_msgq_get((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
++        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
      }
-+    return (ret == 0) ? 1 : 0;
-+}
 +
-+static uint32_t queue_msg_waiting_wrapper(void *queue)
-+{
-+    return k_msgq_num_used_get((struct k_msgq *)queue);
++    return ret == 0 ? 1 : 0;
+ }
+ 
+-static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++static uint32_t queue_msg_waiting_wrapper(void *handle)
+ {
+-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+-        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, portMAX_DELAY);
+-    } else {
+-        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, block_time_tick);
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
+     }
++
++    struct wifi_adapter_msgq *queue = handle;
++    return k_msgq_num_used_get(&queue->msgq);
 +}
 +
 +static void *event_group_create_wrapper(void)
@@ -4631,15 +4961,10 @@
 +static uint32_t event_group_clear_bits_wrapper(void *event, uint32_t bits)
 +{
 +    return 0;
- }
- 
- static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
- {
--    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
--        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, portMAX_DELAY);
--    } else {
--        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, block_time_tick);
--    }
++}
++
++static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++{
 +    return 0;
  }
  
@@ -4713,7 +5038,7 @@
  }
  
  static void IRAM_ATTR wifi_apb80m_request_wrapper(void)
-@@ -392,20 +445,31 @@
+@@ -392,20 +493,31 @@
      return os_get_time(t);
  }
  
@@ -4752,7 +5077,7 @@
  }
  
  static int coex_init_wrapper(void)
-@@ -535,7 +599,7 @@
+@@ -535,7 +647,7 @@
  #endif
  }
  
@@ -4761,7 +5086,7 @@
  {
  #if CONFIG_EXTERNAL_COEX_ENABLE
      return coex_schm_curr_phase_get();
-@@ -544,7 +608,7 @@
+@@ -544,7 +656,7 @@
  #endif
  }
  
@@ -4770,7 +5095,7 @@
  {
  #if CONFIG_EXTERNAL_COEX_ENABLE
      return coex_register_start_cb(cb);
-@@ -589,7 +653,7 @@
+@@ -589,7 +701,7 @@
  #endif
  }
  
@@ -4779,7 +5104,7 @@
  {
  #if CONFIG_EXTERNAL_COEX_ENABLE
      return coex_schm_get_phase_by_idx(phase_idx);
-@@ -613,17 +677,94 @@
+@@ -613,17 +725,94 @@
      esp_phy_disable(PHY_MODEM_WIFI);
  }
  
@@ -4878,7 +5203,7 @@
      ._wifi_int_disable = esp_coex_common_int_disable_wrapper,
      ._wifi_int_restore = esp_coex_common_int_restore_wrapper,
      ._task_yield_from_isr = esp_coex_common_task_yield_from_isr_wrapper,
-@@ -644,24 +785,24 @@
+@@ -644,24 +833,24 @@
      ._queue_send_to_back = queue_send_to_back_wrapper,
      ._queue_send_to_front = queue_send_to_front_wrapper,
      ._queue_recv = queue_recv_wrapper,
@@ -4915,7 +5240,7 @@
      ._dport_access_stall_other_cpu_start_wrap = esp_empty_wrapper,
      ._dport_access_stall_other_cpu_end_wrap = esp_empty_wrapper,
      ._wifi_apb80m_request = wifi_apb80m_request_wrapper,
-@@ -697,12 +838,12 @@
+@@ -697,12 +886,12 @@
      ._nvs_erase_key = nvs_erase_key,
      ._get_random = os_get_random,
      ._get_time = get_time_wrapper,
@@ -4961,7 +5286,7 @@
  #include "esp_intr_alloc.h"
  #include "esp_attr.h"
  #include "esp_log.h"
-@@ -32,137 +29,112 @@
+@@ -32,137 +29,118 @@
  #include "esp_cpu.h"
  #include "esp_private/wifi_os_adapter.h"
  #include "esp_private/wifi.h"
@@ -4989,17 +5314,20 @@
 -#endif
 +#include "wifi/wifi_event.h"
 +#include "esp_heap_adapter.h"
- 
--#define TAG "esp_adapter"
++
 +LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
  
--#define MHZ (1000000)
+-#define TAG "esp_adapter"
 +struct wifi_task {
 +	struct k_thread thread;
 +	k_thread_stack_t *stack;
 +};
-+
-+static void *wifi_msgq_buffer;
+ 
+-#define MHZ (1000000)
++struct wifi_adapter_msgq {
++	struct k_msgq msgq;
++	void *buffer;
++};
  
  #ifdef CONFIG_PM_ENABLE
  extern void wifi_apb80m_request(void);
@@ -5086,7 +5414,7 @@
 -    if (!queue) {
 -        return NULL;
 -    }
-+	queue = (wifi_static_queue_t *)k_malloc(sizeof(wifi_static_queue_t));
++	queue = (wifi_static_queue_t *)wifi_malloc(sizeof(wifi_static_queue_t));
  
 -#if CONFIG_SPIRAM_USE_MALLOC
 -    /* Wi-Fi still use internal RAM */
@@ -5099,36 +5427,38 @@
 -    if (!queue->storage) {
 -        goto _error;
 -    }
-+	wifi_msgq_buffer = k_malloc(queue_len * item_size);
++	queue->storage = wifi_malloc(queue_len * item_size);
  
 -    queue->handle = xQueueCreateStatic(queue_len, item_size, ((uint8_t*)(queue->storage)) + sizeof(StaticQueue_t), (StaticQueue_t*)(queue->storage));
-+	if (wifi_msgq_buffer == NULL) {
-+		LOG_ERR("msg buffer allocation failed");
-+		return NULL;
-+	}
- 
+-
 -    if (!queue->handle) {
 -        goto _error;
 -    }
-+	queue->handle = k_malloc(sizeof(struct k_msgq));
- 
--    return queue;
-+	if (queue->handle == NULL) {
-+		k_free(wifi_msgq_buffer);
-+		LOG_ERR("queue handle allocation failed");
++	if (queue->storage == NULL) {
++		LOG_ERR("msg buffer allocation failed");
++		esp_wifi_free(queue);
 +		return NULL;
 +	}
+ 
+-    return queue;
++	queue->handle = wifi_malloc(sizeof(struct k_msgq));
  
 -_error:
 -    if (queue) {
 -        if (queue->storage) {
 -            free(queue->storage);
 -        }
-+	k_msgq_init((struct k_msgq *)queue->handle, wifi_msgq_buffer, item_size, queue_len);
++	if (queue->handle == NULL) {
++		esp_wifi_free(queue->storage);
++		esp_wifi_free(queue);
++		LOG_ERR("queue handle allocation failed");
++		return NULL;
++	}
  
 -        free(queue);
 -    }
--
++	k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
+ 
 -    return NULL;
 -#else
 -    queue->handle = xQueueCreate(queue_len, item_size);
@@ -5151,13 +5481,14 @@
 -        free(queue);
 -    }
 +	if (queue) {
-+		k_free(queue->handle);
-+		k_free(queue);
++		esp_wifi_free(queue->handle);
++		esp_wifi_free(queue->storage);
++		esp_wifi_free(queue);
 +	}
  }
  
  static void * wifi_create_queue_wrapper(int queue_len, int item_size)
-@@ -187,173 +159,215 @@
+@@ -187,173 +165,273 @@
  
  static void set_isr_wrapper(int32_t n, void *f, void *arg)
  {
@@ -5178,16 +5509,39 @@
 +static void intr_off(unsigned int mask)
  {
 -    SemaphoreHandle_t *sem = (SemaphoreHandle_t*)(data);
-+	irq_disable(__builtin_ctz(mask));
-+}
- 
+-
 -    if (sem) {
 -        vSemaphoreDelete(sem);
 -    }
++	irq_disable(__builtin_ctz(mask));
+ }
+ 
+-static void * wifi_thread_semphr_get_wrapper(void)
 +static void *wifi_thread_semphr_get_wrapper(void)
-+{
+ {
+-    static bool s_wifi_thread_sem_key_init = false;
+-    static pthread_key_t s_wifi_thread_sem_key;
+-    SemaphoreHandle_t sem = NULL;
+-
+-    if (s_wifi_thread_sem_key_init == false) {
+-        if (0 != pthread_key_create(&s_wifi_thread_sem_key, wifi_thread_semphr_free)) {
+-            return NULL;
+-        }
+-        s_wifi_thread_sem_key_init = true;
+-    }
+-
+-    sem = pthread_getspecific(s_wifi_thread_sem_key);
+-    if (!sem) {
+-        sem = xSemaphoreCreateCounting(1, 0);
+-        if (sem) {
+-            pthread_setspecific(s_wifi_thread_sem_key, sem);
+-            ESP_LOGV(TAG, "thread sem create: sem=%p", sem);
+-        }
+-    }
 +	struct k_sem *sem = NULL;
-+
+ 
+-    ESP_LOGV(TAG, "thread sem get: sem=%p", sem);
+-    return (void*)sem;
 +	sem = k_thread_custom_data_get();
 +	if (!sem) {
 +		sem = (struct k_sem *)wifi_malloc(sizeof(struct k_sem));
@@ -5202,49 +5556,27 @@
 +	return (void *)sem;
  }
  
--static void * wifi_thread_semphr_get_wrapper(void)
+-static void * recursive_mutex_create_wrapper(void)
 +static void *recursive_mutex_create_wrapper(void)
  {
--    static bool s_wifi_thread_sem_key_init = false;
--    static pthread_key_t s_wifi_thread_sem_key;
--    SemaphoreHandle_t sem = NULL;
+-    return (void *)xSemaphoreCreateRecursiveMutex();
 +	struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
- 
--    if (s_wifi_thread_sem_key_init == false) {
--        if (0 != pthread_key_create(&s_wifi_thread_sem_key, wifi_thread_semphr_free)) {
--            return NULL;
--        }
--        s_wifi_thread_sem_key_init = true;
--    }
++
 +	if (my_mutex == NULL) {
 +		LOG_ERR("recursive_mutex_create_wrapper allocation failed");
 +	}
- 
--    sem = pthread_getspecific(s_wifi_thread_sem_key);
--    if (!sem) {
--        sem = xSemaphoreCreateCounting(1, 0);
--        if (sem) {
--            pthread_setspecific(s_wifi_thread_sem_key, sem);
--            ESP_LOGV(TAG, "thread sem create: sem=%p", sem);
--        }
--    }
++
 +	k_mutex_init(my_mutex);
- 
--    ESP_LOGV(TAG, "thread sem get: sem=%p", sem);
--    return (void*)sem;
++
 +	return (void *)my_mutex;
  }
  
--static void * recursive_mutex_create_wrapper(void)
+-static void * mutex_create_wrapper(void)
 +static void *mutex_create_wrapper(void)
  {
--    return (void *)xSemaphoreCreateRecursiveMutex();
--}
-+	struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
- 
--static void * mutex_create_wrapper(void)
--{
 -    return (void *)xSemaphoreCreateMutex();
++	struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
++
 +	if (my_mutex == NULL) {
 +		LOG_ERR("recursive_mutex_create_wrapper allocation failed");
 +	}
@@ -5276,31 +5608,10 @@
 +
 +	k_mutex_unlock(my_mutex);
 +	return 0;
-+}
-+
-+static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
-+{
-+	struct k_queue *queue = (struct k_queue *)wifi_malloc(sizeof(struct k_queue));
-+
-+	if (queue == NULL) {
-+		LOG_ERR("queue malloc failed");
-+		return NULL;
-+	}
-+
-+	k_msgq_init((struct k_msgq *)queue, wifi_msgq_buffer, item_size, queue_len);
-+
-+	return (void *)queue;
-+}
-+
-+static void queue_delete_wrapper(void *handle)
-+{
-+	if (handle != NULL) {
-+		esp_wifi_free(handle);
-+	}
  }
  
 -static void * queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
-+static void task_delete_wrapper(void *handle)
++static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
  {
 -    StaticQueue_t *queue_buffer = heap_caps_malloc_prefer(sizeof(StaticQueue_t) + (queue_len * item_size), 2,
 -                                                          MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM,
@@ -5314,12 +5625,29 @@
 -        free(queue_buffer);
 -        return NULL;
 -    }
--
++	struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
++
++	if (queue == NULL) {
++		LOG_ERR("queue malloc failed");
++		return NULL;
++	}
++
++	queue->buffer = wifi_malloc(queue_len * item_size);
++	if (queue->buffer == NULL) {
++		LOG_ERR("queue buffer malloc failed");
++		esp_wifi_free(queue);
++		return NULL;
++	}
+ 
 -    return (void *)queue_handle;
--}
--
++	k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
++
++	return (void *)queue;
+ }
+ 
 -static void queue_delete_wrapper(void *queue)
--{
++static void queue_delete_wrapper(void *handle)
+ {
 -    if (queue) {
 -        StaticQueue_t *queue_buffer = NULL;
 -        xQueueGetStaticBuffers(queue, NULL, &queue_buffer);
@@ -5328,6 +5656,16 @@
 -            free(queue_buffer);
 -        }
 -    }
++	if (handle != NULL) {
++		struct wifi_adapter_msgq *queue = handle;
++
++		esp_wifi_free(queue->buffer);
++		esp_wifi_free(queue);
++	}
++}
++
++static void task_delete_wrapper(void *handle)
++{
 +	if (handle == NULL) {
 +		return;
 +	}
@@ -5341,69 +5679,114 @@
 +	esp_wifi_free(t);
  }
  
- static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
--    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
+     if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueSend(queue, item, portMAX_DELAY);
--    } else {
++        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
+     } else {
 -        return (int32_t)xQueueSend(queue, item, block_time_tick);
--    }
-+	if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-+		k_msgq_put((struct k_msgq *)queue, item, K_FOREVER);
-+	} else {
-+		k_msgq_put((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
-+	}
-+	return 1;
++        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
+     }
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
++static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
  {
 -    return (int32_t)xQueueSendFromISR(queue, item, hptw);
-+	int *hpt = (int *)hptw;
++    int *hpt = (int *)hptw;
++    int ret;
 +
-+	k_msgq_put((struct k_msgq *)queue, item, K_NO_WAIT);
-+	if (hpt) {
-+		*hpt = 0;
-+	}
-+	return 1;
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
++    if (hpt) {
++        *hpt = 0;
++    }
++    return ret == 0 ? 1 : 0;
  }
  
 -static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
-+int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_BACK);
-+	return 0;
++    return queue_send_wrapper(handle, item, block_time_tick);
  }
  
 -static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
-+int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
 -    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_FRONT);
-+	return 0;
++    ARG_UNUSED(block_time_tick);
++
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
++    ret = k_msgq_put_front(&queue->msgq, item);
++
++    return ret == 0 ? 1 : 0;
  }
  
- static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
+-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
++static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
  {
--    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
++    int ret;
++
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
++    }
++
++    struct wifi_adapter_msgq *queue = handle;
+     if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (int32_t)xQueueReceive(queue, item, portMAX_DELAY);
--    } else {
++        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
+     } else {
 -        return (int32_t)xQueueReceive(queue, item, block_time_tick);
--    }
-+	if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-+		k_msgq_get((struct k_msgq *)queue, item, K_FOREVER);
-+	} else {
-+		k_msgq_get((struct k_msgq *)queue, item, K_TICKS(block_time_tick));
-+	}
-+	return 1;
++        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
+     }
++
++    return ret == 0 ? 1 : 0;
  }
  
- static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
+-static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++static uint32_t queue_msg_waiting_wrapper(void *handle)
  {
 -    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
 -        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, portMAX_DELAY);
 -    } else {
 -        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, block_time_tick);
--    }
++    if (!handle) {
++        LOG_ERR("Received NULL queue handle");
++        return 0;
+     }
++
++    struct wifi_adapter_msgq *queue = handle;
++    return k_msgq_num_used_get(&queue->msgq);
++}
++
++static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
++{
 +	return 0;
  }
  
@@ -5467,7 +5850,7 @@
  }
  
  static void IRAM_ATTR wifi_apb80m_request_wrapper(void)
-@@ -409,25 +423,129 @@
+@@ -409,25 +487,124 @@
      return os_get_time(t);
  }
  
@@ -5479,24 +5862,13 @@
 +}
 +
 +static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
- {
--    return heap_caps_realloc(ptr, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
++{
 +	return k_calloc(n, size);
- }
- 
--static void * IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
++}
++
 +static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
- {
--    return heap_caps_calloc(n, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
++{
 +	return k_calloc(1, size);
- }
- 
--static void * IRAM_ATTR zalloc_internal_wrapper(size_t size)
-+uint32_t uxQueueMessagesWaiting(void *queue)
- {
--    void *ptr = heap_caps_calloc(1, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
--    return ptr;
-+	return 0;
 +}
 +
 +void *xEventGroupCreate(void)
@@ -5552,17 +5924,23 @@
 +}
 +
 +int32_t nvs_get_u8(uint32_t handle, const char *key, uint8_t *out_value)
-+{
+ {
+-    return heap_caps_realloc(ptr, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
 +	return 0;
-+}
-+
+ }
+ 
+-static void * IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 +int32_t nvs_set_u16(uint32_t handle, const char *key, uint16_t value)
-+{
+ {
+-    return heap_caps_calloc(n, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
 +	return 0;
-+}
-+
+ }
+ 
+-static void * IRAM_ATTR zalloc_internal_wrapper(size_t size)
 +int32_t nvs_get_u16(uint32_t handle, const char *key, uint16_t *out_value)
-+{
+ {
+-    void *ptr = heap_caps_calloc(1, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+-    return ptr;
 +	return 0;
 +}
 +
@@ -5605,7 +5983,7 @@
      return coex_init();
  #else
      return 0;
-@@ -436,14 +554,14 @@
+@@ -436,14 +613,14 @@
  
  static void coex_deinit_wrapper(void)
  {
@@ -5622,7 +6000,7 @@
      return coex_enable();
  #else
      return 0;
-@@ -452,23 +570,30 @@
+@@ -452,23 +629,30 @@
  
  static void coex_disable_wrapper(void)
  {
@@ -5656,7 +6034,7 @@
      return coex_wifi_request(event, latency, duration);
  #else
      return 0;
-@@ -477,7 +602,7 @@
+@@ -477,7 +661,7 @@
  
  static IRAM_ATTR int coex_wifi_release_wrapper(uint32_t event)
  {
@@ -5665,7 +6043,7 @@
      return coex_wifi_release(event);
  #else
      return 0;
-@@ -486,7 +611,7 @@
+@@ -486,7 +670,7 @@
  
  static int coex_wifi_channel_set_wrapper(uint8_t primary, uint8_t secondary)
  {
@@ -5674,7 +6052,7 @@
      return coex_wifi_channel_set(primary, secondary);
  #else
      return 0;
-@@ -495,7 +620,7 @@
+@@ -495,7 +679,7 @@
  
  static IRAM_ATTR int coex_event_duration_get_wrapper(uint32_t event, uint32_t *duration)
  {
@@ -5683,7 +6061,7 @@
      return coex_event_duration_get(event, duration);
  #else
      return 0;
-@@ -504,7 +629,7 @@
+@@ -504,7 +688,7 @@
  
  static int coex_pti_get_wrapper(uint32_t event, uint8_t *pti)
  {
@@ -5692,7 +6070,7 @@
      return coex_pti_get(event, pti);
  #else
      return 0;
-@@ -513,21 +638,21 @@
+@@ -513,21 +697,21 @@
  
  static void coex_schm_status_bit_clear_wrapper(uint32_t type, uint32_t status)
  {
@@ -5717,7 +6095,7 @@
      return coex_schm_interval_set(interval);
  #else
      return 0;
-@@ -536,7 +661,7 @@
+@@ -536,7 +720,7 @@
  
  static uint32_t coex_schm_interval_get_wrapper(void)
  {
@@ -5726,7 +6104,7 @@
      return coex_schm_interval_get();
  #else
      return 0;
-@@ -545,7 +670,7 @@
+@@ -545,7 +729,7 @@
  
  static uint8_t coex_schm_curr_period_get_wrapper(void)
  {
@@ -5735,7 +6113,7 @@
      return coex_schm_curr_period_get();
  #else
      return 0;
-@@ -554,7 +679,7 @@
+@@ -554,7 +738,7 @@
  
  static void * coex_schm_curr_phase_get_wrapper(void)
  {
@@ -5744,7 +6122,7 @@
      return coex_schm_curr_phase_get();
  #else
      return NULL;
-@@ -563,7 +688,7 @@
+@@ -563,7 +747,7 @@
  
  static int coex_register_start_cb_wrapper(int (* cb)(void))
  {
@@ -5753,7 +6131,7 @@
      return coex_register_start_cb(cb);
  #else
      return 0;
-@@ -572,7 +697,7 @@
+@@ -572,7 +756,7 @@
  
  static int coex_schm_process_restart_wrapper(void)
  {
@@ -5762,7 +6140,7 @@
      return coex_schm_process_restart();
  #else
      return 0;
-@@ -581,7 +706,7 @@
+@@ -581,7 +765,7 @@
  
  static int coex_schm_register_cb_wrapper(int type, int(*cb)(int))
  {
@@ -5771,7 +6149,7 @@
      return coex_schm_register_callback(type, cb);
  #else
      return 0;
-@@ -608,7 +733,7 @@
+@@ -608,7 +792,7 @@
  
  static void * coex_schm_get_phase_by_idx_wrapper(int phase_idx)
  {
@@ -5780,7 +6158,7 @@
      return coex_schm_get_phase_by_idx(phase_idx);
  #else
      return NULL;
-@@ -622,134 +747,152 @@
+@@ -622,134 +806,152 @@
  
  static void esp_phy_enable_wrapper(void)
  {
@@ -5965,7 +6343,7 @@
 +	._queue_send_to_back = queue_send_to_back_wrapper,
 +	._queue_send_to_front = queue_send_to_front_wrapper,
 +	._queue_recv = queue_recv_wrapper,
-+	._queue_msg_waiting = uxQueueMessagesWaiting,
++	._queue_msg_waiting = queue_msg_waiting_wrapper,
 +	._event_group_create = (void *(*)(void))xEventGroupCreate,
 +	._event_group_delete = (void (*)(void *))vEventGroupDelete,
 +	._event_group_set_bits = xEventGroupSetBits,

--- a/tools/sync/patches/mbedtls.patch
+++ b/tools/sync/patches/mbedtls.patch
@@ -88,6 +88,24 @@
  
 --- a/components/mbedtls/port/include/mbedtls/esp_config.h
 +++ b/components/mbedtls/port/include/mbedtls/esp_config.h
+@@ -190,7 +190,7 @@
+ #ifdef CONFIG_MBEDTLS_HARDWARE_SHA
+     #define ESP_SHA_DRIVER_ENABLED
+     #define MBEDTLS_PSA_ACCEL_ALG_HMAC
+-    #define MBEDTLS_PSA_BUILTIN_ALG_HMAC
++    #define MBEDTLS_PSA_BUILTIN_ALG_HMAC 1
+     #if SOC_SHA_SUPPORT_SHA1
+         #define MBEDTLS_PSA_ACCEL_ALG_SHA_1
+         #undef MBEDTLS_PSA_BUILTIN_ALG_SHA_1
+@@ -233,7 +233,7 @@
+ #else
+ #if !defined(MBEDTLS_PSA_BUILTIN_ALG_HMAC)
+     /* If ROM MD5 is not enabled, use the builtin HMAC algorithm for HMAC(MD5) operations */
+-    #define MBEDTLS_PSA_BUILTIN_ALG_HMAC
++    #define MBEDTLS_PSA_BUILTIN_ALG_HMAC 1
+ #endif
+ #endif /* MBEDTLS_PSA_BUILTIN_ALG_HMAC */
+ 
 @@ -606,6 +606,7 @@
   *
   * Comment this macro to disable FIXED POINT curves optimisation.
@@ -139,6 +157,63 @@
   * \def MBEDTLS_RIPEMD160_C
   *
   * Enable the RIPEMD-160 hash algorithm.
+@@ -2587,7 +2604,7 @@
+  *            on it, and considering stronger message digests instead.
+  *
+  */
+-#if CONFIG_MBEDTLS_SHA1_C
++#if defined(CONFIG_MBEDTLS_SHA1_C) || defined(CONFIG_PSA_WANT_ALG_SHA_1)
+ #define PSA_WANT_ALG_SHA_1 1
+ #else
+ #undef PSA_WANT_ALG_SHA_1
+@@ -2626,7 +2643,7 @@
+  *
+  * This module adds support for SHA-384 and SHA-512.
+  */
+-#ifdef CONFIG_MBEDTLS_SHA512_C
++#if defined(CONFIG_MBEDTLS_SHA512_C) || defined(CONFIG_PSA_WANT_ALG_SHA_512)
+ #define PSA_WANT_ALG_SHA_512 1
+ #else
+ #undef PSA_WANT_ALG_SHA_512
+@@ -2647,7 +2664,7 @@
+  *
+  * Comment to disable SHA-384
+  */
+-#ifdef CONFIG_MBEDTLS_SHA384_C
++#if defined(CONFIG_MBEDTLS_SHA384_C) || defined(CONFIG_PSA_WANT_ALG_SHA_384)
+ #define PSA_WANT_ALG_SHA_384 1
+ #else
+ #undef PSA_WANT_ALG_SHA_384
+@@ -2671,11 +2688,19 @@
+  */
+ #ifdef CONFIG_MBEDTLS_SHA256_C
+ #define MBEDTLS_SHA256_C
++#endif
++
++#if defined(CONFIG_MBEDTLS_SHA256_C) || defined(CONFIG_PSA_WANT_ALG_SHA_256)
+ #define PSA_WANT_ALG_SHA_256 1
+-#define PSA_WANT_ALG_SHA_224 1
+ #else
+ #undef PSA_WANT_ALG_SHA_256
+ #undef MBEDTLS_PSA_ACCEL_ALG_SHA_256
++#endif
++
++#if defined(CONFIG_MBEDTLS_SHA224_C) || defined(CONFIG_MBEDTLS_SHA256_C) || \
++    defined(CONFIG_PSA_WANT_ALG_SHA_224)
++#define PSA_WANT_ALG_SHA_224 1
++#else
+ #undef PSA_WANT_ALG_SHA_224
+ #undef MBEDTLS_PSA_ACCEL_ALG_SHA_224
+ #endif
+@@ -2720,7 +2745,7 @@
+ #define PSA_WANT_ALG_SHA3_512 1
+ #if !defined(MBEDTLS_PSA_BUILTIN_ALG_HMAC)
+     /* If SHA3 is enabled, use the builtin HMAC algorithm for HMAC(SHA3) operations */
+-    #define MBEDTLS_PSA_BUILTIN_ALG_HMAC
++    #define MBEDTLS_PSA_BUILTIN_ALG_HMAC 1
+ #endif /* MBEDTLS_PSA_BUILTIN_ALG_HMAC */
+ #else
+ #undef PSA_WANT_ALG_SHA3_224
 --- a/components/mbedtls/port/mbedtls_rom/mbedtls_rom_osi.c
 +++ b/components/mbedtls/port/mbedtls_rom/mbedtls_rom_osi.c
 @@ -444,7 +444,7 @@

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -150,6 +150,13 @@ if(CONFIG_SOC_SERIES_ESP32)
       ../../components/wpa_supplicant/src/eap_peer
       ../../components/wpa_supplicant/src/utils
     )
+    zephyr_include_directories_ifdef(
+      CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT
+      ${ZEPHYR_MBEDTLS_MODULE_DIR}/library
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/core
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/src
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/extras
+    )
   endif()
 
   zephyr_link_libraries(
@@ -486,7 +493,6 @@ if(CONFIG_SOC_SERIES_ESP32)
       )
 
     set(WPA_SUPPLICANT_COMPONENT_DIR "../../components/wpa_supplicant")
-    #TODO: Additional WPA supplicant feature like Enterprise mode etc. are yet to be supported.
     set(WPA_SUPPLICANT_SRCS "${WPA_SUPPLICANT_COMPONENT_DIR}/port/os_xtensa.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/port/eloop.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/ap_config.c"
@@ -571,23 +577,29 @@ if(CONFIG_SOC_SERIES_ESP32)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")
     endif()
 
-    set(TLS_SRCS
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
-      )
+    if(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT)
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/tls_mbedtls.c"
+        )
+    else()
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
+        )
+    endif()
 
     if(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO)
       set(CRYPTO_SRCS
@@ -595,6 +607,7 @@ if(CONFIG_SOC_SERIES_ESP32)
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-ec.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/fastpbkdf2.c"
          # Add internal RC4 as RC4 has been removed from mbedtls
          "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/rc4.c"
         )
@@ -683,6 +696,20 @@ if(CONFIG_SOC_SERIES_ESP32)
     zephyr_compile_definitions(CONFIG_ESP_WIFI_ENABLED)
     zephyr_compile_definitions(CONFIG_SOC_WIFI_SUPPORTED)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO CONFIG_CRYPTO_MBEDTLS)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_ENABLED)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK)
+    zephyr_compile_definitions_ifndef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_TLS_INTERNAL_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_GCMP)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_ESP_WIFI_GCMP_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_GMAC)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_ESP_WIFI_GMAC_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B CONFIG_SUITEB)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B_192 CONFIG_SUITEB192)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_BSS_MAX_IDLE_SUPPORT CONFIG_ESP_WIFI_BSS_MAX_IDLE_SUPPORT)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE CONFIG_WPA3_SAE)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_OWE_STA CONFIG_OWE_STA)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_SAE_H2E CONFIG_SAE_H2E)

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -132,6 +132,13 @@ if(CONFIG_SOC_SERIES_ESP32C2)
       ../../components/wpa_supplicant/src/eap_peer
       ../../components/wpa_supplicant/src/utils
     )
+    zephyr_include_directories_ifdef(
+      CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT
+      ${ZEPHYR_MBEDTLS_MODULE_DIR}/library
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/core
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/src
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/extras
+    )
   endif()
 
   zephyr_link_libraries_ifdef(CONFIG_SOC_ESP32C2_REV_2_0
@@ -450,7 +457,6 @@ if(CONFIG_SOC_SERIES_ESP32C2)
       )
 
     set(WPA_SUPPLICANT_COMPONENT_DIR "../../components/wpa_supplicant")
-    #TODO: Additional WPA supplicant feature like Enterprise mode etc. are yet to be supported.
     set(WPA_SUPPLICANT_SRCS "${WPA_SUPPLICANT_COMPONENT_DIR}/port/os_xtensa.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/port/eloop.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/ap_config.c"
@@ -535,23 +541,29 @@ if(CONFIG_SOC_SERIES_ESP32C2)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")
     endif()
 
-    set(TLS_SRCS
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
-      )
+    if(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT)
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/tls_mbedtls.c"
+        )
+    else()
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
+        )
+    endif()
 
     if(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO)
       set(CRYPTO_SRCS
@@ -559,6 +571,7 @@ if(CONFIG_SOC_SERIES_ESP32C2)
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-ec.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/fastpbkdf2.c"
          # Add internal RC4 as RC4 has been removed from mbedtls
          "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/rc4.c"
         )
@@ -651,6 +664,20 @@ if(CONFIG_SOC_SERIES_ESP32C2)
     zephyr_compile_definitions(CONFIG_ESP_WIFI_ENABLED)
     zephyr_compile_definitions(CONFIG_SOC_WIFI_SUPPORTED)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO CONFIG_CRYPTO_MBEDTLS)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_ENABLED)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK)
+    zephyr_compile_definitions_ifndef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_TLS_INTERNAL_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_GCMP)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_ESP_WIFI_GCMP_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_GMAC)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_ESP_WIFI_GMAC_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B CONFIG_SUITEB)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B_192 CONFIG_SUITEB192)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_BSS_MAX_IDLE_SUPPORT CONFIG_ESP_WIFI_BSS_MAX_IDLE_SUPPORT)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE CONFIG_WPA3_SAE)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_OWE_STA CONFIG_OWE_STA)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_SAE_H2E CONFIG_SAE_H2E)

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -138,6 +138,13 @@ if(CONFIG_SOC_SERIES_ESP32C3)
       ../../components/wpa_supplicant/src/eap_peer
       ../../components/wpa_supplicant/src/utils
     )
+    zephyr_include_directories_ifdef(
+      CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT
+      ${ZEPHYR_MBEDTLS_MODULE_DIR}/library
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/core
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/src
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/extras
+    )
   endif()
 
   zephyr_link_libraries_ifdef(CONFIG_SOC_ESP32C3_REV_1_1
@@ -476,7 +483,6 @@ if(CONFIG_SOC_SERIES_ESP32C3)
       )
 
     set(WPA_SUPPLICANT_COMPONENT_DIR "../../components/wpa_supplicant")
-    #TODO: Additional WPA supplicant feature like Enterprise mode etc. are yet to be supported.
     set(WPA_SUPPLICANT_SRCS "${WPA_SUPPLICANT_COMPONENT_DIR}/port/os_xtensa.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/port/eloop.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/ap_config.c"
@@ -561,23 +567,29 @@ if(CONFIG_SOC_SERIES_ESP32C3)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")
     endif()
 
-    set(TLS_SRCS
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
-      )
+    if(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT)
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/tls_mbedtls.c"
+        )
+    else()
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
+        )
+    endif()
 
     if(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO)
       set(CRYPTO_SRCS
@@ -585,6 +597,7 @@ if(CONFIG_SOC_SERIES_ESP32C3)
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-ec.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/fastpbkdf2.c"
          # Add internal RC4 as RC4 has been removed from mbedtls
          "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/rc4.c"
         )
@@ -672,6 +685,20 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     zephyr_compile_definitions(CONFIG_ESP_WIFI_ENABLED)
     zephyr_compile_definitions(CONFIG_SOC_WIFI_SUPPORTED)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO CONFIG_CRYPTO_MBEDTLS)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_ENABLED)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK)
+    zephyr_compile_definitions_ifndef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_TLS_INTERNAL_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_GCMP)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_ESP_WIFI_GCMP_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_GMAC)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_ESP_WIFI_GMAC_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B CONFIG_SUITEB)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B_192 CONFIG_SUITEB192)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_BSS_MAX_IDLE_SUPPORT CONFIG_ESP_WIFI_BSS_MAX_IDLE_SUPPORT)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE CONFIG_WPA3_SAE)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_OWE_STA CONFIG_OWE_STA)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_SAE_H2E CONFIG_SAE_H2E)

--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -164,6 +164,13 @@ if(CONFIG_SOC_SERIES_ESP32C5)
       ../../components/wpa_supplicant/src/eap_peer
       ../../components/wpa_supplicant/src/utils
     )
+    zephyr_include_directories_ifdef(
+      CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT
+      ${ZEPHYR_MBEDTLS_MODULE_DIR}/library
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/core
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/src
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/extras
+    )
   endif()
 
   zephyr_link_libraries(
@@ -606,7 +613,6 @@ if(CONFIG_SOC_SERIES_ESP32C5)
   if (CONFIG_WIFI_ESP32)
 
     set(WPA_SUPPLICANT_COMPONENT_DIR "../../components/wpa_supplicant")
-    #TODO: Additional WPA supplicant feature like Enterprise mode etc. are yet to be supported.
     set(WPA_SUPPLICANT_SRCS "${WPA_SUPPLICANT_COMPONENT_DIR}/port/os_xtensa.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/port/eloop.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/ap_config.c"
@@ -691,23 +697,29 @@ if(CONFIG_SOC_SERIES_ESP32C5)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")
     endif()
 
-    set(TLS_SRCS
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
-      )
+    if(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT)
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/tls_mbedtls.c"
+        )
+    else()
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
+        )
+    endif()
 
     if(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO)
       set(CRYPTO_SRCS
@@ -715,6 +727,7 @@ if(CONFIG_SOC_SERIES_ESP32C5)
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-ec.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/fastpbkdf2.c"
          # Add internal RC4 as RC4 has been removed from mbedtls
          "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/rc4.c"
         )
@@ -802,6 +815,20 @@ if(CONFIG_SOC_SERIES_ESP32C5)
     zephyr_compile_definitions(CONFIG_ESP_WIFI_ENABLED)
     zephyr_compile_definitions(CONFIG_SOC_WIFI_SUPPORTED)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO CONFIG_CRYPTO_MBEDTLS)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_ENABLED)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK)
+    zephyr_compile_definitions_ifndef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_TLS_INTERNAL_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_GCMP)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_ESP_WIFI_GCMP_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_GMAC)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_ESP_WIFI_GMAC_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B CONFIG_SUITEB)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B_192 CONFIG_SUITEB192)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_BSS_MAX_IDLE_SUPPORT CONFIG_ESP_WIFI_BSS_MAX_IDLE_SUPPORT)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE CONFIG_WPA3_SAE)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_OWE_STA CONFIG_OWE_STA)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_SAE_H2E CONFIG_SAE_H2E)

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -159,6 +159,13 @@ if(CONFIG_SOC_SERIES_ESP32C6)
       ../../components/wpa_supplicant/src/eap_peer
       ../../components/wpa_supplicant/src/utils
     )
+    zephyr_include_directories_ifdef(
+      CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT
+      ${ZEPHYR_MBEDTLS_MODULE_DIR}/library
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/core
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/src
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/extras
+    )
   endif()
 
   zephyr_link_libraries(
@@ -578,7 +585,6 @@ if(CONFIG_SOC_SERIES_ESP32C6)
   if (CONFIG_WIFI_ESP32)
 
     set(WPA_SUPPLICANT_COMPONENT_DIR "../../components/wpa_supplicant")
-    #TODO: Additional WPA supplicant feature like Enterprise mode etc. are yet to be supported.
     set(WPA_SUPPLICANT_SRCS "${WPA_SUPPLICANT_COMPONENT_DIR}/port/os_xtensa.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/port/eloop.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/ap_config.c"
@@ -663,23 +669,29 @@ if(CONFIG_SOC_SERIES_ESP32C6)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")
     endif()
 
-    set(TLS_SRCS
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
-      )
+    if(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT)
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/tls_mbedtls.c"
+        )
+    else()
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
+        )
+    endif()
 
     if(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO)
       set(CRYPTO_SRCS
@@ -687,6 +699,7 @@ if(CONFIG_SOC_SERIES_ESP32C6)
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-ec.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/fastpbkdf2.c"
          # Add internal RC4 as RC4 has been removed from mbedtls
          "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/rc4.c"
         )
@@ -780,6 +793,20 @@ if(CONFIG_SOC_SERIES_ESP32C6)
     zephyr_compile_definitions(CONFIG_ESP_WIFI_ENABLED)
     zephyr_compile_definitions(CONFIG_SOC_WIFI_SUPPORTED)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO CONFIG_CRYPTO_MBEDTLS)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_ENABLED)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK)
+    zephyr_compile_definitions_ifndef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_TLS_INTERNAL_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_GCMP)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_ESP_WIFI_GCMP_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_GMAC)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_ESP_WIFI_GMAC_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B CONFIG_SUITEB)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B_192 CONFIG_SUITEB192)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_BSS_MAX_IDLE_SUPPORT CONFIG_ESP_WIFI_BSS_MAX_IDLE_SUPPORT)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE CONFIG_WPA3_SAE)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_OWE_STA CONFIG_OWE_STA)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_SAE_H2E CONFIG_SAE_H2E)

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -141,6 +141,13 @@ if(CONFIG_SOC_SERIES_ESP32S2)
       ../../components/wpa_supplicant/src/eap_peer
       ../../components/wpa_supplicant/src/utils
     )
+    zephyr_include_directories_ifdef(
+      CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT
+      ${ZEPHYR_MBEDTLS_MODULE_DIR}/library
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/core
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/src
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/extras
+    )
   endif()
 
   zephyr_link_libraries(
@@ -434,7 +441,6 @@ if(CONFIG_SOC_SERIES_ESP32S2)
       )
 
     set(WPA_SUPPLICANT_COMPONENT_DIR "../../components/wpa_supplicant")
-    #TODO: Additional WPA supplicant feature like Enterprise mode etc. are yet to be supported.
     set(WPA_SUPPLICANT_SRCS "${WPA_SUPPLICANT_COMPONENT_DIR}/port/os_xtensa.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/port/eloop.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/ap_config.c"
@@ -519,22 +525,29 @@ if(CONFIG_SOC_SERIES_ESP32S2)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")
     endif()
 
-    set(TLS_SRCS
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c")
+    if(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT)
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/tls_mbedtls.c"
+        )
+    else()
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
+        )
+    endif()
 
       if(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO)
       set(CRYPTO_SRCS
@@ -542,6 +555,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-ec.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/fastpbkdf2.c"
          # Add internal RC4 as RC4 has been removed from mbedtls
          "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/rc4.c"
         )
@@ -625,6 +639,20 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     zephyr_compile_definitions(CONFIG_ESP_WIFI_ENABLED)
     zephyr_compile_definitions(CONFIG_SOC_WIFI_SUPPORTED)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO CONFIG_CRYPTO_MBEDTLS)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_ENABLED)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK)
+    zephyr_compile_definitions_ifndef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_TLS_INTERNAL_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_GCMP)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_ESP_WIFI_GCMP_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_GMAC)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_ESP_WIFI_GMAC_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B CONFIG_SUITEB)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B_192 CONFIG_SUITEB192)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_BSS_MAX_IDLE_SUPPORT CONFIG_ESP_WIFI_BSS_MAX_IDLE_SUPPORT)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE CONFIG_WPA3_SAE)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_OWE_STA CONFIG_OWE_STA)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_SAE_H2E CONFIG_SAE_H2E)

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -158,6 +158,13 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       ../../components/wpa_supplicant/src/eap_peer
       ../../components/wpa_supplicant/src/utils
     )
+    zephyr_include_directories_ifdef(
+      CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT
+      ${ZEPHYR_MBEDTLS_MODULE_DIR}/library
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/core
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/src
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/extras
+    )
   endif()
 
   zephyr_link_libraries(
@@ -540,7 +547,6 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       )
 
     set(WPA_SUPPLICANT_COMPONENT_DIR "../../components/wpa_supplicant")
-    #TODO: Additional WPA supplicant feature like Enterprise mode etc. are yet to be supported.
     set(WPA_SUPPLICANT_SRCS "${WPA_SUPPLICANT_COMPONENT_DIR}/port/os_xtensa.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/port/eloop.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/ap_config.c"
@@ -626,23 +632,29 @@ if(CONFIG_SOC_SERIES_ESP32S3)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")
     endif()
 
-    set(TLS_SRCS
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
-      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
-      )
+    if(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT)
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/tls_mbedtls.c"
+        )
+    else()
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
+        )
+    endif()
 
     if(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO)
       set(CRYPTO_SRCS
@@ -650,6 +662,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-ec.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/fastpbkdf2.c"
          # Add internal RC4 as RC4 has been removed from mbedtls
          "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/rc4.c"
         )
@@ -738,6 +751,20 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     zephyr_compile_definitions(CONFIG_ESP_WIFI_ENABLED)
     zephyr_compile_definitions(CONFIG_SOC_WIFI_SUPPORTED)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO CONFIG_CRYPTO_MBEDTLS)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_ENABLED)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK)
+    zephyr_compile_definitions_ifndef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_TLS_INTERNAL_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_GCMP)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_ESP_WIFI_GCMP_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_GMAC)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_ESP_WIFI_GMAC_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B CONFIG_SUITEB)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B_192 CONFIG_SUITEB192)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_BSS_MAX_IDLE_SUPPORT CONFIG_ESP_WIFI_BSS_MAX_IDLE_SUPPORT)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE CONFIG_WPA3_SAE)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_OWE_STA CONFIG_OWE_STA)
     zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_SAE_H2E CONFIG_SAE_H2E)


### PR DESCRIPTION
This is a copy of https://github.com/zephyrproject-rtos/hal_espressif/pull/550

## Summary

Enable the ESP32 Zephyr HAL build to include the Espressif WPA Enterprise supplicant path.

This is the hal_espressif half of adding WPA2/WPA3-Enterprise station support for ESP32 SoCs in Zephyr. The [companion Zephyr PR](https://github.com/zephyrproject-rtos/zephyr/pull/108362) wires this support into the ESP32 Wi-Fi driver and Wi-Fi shell APIs.

## Changes

- Build the Espressif Enterprise supplicant TLS/crypto sources for ESP32 SoCs when enabled by Zephyr Kconfig.
- Add the compile definitions needed by the Espressif supplicant for:
  - WPA Enterprise support
  - Mbed TLS TLS client backend
  - GCMP/GMAC support
  - Suite-B / Suite-B 192 support
  - BSS max idle support
- Fix Wi-Fi adapter queue allocation/deallocation so each queue owns its backing buffer.
- Define `MBEDTLS_PSA_BUILTIN_ALG_HMAC` consistently as `1` to avoid redefinition warnings with TF-PSA headers.

## Compatibility

This PR is intended to be non-breaking when merged before the Zephyr-side PR.

The Enterprise supplicant sources are only included when Zephyr enables the corresponding `CONFIG_ESP32_WIFI_ENTERPRISE...` symbols.

## Companion Zephyr PR

A companion Zephyr PR will:
- Add the ESP32 Wi-Fi driver Enterprise connection support.
- Add the ESP32 Enterprise Kconfig options.
- Generalize Wi-Fi Enterprise credential handling so non-hostapd drivers can use it.
- Improve Wi-Fi shell Enterprise credential loading.
- Update Zephyr’s hal_espressif module revision after this PR is merged.

## Testing

Tested with ESP32-C6 DevKitC using Zephyr and a local FreeRADIUS/hostapd WPA Enterprise network. The application used for testing was the upstream Zephyr Wi-Fi shell sample for ESP32-C6. Detailed testing instructions will be added to the [Zephyr PR](https://github.com/zephyrproject-rtos/zephyr/pull/108362).

Verified:
- WPA2-Enterprise TTLS-MSCHAPv2
- WPA2-Enterprise PEAP-MSCHAPv2
- WPA2-Enterprise EAP-TLS
- Wi-Fi shell runtime certificate installation
- Connect/disconnect flow