### PR TITLE
zephyr: esp32p4: emit rtl dumps for mcuboot build

### DIFF
--- a/zephyr/esp32p4/CMakeLists.txt
+++ b/zephyr/esp32p4/CMakeLists.txt
@@ -8,6 +8,10 @@ if(CONFIG_SOC_SERIES_ESP32P4)
   zephyr_compile_definitions_ifndef(typeof typeof=__typeof__)
   zephyr_compile_definitions(CONFIG_ESP_REV_MIN_FULL=500)
 
+  if(CONFIG_MCUBOOT)
+    zephyr_compile_options(-fdump-rtl-expand)
+  endif()
+
   zephyr_include_directories(
     include
     ../common/include


### PR DESCRIPTION
Add the -fdump-rtl-expand option under CONFIG_MCUBOOT so the callgraph checker finds the RTL files it needs, matching the other SoC ports.