### PR TITLE
zephyr: pinctrl: generate ethernet rmii pin macros

### DIFF
--- a/zephyr/port/pincfgs/esp32.yml
+++ b/zephyr/port/pincfgs/esp32.yml
@@ -447,6 +447,22 @@ smi:
     sigo: emac_mdo_o
     gpio: [[0, 23], [25, 27], [32, 33]]
 
+rmii:
+  clk:
+    gpio: [0]
+  tx_en:
+    gpio: [21]
+  txd0:
+    gpio: [19]
+  txd1:
+    gpio: [22]
+  crs_dv:
+    gpio: [27]
+  rxd0:
+    gpio: [25]
+  rxd1:
+    gpio: [26]
+
 dac:
   ch1:
     sigo: dac1_out

--- a/zephyr/port/pincfgs/esp32p4.yml
+++ b/zephyr/port/pincfgs/esp32p4.yml
@@ -315,6 +315,22 @@ smi:
     sigo: emac_mdo_o
     gpio: [[0, 54]]
 
+rmii:
+  clk:
+    gpio: [32, 44, 50]
+  tx_en:
+    gpio: [33, 40, 49]
+  txd0:
+    gpio: [34, 41]
+  txd1:
+    gpio: [35, 42]
+  crs_dv:
+    gpio: [28, 45, 51]
+  rxd0:
+    gpio: [29, 46, 52]
+  rxd1:
+    gpio: [30, 47, 53]
+
 sdhc1:
   clkout:
     sigo: sd_card_cclk_2_out

--- a/zephyr/scripts/pinctrl/esp_genpinctrl.py
+++ b/zephyr/scripts/pinctrl/esp_genpinctrl.py
@@ -150,6 +150,25 @@ def get_pinmux(dev_name, pin_name, pin_info, io):
     return pinmux
 
 
+def get_rmii_pinmux(pin_name, io):
+    # The Ethernet RMII data plane is routed through dedicated EMAC
+    # IOMUX pad functions instead of the GPIO matrix, so it uses the
+    # ESP32_RMII_PINMUX() encoding (signal slot + GPIO) rather than
+    # ESP32_PINMUX(). The slot maps to an ESP_RMII_* constant.
+    slot = 'ESP_RMII_' + pin_name.upper()
+
+    pinmux = 'RMII_' + pin_name.upper() + '_GPIO' + str(io)
+    define_str = '#define ' + pinmux
+    macro_str = 'ESP32_RMII_PINMUX(' + str(io) + ', ' + slot + ')'
+
+    if len(define_str + ' ' + macro_str) > 100:
+        pinmux = define_str + ' \\\n\t' + macro_str + '\n'
+    else:
+        pinmux = define_str + ' ' + macro_str + '\n'
+
+    return pinmux
+
+
 def main(pcfg_in):
     zephyr_base = os.getenv('ZEPHYR_BASE')
 
@@ -180,11 +199,20 @@ def main(pcfg_in):
         # diffs minimal and easily trackable
         dev_info = sorted(dev_info.items())
 
+        is_rmii = dev_name.lower() == 'rmii'
+
         for (pin_name, pin_info) in dev_info:
-            f.write('/**\n * @name ' + dev_name.upper() + '_' + pin_name.upper() + '\n * @{\n */\n')
+            if is_rmii:
+                name = 'RMII_' + pin_name.upper()
+            else:
+                name = dev_name.upper() + '_' + pin_name.upper()
+            f.write('/**\n * @name ' + name + '\n * @{\n */\n')
             ios = get_gpios(pin_info)
             for io in ios:
-                pinmux = get_pinmux(dev_name, pin_name, pin_info, io)
+                if is_rmii:
+                    pinmux = get_rmii_pinmux(pin_name, io)
+                else:
+                    pinmux = get_pinmux(dev_name, pin_name, pin_info, io)
                 f.write(pinmux)
             f.write('/** @} */\n\n')
 


### PR DESCRIPTION
Teach esp_genpinctrl.py to emit RMII_<signal>_GPIO<n> macros from a new rmii block, and add that block to esp32 and esp32p4. The macros use ESP32_RMII_PINMUX() since RMII pads use dedicated EMAC IOMUX.