### PR TITLE
requirements: esptool: bump to latest release v5.3.0

### DIFF
--- a/zephyr/requirements.txt
+++ b/zephyr/requirements.txt
@@ -1,1 +1,1 @@
-esptool>=5.2.0
+esptool>=5.3.0


### PR DESCRIPTION
Bump to latest release in order to bring ESP32-P4 and ESP32-S31 features and enhancements.