### PR TITLE
esp32s3: simple boot: use bootloader CPU freq for PLL switch

### DIFF
--- a/zephyr/esp32s3/src/soc_init.c
+++ b/zephyr/esp32s3/src/soc_init.c
@@ -160,7 +160,7 @@ void bootloader_clock_configure(void)
 	 */
 	rtc_cpu_freq_config_t pll_cfg;
 
-	if (rtc_clk_cpu_freq_mhz_to_config(CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ, &pll_cfg)) {
+	if (rtc_clk_cpu_freq_mhz_to_config(CONFIG_BOOTLOADER_CPU_CLK_FREQ_MHZ, &pll_cfg)) {
 		rtc_clk_cpu_freq_set_config(&pll_cfg);
 	}
 


### PR DESCRIPTION
bootloader_clock_configure() switched the CPU from XTAL to PLL at CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ (240 MHz) which has been the cause of failures on some ESP32-S3 rev 0.2 chips.