### PR TITLE
components: wpa_supplicant: fix enterprise EAP reconnect cleanup

### DIFF
--- a/components/wpa_supplicant/esp_supplicant/src/esp_eap_client.c
+++ b/components/wpa_supplicant/esp_supplicant/src/esp_eap_client.c
@@ -139,9 +139,14 @@ static inline void wpa2_task_delete(void *arg)
 {
     void *my_task_hdl = os_task_get_current_task();
     int ret = ESP_OK;
+    void *task_hdl = s_wpa2_task_hdl;
 
-    if (my_task_hdl == s_wpa2_task_hdl) {
+    if (my_task_hdl == task_hdl) {
         wpa_printf(MSG_ERROR, "EAP: should never call task delete api in eap task context");
+        return;
+    }
+
+    if (task_hdl == NULL) {
         return;
     }
 
@@ -151,6 +156,9 @@ static inline void wpa2_task_delete(void *arg)
         wpa_printf(MSG_ERROR, "EAP: failed to post task delete event, ret=%d", ret);
         return;
     }
+
+    os_task_delete(task_hdl);
+    s_wpa2_task_hdl = NULL;
 }
 
 #define WPA_ADDR_LEN 6
@@ -266,8 +274,7 @@ void wpa2_task(void *pvParameters)
         wpa_printf(MSG_ERROR, "EAP: null wifi->EAP sync sem");
     }
 
-    /* At this point, we completed */
-    os_task_delete(NULL);
+    /* The task creator owns the dynamically allocated Zephyr stack wrapper. */
 }
 
 int wpa2_post(uint32_t sig, uint32_t par)
@@ -1356,5 +1363,6 @@ esp_err_t esp_eap_client_set_eap_methods(esp_eap_method_t methods)
     }
 
     g_eap_method_mask = methods;
+    eloop_register_timeout(0, 0, config_changed_handler, NULL, NULL);
     return ESP_OK;
 }

--- a/components/wpa_supplicant/src/eap_peer/eap.c
+++ b/components/wpa_supplicant/src/eap_peer/eap.c
@@ -609,54 +609,60 @@ int eap_peer_config_init(
 	int allowed_method_count = 0;
 	const struct eap_method *methods;
 
-	if (!config_methods) {
-		methods = eap_peer_get_methods(&mcount);
-		if (methods == NULL) {
-			wpa_printf(MSG_ERROR, "EAP: Set config init: EAP methods not registered.");
-			return -1;
-		}
-
-		// Allocate a buffer large enough to accomodate all the registered methods.
-		config_methods = os_malloc(mcount * sizeof(struct eap_method_type));
-		if (config_methods == NULL) {
-			wpa_printf(MSG_ERROR, "EAP: Set config init: Out of memory, set configured methods failed");
-			return -1;
-		}
-
-		if (g_wpa_username) {
-			//set EAP-PEAP
-			if (g_eap_method_mask & ESP_EAP_TYPE_PEAP) {
-				config_methods[allowed_method_count].vendor = EAP_VENDOR_IETF;
-				config_methods[allowed_method_count++].method = EAP_TYPE_PEAP;
-			}
-			//set EAP-TTLS
-			if (g_eap_method_mask & ESP_EAP_TYPE_TTLS) {
-				config_methods[allowed_method_count].vendor = EAP_VENDOR_IETF;
-				config_methods[allowed_method_count++].method = EAP_TYPE_TTLS;
-			}
-		}
-		if (g_wpa_private_key) {
-			//set EAP-TLS
-			if (g_eap_method_mask & ESP_EAP_TYPE_TLS) {
-				config_methods[allowed_method_count].vendor = EAP_VENDOR_IETF;
-				config_methods[allowed_method_count++].method = EAP_TYPE_TLS;
-			}
-		}
-#ifdef EAP_FAST
-		if (g_wpa_pac_file) {
-			//set EAP-FAST
-			if (g_eap_method_mask & ESP_EAP_TYPE_FAST) {
-				config_methods[allowed_method_count].vendor = EAP_VENDOR_IETF;
-				config_methods[allowed_method_count++].method = EAP_TYPE_FAST;
-			}
-		}
-#endif
-		// Terminate the allowed method list
-		config_methods[allowed_method_count].vendor = EAP_VENDOR_IETF;
-		config_methods[allowed_method_count++].method = EAP_TYPE_NONE;
-		// Set the allowed methods to config
-		sm->config.eap_methods = config_methods;
+	if (config_methods) {
+		os_free(config_methods);
+		config_methods = NULL;
+		sm->config.eap_methods = NULL;
 	}
+
+	methods = eap_peer_get_methods(&mcount);
+	if (methods == NULL) {
+		wpa_printf(MSG_ERROR, "EAP: Set config init: EAP methods not registered.");
+		return -1;
+	}
+
+	// Allocate a buffer large enough to accommodate all the registered methods
+	// plus the EAP_TYPE_NONE terminator.
+	config_methods = os_malloc((mcount + 1) * sizeof(struct eap_method_type));
+	if (config_methods == NULL) {
+		wpa_printf(MSG_ERROR, "EAP: Set config init: Out of memory, set configured methods failed");
+		return -1;
+	}
+
+	if (g_wpa_username) {
+		//set EAP-PEAP
+		if (g_eap_method_mask & ESP_EAP_TYPE_PEAP) {
+			config_methods[allowed_method_count].vendor = EAP_VENDOR_IETF;
+			config_methods[allowed_method_count++].method = EAP_TYPE_PEAP;
+		}
+		//set EAP-TTLS
+		if (g_eap_method_mask & ESP_EAP_TYPE_TTLS) {
+			config_methods[allowed_method_count].vendor = EAP_VENDOR_IETF;
+			config_methods[allowed_method_count++].method = EAP_TYPE_TTLS;
+		}
+	}
+	if (g_wpa_private_key) {
+		//set EAP-TLS
+		if (g_eap_method_mask & ESP_EAP_TYPE_TLS) {
+			config_methods[allowed_method_count].vendor = EAP_VENDOR_IETF;
+			config_methods[allowed_method_count++].method = EAP_TYPE_TLS;
+		}
+	}
+#ifdef EAP_FAST
+	if (g_wpa_pac_file) {
+		//set EAP-FAST
+		if (g_eap_method_mask & ESP_EAP_TYPE_FAST) {
+			config_methods[allowed_method_count].vendor = EAP_VENDOR_IETF;
+			config_methods[allowed_method_count++].method = EAP_TYPE_FAST;
+		}
+	}
+#endif
+	// Terminate the allowed method list
+	config_methods[allowed_method_count].vendor = EAP_VENDOR_IETF;
+	config_methods[allowed_method_count++].method = EAP_TYPE_NONE;
+	// Set the allowed methods to config
+	sm->config.eap_methods = config_methods;
+
 	return 0;
 
 }


### PR DESCRIPTION
Fix two issues seen when reconnecting or reprovisioning enterprise Wi-Fi.

First, the EAP task was deleting itself with os_task_delete(NULL). On Zephyr this does not free the allocated task wrapper/stack, so repeated EAP sessions leaked heap. Post the task delete event, then delete the stored task handle from the caller side and clear it.

Second, rebuild the configured EAP method list when initializing peer config. The previous static list could remain stale across profile changes, e.g. switching between EAP-TLS and TTLS. Also allocate space for the terminating EAP_TYPE_NONE entry.

This keeps repeated enterprise reconnects from losing heap and ensures the allowed EAP methods match the current profile.