### PR TITLE
fix: use heap_caps_free for heap_caps allocations

### DIFF
--- a/components/esp_adc/adc_cali_curve_fitting.c
+++ b/components/esp_adc/adc_cali_curve_fitting.c
@@ -106,7 +106,7 @@ esp_err_t adc_cali_create_scheme_curve_fitting(const adc_cali_curve_fitting_conf
 
 err:
     if (scheme) {
-        free(scheme);
+        heap_caps_free(scheme);
     }
     return ret;
 }
@@ -115,10 +115,10 @@ esp_err_t adc_cali_delete_scheme_curve_fitting(adc_cali_handle_t handle)
 {
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid argument: null pointer");
 
-    free(handle->ctx);
+    heap_caps_free(handle->ctx);
     handle->ctx = NULL;
 
-    free(handle);
+    heap_caps_free(handle);
     handle = NULL;
 
     return ESP_OK;

--- a/components/esp_adc/esp32/adc_cali_line_fitting.c
+++ b/components/esp_adc/esp32/adc_cali_line_fitting.c
@@ -206,7 +206,7 @@ esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config
 
 err:
     if (scheme) {
-        free(scheme);
+        heap_caps_free(scheme);
     }
     return ret;
 }
@@ -230,10 +230,10 @@ esp_err_t adc_cali_delete_scheme_line_fitting(adc_cali_handle_t handle)
 {
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid argument: null pointer");
 
-    free(handle->ctx);
+    heap_caps_free(handle->ctx);
     handle->ctx = NULL;
 
-    free(handle);
+    heap_caps_free(handle);
     handle = NULL;
 
     return ESP_OK;

--- a/components/esp_adc/esp32c2/adc_cali_line_fitting.c
+++ b/components/esp_adc/esp32c2/adc_cali_line_fitting.c
@@ -87,7 +87,7 @@ esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config
 
 err:
     if (scheme) {
-        free(scheme);
+        heap_caps_free(scheme);
     }
     return ret;
 }
@@ -96,10 +96,10 @@ esp_err_t adc_cali_delete_scheme_line_fitting(adc_cali_handle_t handle)
 {
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid argument: null pointer");
 
-    free(handle->ctx);
+    heap_caps_free(handle->ctx);
     handle->ctx = NULL;
 
-    free(handle);
+    heap_caps_free(handle);
     handle = NULL;
 
     return ESP_OK;

--- a/components/esp_adc/esp32s2/adc_cali_line_fitting.c
+++ b/components/esp_adc/esp32s2/adc_cali_line_fitting.c
@@ -121,7 +121,7 @@ esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config
 
 err:
     if (scheme) {
-        free(scheme);
+        heap_caps_free(scheme);
     }
     return ret;
 }
@@ -130,10 +130,10 @@ esp_err_t adc_cali_delete_scheme_line_fitting(adc_cali_handle_t handle)
 {
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid argument: null pointer");
 
-    free(handle->ctx);
+    heap_caps_free(handle->ctx);
     handle->ctx = NULL;
 
-    free(handle);
+    heap_caps_free(handle);
     handle = NULL;
 
     return ESP_OK;

--- a/components/esp_driver_tsens/src/temperature_sensor.c
+++ b/components/esp_driver_tsens/src/temperature_sensor.c
@@ -190,7 +190,7 @@ esp_err_t temperature_sensor_uninstall(temperature_sensor_handle_t tsens)
     ESP_RETURN_ON_FALSE(tsens->fsm == TEMP_SENSOR_FSM_INIT, ESP_ERR_INVALID_STATE, TAG, "tsens not in init state");
 
     if (s_tsens_attribute_copy) {
-        free(s_tsens_attribute_copy);
+        heap_caps_free(s_tsens_attribute_copy);
     }
     s_tsens_attribute_copy = NULL;
 
@@ -217,7 +217,7 @@ esp_err_t temperature_sensor_uninstall(temperature_sensor_handle_t tsens)
 
     temperature_sensor_power_release();
 
-    free(tsens);
+    heap_caps_free(tsens);
     return ESP_OK;
 }
 

--- a/components/esp_hw_support/port/regdma_link.c
+++ b/components/esp_hw_support/port/regdma_link.c
@@ -480,7 +480,7 @@ static void regdma_link_destroy_wrapper(void *link, int entry, int depth)
     regdma_link_stats_t *stat = regdma_link_get_stats(link);
     stat->ref &= ~BIT(entry);
     if (stat->ref == 0) {
-        free(regdma_link_get_instance(link));
+        heap_caps_free(regdma_link_get_instance(link));
     }
 }
 

--- a/components/esp_timer/src/esp_timer_etm.c
+++ b/components/esp_timer/src/esp_timer_etm.c
@@ -18,7 +18,7 @@ ESP_LOG_ATTR_TAG(TAG, "esptimer-etm");
 
 static esp_err_t esp_timer_etm_event_del(esp_etm_event_t *event)
 {
-    free(event);
+    heap_caps_free(event);
     return ESP_OK;
 }
 

--- a/components/spi_flash/esp_flash_spi_init.c
+++ b/components/spi_flash/esp_flash_spi_init.c
@@ -444,8 +444,8 @@ esp_err_t spi_bus_remove_flash_device(esp_flash_t *chip)
     if (dev_handle) {
         spi_bus_lock_unregister_dev(dev_handle);
     }
-    free(chip->host);
-    free(chip);
+    heap_caps_free(chip->host);
+    heap_caps_free(chip);
     return ESP_OK;
 }
 


### PR DESCRIPTION
Bare free() does not match the heap_caps allocator on Zephyr and corrupts the heap; pair these frees with their heap_caps_free.