### PR TITLE
cmakelists: mode sleep files into PM branch

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -284,6 +284,7 @@ if(CONFIG_SOC_SERIES_ESP32)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+      ../../components/esp_hw_support/sleep_modes.c
       ../../components/esp_hw_support/sleep_gpio.c
       ../../components/esp_hw_support/sleep_event.c
       ../../components/esp_driver_gpio/src/gpio.c
@@ -387,7 +388,6 @@ if(CONFIG_SOC_SERIES_ESP32)
     ../../components/esp_hal_ana_conv/adc_hal_common.c
     ../../components/esp_hw_support/sar_periph_ctrl_common.c
     ../../components/esp_hw_support/rtc_module.c
-    ../../components/esp_hw_support/sleep_modes.c
     ../../components/esp_mm/esp_cache_utils.c
     ../../components/esp_mm/esp_mmu_map.c
     ../../components/esp_mm/port/${CONFIG_SOC_SERIES}/ext_mem_layout.c

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -213,6 +213,7 @@ if(CONFIG_SOC_SERIES_ESP32C2)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+    ../../components/esp_hw_support/sleep_modes.c
     ../../components/esp_hw_support/sleep_gpio.c
     ../../components/esp_hw_support/sleep_event.c
     ../../components/esp_driver_gpio/src/gpio.c
@@ -285,7 +286,6 @@ if(CONFIG_SOC_SERIES_ESP32C2)
     ../../components/esp_hw_support/sar_periph_ctrl_common.c
     ../../components/esp_hw_support/rtc_module.c
     ../../components/esp_hw_support/sar_tsens_ctrl.c
-    ../../components/esp_hw_support/sleep_modes.c
     ../../components/esp_mm/esp_cache_msync.c
     ../../components/esp_mm/esp_cache_utils.c
     ../../components/esp_mm/esp_mmu_map.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -251,6 +251,7 @@ if(CONFIG_SOC_SERIES_ESP32C3)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+      ../../components/esp_hw_support/sleep_modes.c
       ../../components/esp_hw_support/sleep_gpio.c
       ../../components/esp_hw_support/sleep_event.c
       ../../components/esp_hw_support/sleep_console.c
@@ -355,7 +356,6 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     ../../components/esp_hw_support/sar_periph_ctrl_common.c
     ../../components/esp_hw_support/rtc_module.c
     ../../components/esp_hw_support/sar_tsens_ctrl.c
-    ../../components/esp_hw_support/sleep_modes.c
     ../../components/esp_mm/esp_cache_msync.c
     ../../components/esp_mm/esp_cache_utils.c
     ../../components/esp_mm/esp_mmu_map.c

--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -394,8 +394,6 @@ if(CONFIG_SOC_SERIES_ESP32C5)
     ../../components/esp_hw_support/sar_periph_ctrl_common.c
     ../../components/esp_hw_support/rtc_module.c
     ../../components/esp_hw_support/sar_tsens_ctrl.c
-    ../../components/esp_hw_support/sleep_modes.c
-    ../../components/esp_hw_support/sleep_retention.c
     ../../components/esp_mm/esp_cache_msync.c
     ../../components/esp_rom/patches/esp_rom_crc.c
     ../../components/esp_rom/patches/esp_rom_efuse.c

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -372,8 +372,6 @@ if(CONFIG_SOC_SERIES_ESP32C6)
     ../../components/esp_hw_support/sar_periph_ctrl_common.c
     ../../components/esp_hw_support/rtc_module.c
     ../../components/esp_hw_support/sar_tsens_ctrl.c
-    ../../components/esp_hw_support/sleep_modes.c
-    ../../components/esp_hw_support/sleep_retention.c
     ../../components/esp_mm/esp_cache_msync.c
     ../../components/esp_rom/patches/esp_rom_crc.c
     ../../components/esp_rom/patches/esp_rom_efuse.c

--- a/zephyr/esp32h2/CMakeLists.txt
+++ b/zephyr/esp32h2/CMakeLists.txt
@@ -259,8 +259,6 @@ if(CONFIG_SOC_SERIES_ESP32H2)
     ../../components/esp_hw_support/sar_periph_ctrl_common.c
     ../../components/esp_hw_support/rtc_module.c
     ../../components/esp_hw_support/sar_tsens_ctrl.c
-    ../../components/esp_hw_support/sleep_modes.c
-    ../../components/esp_hw_support/sleep_retention.c
     ../../components/esp_mm/esp_cache_msync.c
     ../../components/esp_rom/patches/esp_rom_crc.c
     ../../components/esp_rom/patches/esp_rom_efuse.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -287,6 +287,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+      ../../components/esp_hw_support/sleep_modes.c
       ../../components/esp_hw_support/sleep_gpio.c
       ../../components/esp_hw_support/sleep_event.c
       ../../components/esp_driver_gpio/src/gpio.c
@@ -378,7 +379,6 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     ../../components/esp_hw_support/sar_periph_ctrl_common.c
     ../../components/esp_hw_support/rtc_module.c
     ../../components/esp_hw_support/sar_tsens_ctrl.c
-    ../../components/esp_hw_support/sleep_modes.c
     ../../components/esp_mm/esp_cache_msync.c
     ../../components/esp_mm/esp_cache_utils.c
     ../../components/esp_mm/esp_mmu_map.c

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -345,6 +345,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+      ../../components/esp_hw_support/sleep_modes.c
       ../../components/esp_hw_support/sleep_gpio.c
       ../../components/esp_hw_support/sleep_event.c
       ../../components/esp_hw_support/sleep_console.c
@@ -437,7 +438,6 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     ../../components/esp_hw_support/sar_periph_ctrl_common.c
     ../../components/esp_hw_support/rtc_module.c
     ../../components/esp_hw_support/sar_tsens_ctrl.c
-    ../../components/esp_hw_support/sleep_modes.c
     ../../components/esp_mm/esp_cache_msync.c
     ../../components/esp_mm/esp_cache_utils.c
     ../../components/esp_mm/esp_mmu_map.c


### PR DESCRIPTION
Move PM and POWEROFF dependent files into its branch so it is only build when required.