### PR TITLE
esp32c3: bt: free osi_funcs_p with esp_bt_free() instead of libc free()

### DIFF
--- a/components/bt/controller/esp32c3/bt.c
+++ b/components/bt/controller/esp32c3/bt.c
@@ -2082,7 +2082,7 @@ static void bt_controller_deinit_internal(void)
 #endif // CONFIG_BT_CTRL_LE_LOG_EN
 
     if (osi_funcs_p != NULL) {
-        free(osi_funcs_p);
+        esp_bt_free(osi_funcs_p);
         osi_funcs_p = NULL;
     }
 


### PR DESCRIPTION
## Summary

`bt_controller_deinit_internal()` in `components/bt/controller/esp32c3/bt.c` frees `osi_funcs_p` with libc `free()`, but the buffer is allocated with `malloc_internal_wrapper()` (`esp_bt_malloc_func`). When `CONFIG_ESP_BT_HEAP_SYSTEM` is selected (the default for the Zephyr ESP32
Bluetooth HCI driver in `drivers/bluetooth/hci/Kconfig.esp32`) `esp_bt_malloc_func` maps to `k_malloc()`, so the matching deallocation must go through `esp_bt_free()` (`k_free`). Using libc `free()` hands a `k_heap` pointer to the libc allocator (a different heap).

The `esp32` controller variant already frees `osi_funcs_p` via `esp_bt_free()`; this brings `esp32c3` (used by ESP32-C3 and ESP32-S3) in line. It is the only `free(osi_funcs_p)` left across the controller variants.

## Impact

On ESP32-S3 / ESP32-C3, calling `bt_disable()` corrupts the heap. With `CONFIG_SYS_HEAP_HARDENING` enabled the mismatched free is caught:

```
<err> os_heap: heap canary: corruption at 0x3fcbbc18
<err> os: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
```

Backtrace: `bt_disable` → `bt_esp32_close` → `esp_bt_controller_deinit` → `bt_controller_deinit_internal` → `free(osi_funcs_p)` → `sys_heap_free(z_malloc_heap, ...)` on a pointer that lives in the `k_heap`. Without hardening, it is silent corruption.

## Fix

```c
-        free(osi_funcs_p);
+        esp_bt_free(osi_funcs_p);
```

## Test

ESP32-S3, Zephyr BLE peripheral. Connect → pair → disconnect → `bt_disable()`.
Before: kernel panic (heap canary / free-list corruption) every time.
After: `bt_disable()` completes cleanly. Verified with `CONFIG_SYS_HEAP_HARDENING_EXTREME=y`.