### PR TITLE
phy: support zephyr radio calibration persistence

### DIFF
--- a/components/esp_phy/src/phy_init.c
+++ b/components/esp_phy/src/phy_init.c
@@ -688,7 +688,7 @@ void esp_phy_release_init_data(const esp_phy_init_data_t* init_data)
 
 
 /* PHY calibration data handling functions */
-#ifdef CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE
+#if defined(CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE) && !defined(__ZEPHYR__)
 static const char* PHY_NAMESPACE = "phy";
 static const char* PHY_CAL_VERSION_KEY = "cal_version";
 static const char* PHY_CAL_MAC_KEY = "cal_mac";

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -168,6 +168,21 @@ config ESP_PHY_ENABLED
 	bool
 	default y if (SOC_PHY_SUPPORTED)
 
+# RF calibration data persistence. The esp_phy code checks
+# CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE to decide whether to load and
+# store calibration data in NVS (partial calibration on warm boots) or run a
+# full calibration on every boot. This symbol is not user-facing; it is
+# derived from the generic RADIO_CAL feature so RADIO_CAL is the single knob.
+config ESP_PHY_CALIBRATION_AND_DATA_STORAGE
+	bool
+	default y if RADIO_CAL
+
+# Calibration intensity used when stored data is present: 0 = partial (the
+# fast warm-boot path), 1 = none, 2 = full.
+config ESP_PHY_CALIBRATION_MODE
+	int
+	default 0
+
 config SOC_XTAL_FREQ_MHZ
 	int
 	default XTAL_FREQ if SOC_SERIES_ESP32C2

--- a/zephyr/port/stubs/phy_stubs.c
+++ b/zephyr/port/stubs/phy_stubs.c
@@ -101,18 +101,21 @@ void phy_improve_rx_special(bool enable)
 }
 #endif
 
+__attribute__((weak))
 esp_err_t esp_phy_load_cal_data_from_nvs(esp_phy_calibration_data_t *out_cal_data)
 {
 	ARG_UNUSED(out_cal_data);
 	return ESP_OK;
 }
 
+__attribute__((weak))
 esp_err_t esp_phy_store_cal_data_to_nvs(const esp_phy_calibration_data_t *cal_data)
 {
 	ARG_UNUSED(cal_data);
 	return ESP_OK;
 }
 
+__attribute__((weak))
 esp_err_t esp_phy_erase_cal_data_in_nvs(void)
 {
 	return ESP_OK;


### PR DESCRIPTION
Make the esp_phy NVS cal-data hooks weak so a Zephyr binding can provide real implementations, and guard the in-tree NVS helper block so it is excluded on Zephyr while the call sites remain. Derive ESP_PHY_CALIBRATION_AND_DATA_STORAGE from the generic RADIO_CAL option and default the calibration mode to partial, so RADIO_CAL is the single knob that enables persisted calibration.