### PR TITLE
west: drop never used 'help' parameter in WestCommand() constructor

### DIFF
--- a/west/tools.py
+++ b/west/tools.py
@@ -121,8 +121,7 @@ class Tools(WestCommand):
     def __init__(self):
         super().__init__(
             'espressif',
-            # Keep this in sync with the string in west-commands.yml.
-            'Espressif tools for west framework.',
+            '',
             dedent('''
             This interface allows having esp-idf monitor support.'''),
             accepts_unknown_args=False)


### PR DESCRIPTION
This removes the warning seen in `west espressif -h`.  See https://github.com/zephyrproject-rtos/west/issues/927 for details.