### PR TITLE
hal: esp_wifi adapter task cleanup fixes

### DIFF
--- a/components/esp_wifi/esp32/esp_adapter.c
+++ b/components/esp_wifi/esp32/esp_adapter.c
@@ -51,6 +51,7 @@ LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 struct wifi_task {
     struct k_thread thread;
     k_thread_stack_t *stack;
+    struct k_work cleanup_work;
 };
 
 struct wifi_adapter_msgq {
@@ -107,6 +108,20 @@ IRAM_ATTR void *wifi_calloc(size_t n, size_t size)
 static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
 {
     return wifi_calloc(1, size);
+}
+
+static void wifi_task_cleanup_work(struct k_work *work)
+{
+    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
+
+    k_thread_join(&t->thread, K_FOREVER);
+    if (t->thread.custom_data) {
+        esp_wifi_free_func(t->thread.custom_data);
+    }
+
+    k_thread_stack_free(t->stack);
+    k_object_release(&t->thread);
+    esp_wifi_free_func(t);
 }
 
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
@@ -282,14 +297,22 @@ static void queue_delete_wrapper(void *handle)
 
 static void task_delete_wrapper(void *handle)
 {
-    if (handle == NULL) {
-        return;
-    }
-
-    k_tid_t tid = (k_tid_t)handle;
+    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
     struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
 
+    if (tid == k_current_get()) {
+        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
+        k_work_submit(&t->cleanup_work);
+        k_thread_abort(k_current_get());
+        CODE_UNREACHABLE;
+    }
+
     k_thread_abort(tid);
+
+    if (tid->custom_data) {
+        esp_wifi_free(tid->custom_data);
+    }
+    
     k_thread_stack_free(t->stack);
     k_object_release(tid);
     esp_wifi_free(t);

--- a/components/esp_wifi/esp32c2/esp_adapter.c
+++ b/components/esp_wifi/esp32c2/esp_adapter.c
@@ -44,6 +44,7 @@ LOG_MODULE_REGISTER(esp32c2_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 struct wifi_task {
     struct k_thread thread;
     k_thread_stack_t *stack;
+    struct k_work cleanup_work;
 };
 
 struct wifi_adapter_msgq {
@@ -95,6 +96,20 @@ static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
 static void esp_wifi_free(void *mem)
 {
     esp_wifi_free_func(mem);
+}
+
+static void wifi_task_cleanup_work(struct k_work *work)
+{
+    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
+
+    k_thread_join(&t->thread, K_FOREVER);
+    if (t->thread.custom_data) {
+        esp_wifi_free_func(t->thread.custom_data);
+    }
+
+    k_thread_stack_free(t->stack);
+    k_object_release(&t->thread);
+    esp_wifi_free_func(t);
 }
 
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
@@ -277,14 +292,22 @@ static void queue_delete_wrapper(void *handle)
 
 static void task_delete_wrapper(void *handle)
 {
-    if (handle == NULL) {
-        return;
-    }
-
-    k_tid_t tid = (k_tid_t)handle;
+    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
     struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
 
+    if (tid == k_current_get()) {
+        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
+        k_work_submit(&t->cleanup_work);
+        k_thread_abort(k_current_get());
+        CODE_UNREACHABLE;
+    }
+
     k_thread_abort(tid);
+
+    if (tid->custom_data) {
+        esp_wifi_free(tid->custom_data);
+    }
+    
     k_thread_stack_free(t->stack);
     k_object_release(tid);
     esp_wifi_free(t);

--- a/components/esp_wifi/esp32c3/esp_adapter.c
+++ b/components/esp_wifi/esp32c3/esp_adapter.c
@@ -61,6 +61,7 @@ struct wifi_adapter_msgq {
 struct wifi_task {
     struct k_thread thread;
     k_thread_stack_t *stack;
+    struct k_work cleanup_work;
 };
 
 #ifdef CONFIG_PM
@@ -107,6 +108,20 @@ static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
 static void esp_wifi_free(void *mem)
 {
     esp_wifi_free_func(mem);
+}
+
+static void wifi_task_cleanup_work(struct k_work *work)
+{
+    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
+
+    k_thread_join(&t->thread, K_FOREVER);
+    if (t->thread.custom_data) {
+        esp_wifi_free_func(t->thread.custom_data);
+    }
+
+    k_thread_stack_free(t->stack);
+    k_object_release(&t->thread);
+    esp_wifi_free_func(t);
 }
 
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
@@ -427,14 +442,22 @@ static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t s
 
 static void task_delete_wrapper(void *handle)
 {
-    if (handle == NULL) {
-        return;
-    }
-
-    k_tid_t tid = (k_tid_t)handle;
+    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
     struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
 
+    if (tid == k_current_get()) {
+        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
+        k_work_submit(&t->cleanup_work);
+        k_thread_abort(k_current_get());
+        CODE_UNREACHABLE;
+    }
+
     k_thread_abort(tid);
+
+    if (tid->custom_data) {
+        esp_wifi_free(tid->custom_data);
+    }
+    
     k_thread_stack_free(t->stack);
     k_object_release(tid);
     esp_wifi_free(t);

--- a/components/esp_wifi/esp32c5/esp_adapter.c
+++ b/components/esp_wifi/esp32c5/esp_adapter.c
@@ -70,6 +70,7 @@ struct wifi_adapter_msgq {
 struct wifi_task {
     struct k_thread thread;
     k_thread_stack_t *stack;
+    struct k_work cleanup_work;
 };
 
 #ifdef CONFIG_PM
@@ -116,6 +117,20 @@ static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
 static void esp_wifi_free(void *mem)
 {
     esp_wifi_free_func(mem);
+}
+
+static void wifi_task_cleanup_work(struct k_work *work)
+{
+    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
+
+    k_thread_join(&t->thread, K_FOREVER);
+    if (t->thread.custom_data) {
+        esp_wifi_free_func(t->thread.custom_data);
+    }
+
+    k_thread_stack_free(t->stack);
+    k_object_release(&t->thread);
+    esp_wifi_free_func(t);
 }
 
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
@@ -436,14 +451,22 @@ static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t s
 
 static void task_delete_wrapper(void *handle)
 {
-    if (handle == NULL) {
-        return;
-    }
-
-    k_tid_t tid = (k_tid_t)handle;
+    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
     struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
 
+    if (tid == k_current_get()) {
+        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
+        k_work_submit(&t->cleanup_work);
+        k_thread_abort(k_current_get());
+        CODE_UNREACHABLE;
+    }
+
     k_thread_abort(tid);
+
+    if (tid->custom_data) {
+        esp_wifi_free(tid->custom_data);
+    }
+    
     k_thread_stack_free(t->stack);
     k_object_release(tid);
     esp_wifi_free(t);

--- a/components/esp_wifi/esp32c6/esp_adapter.c
+++ b/components/esp_wifi/esp32c6/esp_adapter.c
@@ -70,6 +70,7 @@ struct wifi_adapter_msgq {
 struct wifi_task {
     struct k_thread thread;
     k_thread_stack_t *stack;
+    struct k_work cleanup_work;
 };
 
 #ifdef CONFIG_PM
@@ -116,6 +117,20 @@ static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
 static void esp_wifi_free(void *mem)
 {
     esp_wifi_free_func(mem);
+}
+
+static void wifi_task_cleanup_work(struct k_work *work)
+{
+    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
+
+    k_thread_join(&t->thread, K_FOREVER);
+    if (t->thread.custom_data) {
+        esp_wifi_free_func(t->thread.custom_data);
+    }
+
+    k_thread_stack_free(t->stack);
+    k_object_release(&t->thread);
+    esp_wifi_free_func(t);
 }
 
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
@@ -437,14 +452,22 @@ static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t s
 
 static void task_delete_wrapper(void *handle)
 {
-    if (handle == NULL) {
-        return;
-    }
-
-    k_tid_t tid = (k_tid_t)handle;
+    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
     struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
 
+    if (tid == k_current_get()) {
+        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
+        k_work_submit(&t->cleanup_work);
+        k_thread_abort(k_current_get());
+        CODE_UNREACHABLE;
+    }
+
     k_thread_abort(tid);
+
+    if (tid->custom_data) {
+        esp_wifi_free(tid->custom_data);
+    }
+
     k_thread_stack_free(t->stack);
     k_object_release(tid);
     esp_wifi_free(t);

--- a/components/esp_wifi/esp32s2/esp_adapter.c
+++ b/components/esp_wifi/esp32s2/esp_adapter.c
@@ -43,6 +43,7 @@ LOG_MODULE_REGISTER(esp32s2_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 struct wifi_task {
     struct k_thread thread;
     k_thread_stack_t *stack;
+    struct k_work cleanup_work;
 };
 
 struct wifi_adapter_msgq {
@@ -97,6 +98,20 @@ static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
 static void esp_wifi_free(void *mem)
 {
     esp_wifi_free_func(mem);
+}
+
+static void wifi_task_cleanup_work(struct k_work *work)
+{
+    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
+
+    k_thread_join(&t->thread, K_FOREVER);
+    if (t->thread.custom_data) {
+        esp_wifi_free_func(t->thread.custom_data);
+    }
+
+    k_thread_stack_free(t->stack);
+    k_object_release(&t->thread);
+    esp_wifi_free_func(t);
 }
 
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
@@ -273,14 +288,22 @@ static void queue_delete_wrapper(void *handle)
 
 static void task_delete_wrapper(void *handle)
 {
-    if (handle == NULL) {
-        return;
-    }
-
-    k_tid_t tid = (k_tid_t)handle;
+    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
     struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
 
+    if (tid == k_current_get()) {
+        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
+        k_work_submit(&t->cleanup_work);
+        k_thread_abort(k_current_get());
+        CODE_UNREACHABLE;
+    }
+
     k_thread_abort(tid);
+
+    if (tid->custom_data) {
+        esp_wifi_free(tid->custom_data);
+    }
+
     k_thread_stack_free(t->stack);
     k_object_release(tid);
     esp_wifi_free(t);

--- a/components/esp_wifi/esp32s3/esp_adapter.c
+++ b/components/esp_wifi/esp32s3/esp_adapter.c
@@ -49,7 +49,22 @@ LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 struct wifi_task {
 	struct k_thread thread;
 	k_thread_stack_t *stack;
+	struct k_work cleanup_work;
 };
+
+static void wifi_task_cleanup_work(struct k_work *work)
+{
+	struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
+
+	k_thread_join(&t->thread, K_FOREVER);
+	if (t->thread.custom_data) {
+		esp_wifi_free_func(t->thread.custom_data);
+	}
+
+	k_thread_stack_free(t->stack);
+	k_object_release(&t->thread);
+	esp_wifi_free_func(t);
+}
 
 struct wifi_adapter_msgq {
 	struct k_msgq msgq;
@@ -278,14 +293,22 @@ static void queue_delete_wrapper(void *handle)
 
 static void task_delete_wrapper(void *handle)
 {
-	if (handle == NULL) {
-		return;
-	}
-
-	k_tid_t tid = (k_tid_t)handle;
+	k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
 	struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
 
+	if (tid == k_current_get()) {
+		k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
+		k_work_submit(&t->cleanup_work);
+		k_thread_abort(k_current_get());
+		CODE_UNREACHABLE;
+	}
+
 	k_thread_abort(tid);
+
+	if (tid->custom_data) {
+		esp_wifi_free(tid->custom_data);
+	}
+	
 	k_thread_stack_free(t->stack);
 	k_object_release(tid);
 	esp_wifi_free(t);


### PR DESCRIPTION
On EAP-TLS failures or other connection errors, the wifi task is not fully cleaned up leading to memory leakage.

Add a workqueue function to task_delete_wrapper to cleanup task on connection errors.