### PR TITLE
driver: spi_flash: detect flash chip post-kernel

### DIFF
--- a/zephyr/common/flash_init.c
+++ b/zephyr/common/flash_init.c
@@ -59,15 +59,12 @@ void esp_flash_config(void)
 
 	/*
 	 * Flash timing tuning must run right after spi_flash_init_chip_state()
-	 * and before esp_flash_app_init()/esp_flash_init_default_chip(),
-	 * matching ESP-IDF's mspi_init() sequence in cpu_start.c.
+	 * and before esp_flash_init_default_chip(), matching the mspi_init()
+	 * sequence.
 	 */
 #if SOC_SPI_MEM_SUPPORT_TIMING_TUNING
 	mspi_timing_flash_tuning();
 #endif
-
-	/* Switch to OS-aware functions for runtime flash operations */
-	esp_flash_app_init();
 
 	ret = esp_flash_init_default_chip();
 	if (ret != ESP_OK) {

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -223,6 +223,12 @@ if(CONFIG_SOC_SERIES_ESP32S2)
       ../../components/hal/mmu_hal.c
       ../../components/spi_flash/flash_ops.c
       )
+
+    if (CONFIG_SPIRAM_FETCH_INSTRUCTIONS OR CONFIG_SPIRAM_RODATA)
+      zephyr_sources(
+        ../../components/esp_psram/xip_impl/mmu_psram_flash.c
+        )
+    endif()
   endif()
 
   zephyr_sources_ifdef(CONFIG_I2C_ESP32


### PR DESCRIPTION
Detect the flash chip with no-OS functions during early boot and leave the OS-aware switch to the flash driver, so the mutex-guarded path is only used once the scheduler is running.