### PR TITLE
hal: wifi: Log fix regression

### DIFF
--- a/components/esp_wifi/esp32c2/esp_adapter.c
+++ b/components/esp_wifi/esp32c2/esp_adapter.c
@@ -31,6 +31,7 @@ LOG_MODULE_REGISTER(esp32c2_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 #include "esp_private/periph_ctrl.h"
 #include "esp_private/esp_clk.h"
 #include "os.h"
+#include "esp_log.h"
 #include "private/esp_coexist_internal.h"
 #include "private/esp_modem_wrapper.h"
 #include "esp_rom_sys.h"

--- a/components/esp_wifi/esp32c3/esp_adapter.c
+++ b/components/esp_wifi/esp32c3/esp_adapter.c
@@ -37,6 +37,7 @@ LOG_MODULE_REGISTER(esp32c3_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 #include "esp_private/periph_ctrl.h"
 #include "esp_private/esp_clk.h"
 #include "os.h"
+#include "esp_log.h"
 #ifdef CONFIG_ESP_COEX_ENABLED
 #include "private/esp_coexist_internal.h"
 #endif

--- a/components/esp_wifi/esp32c5/esp_adapter.c
+++ b/components/esp_wifi/esp32c5/esp_adapter.c
@@ -40,6 +40,7 @@ extern void intr_matrix_route(int intr_src, int intr_num);
 #include "esp_private/periph_ctrl.h"
 #include "esp_private/esp_clk.h"
 #include "os.h"
+#include "esp_log.h"
 #ifdef CONFIG_ESP_COEX_ENABLED
 #include "private/esp_coexist_internal.h"
 #endif

--- a/components/esp_wifi/esp32c6/esp_adapter.c
+++ b/components/esp_wifi/esp32c6/esp_adapter.c
@@ -40,6 +40,7 @@ extern void intr_matrix_route(int intr_src, int intr_num);
 #include "esp_private/periph_ctrl.h"
 #include "esp_private/esp_clk.h"
 #include "os.h"
+#include "esp_log.h"
 #ifdef CONFIG_ESP_COEX_ENABLED
 #include "private/esp_coexist_internal.h"
 #endif

--- a/components/esp_wifi/esp32s2/esp_adapter.c
+++ b/components/esp_wifi/esp32s2/esp_adapter.c
@@ -31,6 +31,7 @@ LOG_MODULE_REGISTER(esp32s2_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 #include "esp_private/periph_ctrl.h"
 #include "esp_private/esp_clk.h"
 #include "os.h"
+#include "esp_log.h"
 #include "private/esp_coexist_internal.h"
 #include "private/esp_modem_wrapper.h"
 #include "esp_rom_sys.h"


### PR DESCRIPTION
Reinstate previously fixed issue with Wi-Fi log.
Restores #537 fix (partially).