### PR TITLE
hal: espressif: replace dynamic heap with static storage

### DIFF
--- a/components/esp_adc/adc_cali_curve_fitting.c
+++ b/components/esp_adc/adc_cali_curve_fitting.c
@@ -66,8 +66,18 @@ static esp_err_t check_valid(const adc_cali_curve_fitting_config_t *config);
 /* ------------------------ Interface Functions --------------------------- */
 static esp_err_t cali_raw_to_voltage(void *arg, int raw, int *voltage);
 
+/*
+ * Caller-owned storage replacing the heap. The driver provides one
+ * adc_cali_scheme_storage_t per channel; the scheme and its characteristics
+ * are carved out of it, so no dynamic allocation is needed.
+ */
+typedef struct {
+    adc_cali_scheme_t scheme;
+    cali_chars_curve_fitting_t chars;
+} adc_cali_scheme_slot_t;
+
 /* ------------------------- Public API ------------------------------------- */
-esp_err_t adc_cali_create_scheme_curve_fitting(const adc_cali_curve_fitting_config_t *config, adc_cali_handle_t *ret_handle)
+esp_err_t adc_cali_create_scheme_curve_fitting(const adc_cali_curve_fitting_config_t *config, void *storage, adc_cali_handle_t *ret_handle)
 {
     esp_err_t ret = ESP_OK;
     ESP_RETURN_ON_FALSE(config && ret_handle, ESP_ERR_INVALID_ARG, TAG, "invalid arg: null pointer");
@@ -80,11 +90,14 @@ esp_err_t adc_cali_create_scheme_curve_fitting(const adc_cali_curve_fitting_conf
     ESP_RETURN_ON_FALSE((adc_encoding_version >= ESP_EFUSE_ADC_CALIB_VER_MIN) &&
                         (adc_encoding_version <= ESP_EFUSE_ADC_CALIB_VER_MAX), ESP_ERR_NOT_SUPPORTED, TAG, "Calibration required eFuse bits not burnt");
 
-    adc_cali_scheme_t *scheme = (adc_cali_scheme_t *)heap_caps_calloc(1, sizeof(adc_cali_scheme_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-    ESP_RETURN_ON_FALSE(scheme, ESP_ERR_NO_MEM, TAG, "no mem for adc calibration scheme");
+    ESP_RETURN_ON_FALSE(storage, ESP_ERR_INVALID_ARG, TAG, "no storage for adc calibration scheme");
+    _Static_assert(sizeof(adc_cali_scheme_slot_t) <= sizeof(adc_cali_scheme_storage_t),
+                   "adc_cali_scheme_storage_t too small for curve fitting scheme");
 
-    cali_chars_curve_fitting_t *chars = (cali_chars_curve_fitting_t *)heap_caps_calloc(1, sizeof(cali_chars_curve_fitting_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-    ESP_GOTO_ON_FALSE(chars, ESP_ERR_NO_MEM, err, TAG, "no memory for the calibration characteristics");
+    adc_cali_scheme_slot_t *slot = (adc_cali_scheme_slot_t *)storage;
+    memset(slot, 0, sizeof(adc_cali_scheme_slot_t));
+    adc_cali_scheme_t *scheme = &slot->scheme;
+    cali_chars_curve_fitting_t *chars = &slot->chars;
 
     scheme->raw_to_voltage = cali_raw_to_voltage;
     scheme->ctx = chars;
@@ -103,23 +116,13 @@ esp_err_t adc_cali_create_scheme_curve_fitting(const adc_cali_curve_fitting_conf
     *ret_handle = scheme;
 
     return ESP_OK;
-
-err:
-    if (scheme) {
-        free(scheme);
-    }
-    return ret;
 }
 
 esp_err_t adc_cali_delete_scheme_curve_fitting(adc_cali_handle_t handle)
 {
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid argument: null pointer");
 
-    free(handle->ctx);
     handle->ctx = NULL;
-
-    free(handle);
-    handle = NULL;
 
     return ESP_OK;
 }

--- a/components/esp_adc/esp32/adc_cali_line_fitting.c
+++ b/components/esp_adc/esp32/adc_cali_line_fitting.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdint.h>
+#include <string.h>
 #include "sdkconfig.h"
 #include "assert.h"
 #include "esp_types.h"
@@ -151,8 +152,18 @@ typedef struct {
     adc_cali_line_fitting_efuse_val_t efuse_val;    ///< Type of calibration value used in characterization
 } cali_chars_line_fitting_t;
 
+/*
+ * Caller-owned storage replacing the heap. The driver provides one
+ * adc_cali_scheme_storage_t per channel; the scheme and its characteristics
+ * are carved out of it, so no dynamic allocation is needed.
+ */
+typedef struct {
+    adc_cali_scheme_t scheme;
+    cali_chars_line_fitting_t chars;
+} adc_cali_scheme_slot_t;
+
 /* ------------------------- Public API ------------------------------------- */
-esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config_t *config, adc_cali_handle_t *ret_handle)
+esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config_t *config, void *storage, adc_cali_handle_t *ret_handle)
 {
     esp_err_t ret = ESP_OK;
     ESP_RETURN_ON_FALSE(config && config, ESP_ERR_INVALID_ARG, TAG, "invalid argument: null pointer");
@@ -160,11 +171,14 @@ esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config
     ESP_RETURN_ON_FALSE(config->atten < SOC_ADC_ATTEN_NUM, ESP_ERR_INVALID_ARG, TAG, "invalid ADC attenuation");
     ESP_RETURN_ON_FALSE(((config->bitwidth >= ADC_LL_RTC_MIN_BITWIDTH && config->bitwidth <= ADC_LL_RTC_MAX_BITWIDTH) || config->bitwidth == ADC_BITWIDTH_DEFAULT), ESP_ERR_INVALID_ARG, TAG, "invalid bitwidth");
 
-    adc_cali_scheme_t *scheme = (adc_cali_scheme_t *)heap_caps_calloc(1, sizeof(adc_cali_scheme_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-    ESP_RETURN_ON_FALSE(scheme, ESP_ERR_NO_MEM, TAG, "no mem for adc calibration scheme");
+    ESP_RETURN_ON_FALSE(storage, ESP_ERR_INVALID_ARG, TAG, "no storage for adc calibration scheme");
+    _Static_assert(sizeof(adc_cali_scheme_slot_t) <= sizeof(adc_cali_scheme_storage_t),
+                   "adc_cali_scheme_storage_t too small for line fitting scheme");
 
-    cali_chars_line_fitting_t *chars = (cali_chars_line_fitting_t *)heap_caps_calloc(1, sizeof(cali_chars_line_fitting_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-    ESP_GOTO_ON_FALSE(chars, ESP_ERR_NO_MEM, err, TAG, "no memory for the calibration characteristics");
+    adc_cali_scheme_slot_t *slot = (adc_cali_scheme_slot_t *)storage;
+    memset(slot, 0, sizeof(adc_cali_scheme_slot_t));
+    adc_cali_scheme_t *scheme = &slot->scheme;
+    cali_chars_line_fitting_t *chars = &slot->chars;
 
     //Check eFuse if enabled to do so
     if (check_efuse_tp() && EFUSE_TP_ENABLED) {
@@ -205,9 +219,7 @@ esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config
     return ESP_OK;
 
 err:
-    if (scheme) {
-        free(scheme);
-    }
+    memset(slot, 0, sizeof(adc_cali_scheme_slot_t));
     return ret;
 }
 
@@ -230,11 +242,7 @@ esp_err_t adc_cali_delete_scheme_line_fitting(adc_cali_handle_t handle)
 {
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid argument: null pointer");
 
-    free(handle->ctx);
     handle->ctx = NULL;
-
-    free(handle);
-    handle = NULL;
 
     return ESP_OK;
 }

--- a/components/esp_adc/esp32c2/adc_cali_line_fitting.c
+++ b/components/esp_adc/esp32c2/adc_cali_line_fitting.c
@@ -42,12 +42,22 @@ typedef struct {
     uint32_t coeff_b;    ///< Offset of ADC-Voltage characteristics
 } cali_chars_line_fitting_t;
 
+/*
+ * Caller-owned storage replacing the heap. The driver provides one
+ * adc_cali_scheme_storage_t per channel; the scheme and its characteristics
+ * are carved out of it, so no dynamic allocation is needed.
+ */
+typedef struct {
+    adc_cali_scheme_t scheme;
+    cali_chars_line_fitting_t chars;
+} adc_cali_scheme_slot_t;
+
 /* ------------------------ Interface Functions --------------------------- */
 static esp_err_t cali_raw_to_voltage(void *arg, int raw, int *voltage);
 static esp_err_t check_valid(const adc_cali_line_fitting_config_t *config);
 
 /* ------------------------- Public API ------------------------------------- */
-esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config_t *config, adc_cali_handle_t *ret_handle)
+esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config_t *config, void *storage, adc_cali_handle_t *ret_handle)
 {
     esp_err_t ret = ESP_OK;
     ESP_RETURN_ON_FALSE(config && ret_handle, ESP_ERR_INVALID_ARG, TAG, "invalid arg: null pointer");
@@ -61,11 +71,14 @@ esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config
     ESP_RETURN_ON_FALSE((adc_cali_version >= ESP_EFUSE_ADC_CALIB_VER_MIN) &&
                         (adc_cali_version <= ESP_EFUSE_ADC_CALIB_VER_MAX), ESP_ERR_NOT_SUPPORTED, TAG, "Calibration required eFuse bits not burnt");
 
-    adc_cali_scheme_t *scheme = (adc_cali_scheme_t *)heap_caps_calloc(1, sizeof(adc_cali_scheme_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-    ESP_RETURN_ON_FALSE(scheme, ESP_ERR_NO_MEM, TAG, "no mem for adc calibration scheme");
+    ESP_RETURN_ON_FALSE(storage, ESP_ERR_INVALID_ARG, TAG, "no storage for adc calibration scheme");
+    _Static_assert(sizeof(adc_cali_scheme_slot_t) <= sizeof(adc_cali_scheme_storage_t),
+                   "adc_cali_scheme_storage_t too small for line fitting scheme");
 
-    cali_chars_line_fitting_t *chars = (cali_chars_line_fitting_t *)heap_caps_calloc(1, sizeof(cali_chars_line_fitting_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-    ESP_GOTO_ON_FALSE(chars, ESP_ERR_NO_MEM, err, TAG, "no memory for the calibration characteristics");
+    adc_cali_scheme_slot_t *slot = (adc_cali_scheme_slot_t *)storage;
+    memset(slot, 0, sizeof(adc_cali_scheme_slot_t));
+    adc_cali_scheme_t *scheme = &slot->scheme;
+    cali_chars_line_fitting_t *chars = &slot->chars;
 
     scheme->raw_to_voltage = cali_raw_to_voltage;
     scheme->ctx = chars;
@@ -84,23 +97,13 @@ esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config
     *ret_handle = scheme;
 
     return ESP_OK;
-
-err:
-    if (scheme) {
-        free(scheme);
-    }
-    return ret;
 }
 
 esp_err_t adc_cali_delete_scheme_line_fitting(adc_cali_handle_t handle)
 {
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid argument: null pointer");
 
-    free(handle->ctx);
     handle->ctx = NULL;
-
-    free(handle);
-    handle = NULL;
 
     return ESP_OK;
 }

--- a/components/esp_adc/esp32s2/adc_cali_line_fitting.c
+++ b/components/esp_adc/esp32s2/adc_cali_line_fitting.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdint.h>
+#include <string.h>
 #include "assert.h"
 #include "esp_types.h"
 #include "esp_err.h"
@@ -57,6 +58,16 @@ typedef struct {
     uint32_t coeff_b;                       ///< Offset of ADC-Voltage curve
 } cali_chars_line_fitting_t;
 
+/*
+ * Caller-owned storage replacing the heap. The driver provides one
+ * adc_cali_scheme_storage_t per channel; the scheme and its characteristics
+ * are carved out of it, so no dynamic allocation is needed.
+ */
+typedef struct {
+    adc_cali_scheme_t scheme;
+    cali_chars_line_fitting_t chars;
+} adc_cali_scheme_slot_t;
+
 /* ----------------------- Characterization Functions ----------------------- */
 static bool prepare_calib_data_for(adc_unit_t unit_id, adc_atten_t atten, adc_calib_parsed_info_t *parsed_data_storage);
 /**
@@ -84,9 +95,8 @@ static bool calculate_characterization_coefficients(const adc_calib_parsed_info_
 static esp_err_t cali_raw_to_voltage(void *arg, int raw, int *voltage);
 
 /* ------------------------- Public API ------------------------------------- */
-esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config_t *config, adc_cali_handle_t *ret_handle)
+esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config_t *config, void *storage, adc_cali_handle_t *ret_handle)
 {
-    esp_err_t ret = ESP_OK;
     ESP_RETURN_ON_FALSE(config && ret_handle, ESP_ERR_INVALID_ARG, TAG, "invalid arg: null pointer");
     ESP_RETURN_ON_FALSE(config->unit_id < SOC_ADC_PERIPH_NUM, ESP_ERR_INVALID_ARG, TAG, "invalid ADC unit");
     ESP_RETURN_ON_FALSE(config->atten < SOC_ADC_ATTEN_NUM, ESP_ERR_INVALID_ARG, TAG, "invalid ADC attenuation");
@@ -96,11 +106,14 @@ esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config
     uint8_t adc_encoding_version = esp_efuse_rtc_table_read_calib_version();
     ESP_RETURN_ON_FALSE(((adc_encoding_version == 1) || (adc_encoding_version == 2)), ESP_ERR_NOT_SUPPORTED, TAG, "Calibration required eFuse bits not burnt");
 
-    adc_cali_scheme_t *scheme = (adc_cali_scheme_t *)heap_caps_calloc(1, sizeof(adc_cali_scheme_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-    ESP_RETURN_ON_FALSE(scheme, ESP_ERR_NO_MEM, TAG, "no mem for adc calibration scheme");
+    ESP_RETURN_ON_FALSE(storage, ESP_ERR_INVALID_ARG, TAG, "no storage for adc calibration scheme");
+    _Static_assert(sizeof(adc_cali_scheme_slot_t) <= sizeof(adc_cali_scheme_storage_t),
+                   "adc_cali_scheme_storage_t too small for line fitting scheme");
 
-    cali_chars_line_fitting_t *chars = (cali_chars_line_fitting_t *)heap_caps_calloc(1, sizeof(cali_chars_line_fitting_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-    ESP_GOTO_ON_FALSE(chars, ESP_ERR_NO_MEM, err, TAG, "no memory for the calibration characteristics");
+    adc_cali_scheme_slot_t *slot = (adc_cali_scheme_slot_t *)storage;
+    memset(slot, 0, sizeof(adc_cali_scheme_slot_t));
+    adc_cali_scheme_t *scheme = &slot->scheme;
+    cali_chars_line_fitting_t *chars = &slot->chars;
 
     scheme->raw_to_voltage = cali_raw_to_voltage;
     scheme->ctx = chars;
@@ -118,23 +131,13 @@ esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config
     *ret_handle = scheme;
 
     return ESP_OK;
-
-err:
-    if (scheme) {
-        free(scheme);
-    }
-    return ret;
 }
 
 esp_err_t adc_cali_delete_scheme_line_fitting(adc_cali_handle_t handle)
 {
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "invalid argument: null pointer");
 
-    free(handle->ctx);
     handle->ctx = NULL;
-
-    free(handle);
-    handle = NULL;
 
     return ESP_OK;
 }

--- a/components/esp_adc/include/esp_adc/adc_cali_scheme.h
+++ b/components/esp_adc/include/esp_adc/adc_cali_scheme.h
@@ -15,6 +15,20 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Opaque storage for one calibration scheme.
+ *
+ * The caller (the ADC driver) provides one of these per channel and passes its
+ * address to adc_cali_create_scheme_*(). The scheme implementation carves its
+ * scheme object and characteristics out of this buffer, so no heap is used.
+ * The buffer is sized to hold the largest scheme plus its characteristics
+ * across all supported calibration schemes.
+ */
+typedef struct {
+    void *_align;
+    uint8_t bytes[64];
+} adc_cali_scheme_storage_t;
+
 #if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
 /*---------------------------------------------------------------
             Curve Fitting Calibration Scheme
@@ -41,7 +55,7 @@ typedef struct {
  *        - ESP_ERR_NO_MEM:        No enough memory
  *        - ESP_ERR_NOT_SUPPORTED: Scheme required eFuse bits not burnt
  */
-esp_err_t adc_cali_create_scheme_curve_fitting(const adc_cali_curve_fitting_config_t *config, adc_cali_handle_t *ret_handle);
+esp_err_t adc_cali_create_scheme_curve_fitting(const adc_cali_curve_fitting_config_t *config, void *storage, adc_cali_handle_t *ret_handle);
 
 /**
  * @brief Delete the Curve Fitting calibration scheme handle
@@ -98,7 +112,7 @@ typedef struct {
  *        - ESP_ERR_NO_MEM:        No enough memory
  *        - ESP_ERR_NOT_SUPPORTED: Scheme required eFuse bits not burnt
  */
-esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config_t *config, adc_cali_handle_t *ret_handle);
+esp_err_t adc_cali_create_scheme_line_fitting(const adc_cali_line_fitting_config_t *config, void *storage, adc_cali_handle_t *ret_handle);
 
 /**
  * @brief Delete the Line Fitting calibration scheme handle

--- a/components/esp_driver_gpio/src/gpio.c
+++ b/components/esp_driver_gpio/src/gpio.c
@@ -36,10 +36,6 @@ extern uint32_t esp_core_id(void);
 #define GPIO_ENTER_CRITICAL()    esp_os_enter_critical(&gpio_context.gpio_spinlock)
 #define GPIO_EXIT_CRITICAL()     esp_os_exit_critical(&gpio_context.gpio_spinlock)
 
-#define MALLOC_CAP_INTERNAL 0
-#define MALLOC_CAP_DEFAULT 0
-#define heap_caps_calloc(n, size, caps) k_calloc(n, size)
-
 static inline uint64_t esp_gpio_reserve(uint64_t mask) { (void)mask; return 0; }
 static inline void esp_gpio_revoke(uint64_t mask) { (void)mask; }
 static inline bool esp_gpio_is_reserved(uint64_t mask) { (void)mask; return false; }
@@ -524,6 +520,7 @@ esp_err_t gpio_reset_pin(gpio_num_t gpio_num)
     return ESP_OK;
 }
 
+#ifndef __ZEPHYR__
 static inline void IRAM_ATTR gpio_isr_loop(uint32_t status, const uint32_t gpio_num_start)
 {
     while (status) {
@@ -648,6 +645,7 @@ esp_err_t gpio_uninstall_isr_service(void)
     k_free(gpio_isr_func_free);
     return ESP_OK;
 }
+#endif /* __ZEPHYR__ */
 
 static void gpio_isr_register_on_core_static(void *param)
 {

--- a/components/esp_driver_tsens/src/temperature_sensor.c
+++ b/components/esp_driver_tsens/src/temperature_sensor.c
@@ -42,7 +42,14 @@ static int s_deltaT = INT_MIN; // unused number
 static int s_temperature_regval_2_celsius(temperature_sensor_handle_t tsens, uint8_t regval);
 #endif // SOC_TEMPERATURE_SENSOR_INTR_SUPPORT
 
+/*
+ * Static storage replacing the heap. The attribute copy is a fixed-size sorted
+ * table; the sensor object is a single instance, since there is one temperature
+ * sensor peripheral and install is guarded against a second call.
+ */
+static temperature_sensor_attribute_t s_tsens_attribute_storage[TEMPERATURE_SENSOR_ATTR_RANGE_NUM];
 static temperature_sensor_attribute_t *s_tsens_attribute_copy;
+static temperature_sensor_obj_t s_tsens_obj;
 
 static int inline accuracy_compare(const void *p1, const void *p2)
 {
@@ -51,8 +58,7 @@ static int inline accuracy_compare(const void *p1, const void *p2)
 
 static esp_err_t temperature_sensor_attribute_table_sort(void)
 {
-    s_tsens_attribute_copy = (temperature_sensor_attribute_t *)heap_caps_malloc(sizeof(temperature_sensor_attributes), TEMPERATURE_SENSOR_MEM_ALLOC_CAPS);
-    ESP_RETURN_ON_FALSE(s_tsens_attribute_copy != NULL, ESP_ERR_NO_MEM, TAG, "No space for s_tsens_attribute_copy");
+    s_tsens_attribute_copy = s_tsens_attribute_storage;
     for (int i = 0 ; i < TEMPERATURE_SENSOR_ATTR_RANGE_NUM; i++) {
         s_tsens_attribute_copy[i] = temperature_sensor_attributes[i];
     }
@@ -132,9 +138,8 @@ esp_err_t temperature_sensor_install(const temperature_sensor_config_t *tsens_co
     esp_err_t ret = ESP_OK;
     ESP_RETURN_ON_FALSE((tsens_config && ret_tsens), ESP_ERR_INVALID_ARG, TAG, "Invalid argument");
     ESP_RETURN_ON_FALSE((s_tsens_attribute_copy == NULL), ESP_ERR_INVALID_STATE, TAG, "Already installed");
-    temperature_sensor_handle_t tsens = NULL;
-    tsens = (temperature_sensor_obj_t *) heap_caps_calloc(1, sizeof(temperature_sensor_obj_t), MALLOC_CAP_DEFAULT);
-    ESP_RETURN_ON_FALSE((tsens != NULL), ESP_ERR_NO_MEM, TAG, "no mem for temp sensor");
+    temperature_sensor_handle_t tsens = &s_tsens_obj;
+    memset(tsens, 0, sizeof(temperature_sensor_obj_t));
     if (tsens->clk_src == 0) {
         tsens->clk_src = TEMPERATURE_SENSOR_CLK_SRC_DEFAULT;
     } else {
@@ -189,9 +194,6 @@ esp_err_t temperature_sensor_uninstall(temperature_sensor_handle_t tsens)
     ESP_RETURN_ON_FALSE((tsens != NULL), ESP_ERR_INVALID_ARG, TAG, "invalid argument");
     ESP_RETURN_ON_FALSE(tsens->fsm == TEMP_SENSOR_FSM_INIT, ESP_ERR_INVALID_STATE, TAG, "tsens not in init state");
 
-    if (s_tsens_attribute_copy) {
-        free(s_tsens_attribute_copy);
-    }
     s_tsens_attribute_copy = NULL;
 
 #if SOC_TEMPERATURE_SENSOR_INTR_SUPPORT
@@ -217,7 +219,6 @@ esp_err_t temperature_sensor_uninstall(temperature_sensor_handle_t tsens)
 
     temperature_sensor_power_release();
 
-    free(tsens);
     return ESP_OK;
 }
 

--- a/components/esp_mm/esp_mmu_map.c
+++ b/components/esp_mm/esp_mmu_map.c
@@ -116,6 +116,49 @@ typedef struct {
 
 static mmu_ctx_t s_mmu_ctx;
 
+/**
+ * Static pool of mem_block_t, replacing dynamic allocation.
+ *
+ * Each region needs 2 sentinel blocks (dummy head and tail). The rest are
+ * actual mappings: PSRAM mapping done once at init plus any runtime flash
+ * mmap windows. Pool access is serialised by s_mmu_ctx.mutex, so no extra
+ * locking is needed here.
+ */
+#ifndef CONFIG_ESP32_FLASH_MMU_MAX_MAPPINGS
+#define CONFIG_ESP32_FLASH_MMU_MAX_MAPPINGS 8
+#endif
+
+#define MMU_BLOCK_POOL_SIZE \
+    (SOC_MMU_LINEAR_ADDRESS_REGION_NUM * 2 + CONFIG_ESP32_FLASH_MMU_MAX_MAPPINGS)
+
+static mem_block_t s_mem_block_pool[MMU_BLOCK_POOL_SIZE];
+static bool s_mem_block_used[MMU_BLOCK_POOL_SIZE];
+
+static mem_block_t *s_mem_block_alloc(void)
+{
+    for (int i = 0; i < MMU_BLOCK_POOL_SIZE; i++) {
+        if (!s_mem_block_used[i]) {
+            s_mem_block_used[i] = true;
+            memset(&s_mem_block_pool[i], 0, sizeof(mem_block_t));
+            return &s_mem_block_pool[i];
+        }
+    }
+    ESP_LOGW(TAG, "mmu mapping pool exhausted (%d blocks); increase CONFIG_ESP32_FLASH_MMU_MAX_MAPPINGS",
+             MMU_BLOCK_POOL_SIZE);
+    return NULL;
+}
+
+static void s_mem_block_free(mem_block_t *block)
+{
+    if (block == NULL) {
+        return;
+    }
+    int idx = block - s_mem_block_pool;
+    if (idx >= 0 && idx < MMU_BLOCK_POOL_SIZE) {
+        s_mem_block_used[idx] = false;
+    }
+}
+
 #if ENABLE_PADDR_CHECK
 static bool s_is_enclosed(uint32_t block_start, uint32_t block_end, uint32_t new_block_start, uint32_t new_block_size);
 static bool s_is_overlapped(uint32_t block_start, uint32_t block_end, uint32_t new_block_start, uint32_t new_block_size);
@@ -527,7 +570,7 @@ esp_err_t esp_mmu_map_virt(esp_vaddr_t vaddr_start, esp_paddr_t paddr_start, siz
     mem_region_t *found_region = &s_mmu_ctx.mem_regions[found_region_id];
 
     if (TAILQ_EMPTY(&found_region->mem_block_head)) {
-        dummy_head = (mem_block_t *)heap_caps_calloc(1, sizeof(mem_block_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+        dummy_head = s_mem_block_alloc();
         ESP_GOTO_ON_FALSE(dummy_head, ESP_ERR_NO_MEM, err, TAG, "no mem");
 
         dummy_head->laddr_start = found_region->free_head;
@@ -537,7 +580,7 @@ esp_err_t esp_mmu_map_virt(esp_vaddr_t vaddr_start, esp_paddr_t paddr_start, siz
         dummy_head->caps = caps;
         TAILQ_INSERT_HEAD(&found_region->mem_block_head, dummy_head, entries);
 
-        dummy_tail = (mem_block_t *)heap_caps_calloc(1, sizeof(mem_block_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+        dummy_tail = s_mem_block_alloc();
         ESP_GOTO_ON_FALSE(dummy_tail, ESP_ERR_NO_MEM, err, TAG, "no mem");
 
         dummy_tail->laddr_start = found_region->end;
@@ -593,7 +636,7 @@ esp_err_t esp_mmu_map_virt(esp_vaddr_t vaddr_start, esp_paddr_t paddr_start, siz
     }
 #endif //#if ENABLE_PADDR_CHECK
 
-    new_block = (mem_block_t *)heap_caps_calloc(1, sizeof(mem_block_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    new_block = s_mem_block_alloc();
     ESP_GOTO_ON_FALSE(new_block, ESP_ERR_NO_MEM, err, TAG, "no mem");
 
     //Reserve this block as it'll be mapped
@@ -690,15 +733,15 @@ esp_err_t esp_mmu_map_virt(esp_vaddr_t vaddr_start, esp_paddr_t paddr_start, siz
 
 err:
     if (new_block) {
-        k_free(new_block);
+        s_mem_block_free(new_block);
     }
     if (dummy_tail) {
         TAILQ_REMOVE(&found_region->mem_block_head, dummy_tail, entries);
-        k_free(dummy_tail);
+        s_mem_block_free(dummy_tail);
     }
     if (dummy_head) {
         TAILQ_REMOVE(&found_region->mem_block_head, dummy_head, entries);
-        k_free(dummy_head);
+        s_mem_block_free(dummy_head);
     }
     k_mutex_unlock(&s_mmu_ctx.mutex);
 
@@ -789,7 +832,7 @@ esp_err_t esp_mmu_unmap(void *ptr)
 
     //do unmap
     s_do_unmapping(mem_block->vaddr_start, mem_block->size);
-    k_free(found_block);
+    s_mem_block_free(found_block);
 
     k_mutex_unlock(&s_mmu_ctx.mutex);
 

--- a/components/spi_flash/esp_flash_spi_init.c
+++ b/components/spi_flash/esp_flash_spi_init.c
@@ -5,6 +5,7 @@
  */
 
 #include "sdkconfig.h"
+#include <string.h>
 #include "driver/gpio.h"
 #include "esp_rom_gpio.h"
 #include "esp_rom_efuse.h"
@@ -355,6 +356,43 @@ static void deinit_gpspi_clock(esp_flash_t *chip)
 #endif // !CONFIG_IDF_TARGET_ESP32
 }
 
+/*
+ * Static pool of external-flash device instances, replacing the heap. Each
+ * slot bundles a chip and its host so they are reserved and released together.
+ * spi_bus_add_flash_device is on-demand and bounded by the number of SPI
+ * peripherals, so SOC_SPI_PERIPH_NUM slots are always enough.
+ */
+typedef struct {
+    esp_flash_t chip;
+    memspi_host_inst_t host;
+    bool used;
+} spi_flash_dev_slot_t;
+
+static spi_flash_dev_slot_t s_spi_flash_dev_pool[SOC_SPI_PERIPH_NUM];
+
+static spi_flash_dev_slot_t *s_spi_flash_dev_alloc(void)
+{
+    for (int i = 0; i < SOC_SPI_PERIPH_NUM; i++) {
+        if (!s_spi_flash_dev_pool[i].used) {
+            s_spi_flash_dev_pool[i].used = true;
+            memset(&s_spi_flash_dev_pool[i].chip, 0, sizeof(esp_flash_t));
+            memset(&s_spi_flash_dev_pool[i].host, 0, sizeof(memspi_host_inst_t));
+            return &s_spi_flash_dev_pool[i];
+        }
+    }
+    return NULL;
+}
+
+static void s_spi_flash_dev_free(esp_flash_t *chip)
+{
+    for (int i = 0; i < SOC_SPI_PERIPH_NUM; i++) {
+        if (&s_spi_flash_dev_pool[i].chip == chip) {
+            s_spi_flash_dev_pool[i].used = false;
+            return;
+        }
+    }
+}
+
 esp_err_t spi_bus_add_flash_device(esp_flash_t **out_chip, const esp_flash_spi_device_config_t *config)
 {
     if (out_chip == NULL) {
@@ -367,24 +405,18 @@ esp_err_t spi_bus_add_flash_device(esp_flash_t **out_chip, const esp_flash_spi_d
     memspi_host_inst_t *host = NULL;
     esp_err_t ret = ESP_OK;
 
-    uint32_t caps = MALLOC_CAP_DEFAULT;
-    if (config->host_id == SPI1_HOST) caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
-
-    chip = (esp_flash_t*)heap_caps_malloc(sizeof(esp_flash_t), caps);
-    if (!chip) {
+    spi_flash_dev_slot_t *slot = s_spi_flash_dev_alloc();
+    if (!slot) {
         ret = ESP_ERR_NO_MEM;
         goto fail;
     }
 
-    host = (memspi_host_inst_t*)heap_caps_malloc(sizeof(memspi_host_inst_t), caps);
+    chip = &slot->chip;
+    host = &slot->host;
     *chip = (esp_flash_t) {
         .read_mode = config->io_mode,
         .host = (spi_flash_host_inst_t*)host,
     };
-    if (!host) {
-        ret = ESP_ERR_NO_MEM;
-        goto fail;
-    }
 
     int dev_id;
     spi_bus_lock_dev_handle_t dev_handle;
@@ -444,8 +476,7 @@ esp_err_t spi_bus_remove_flash_device(esp_flash_t *chip)
     if (dev_handle) {
         spi_bus_lock_unregister_dev(dev_handle);
     }
-    free(chip->host);
-    free(chip);
+    s_spi_flash_dev_free(chip);
     return ESP_OK;
 }
 

--- a/components/spi_flash/flash_mmap.c
+++ b/components/spi_flash/flash_mmap.c
@@ -55,10 +55,51 @@ extern char _rodata_reserved_end;
 /* 0x1000000, 16MB */
 #define FLASH_MMAP_ADDR_24BIT_MAX  (BIT(24))
 
+#ifndef CONFIG_ESP32_FLASH_MMU_MAX_MAPPINGS
+#define CONFIG_ESP32_FLASH_MMU_MAX_MAPPINGS 8
+#endif
+
+#define MMAP_BLOCK_POOL_SIZE CONFIG_ESP32_FLASH_MMU_MAX_MAPPINGS
+
 typedef struct mmap_block_t {
     uint32_t *vaddr_list;
     int list_num;
+    uint32_t vaddr_storage[MMAP_BLOCK_POOL_SIZE];
 } mmap_block_t;
+
+/*
+ * Static pools replacing the heap allocations. The vaddr list is embedded in
+ * each block (one entry per concurrent mmu mapping). The paddr scratch is only
+ * used transiently inside spi_flash_mmap_pages and never escapes the call.
+ */
+static mmap_block_t s_mmap_block_pool[MMAP_BLOCK_POOL_SIZE];
+static bool s_mmap_block_used[MMAP_BLOCK_POOL_SIZE];
+static int s_mmap_paddr_scratch[MMAP_BLOCK_POOL_SIZE][2];
+
+static mmap_block_t *s_mmap_block_alloc(void)
+{
+    for (int i = 0; i < MMAP_BLOCK_POOL_SIZE; i++) {
+        if (!s_mmap_block_used[i]) {
+            s_mmap_block_used[i] = true;
+            memset(&s_mmap_block_pool[i], 0, sizeof(mmap_block_t));
+            return &s_mmap_block_pool[i];
+        }
+    }
+    ESP_LOGW("flash_mmap", "mmap handle pool exhausted (%d); increase CONFIG_ESP32_FLASH_MMU_MAX_MAPPINGS",
+             MMAP_BLOCK_POOL_SIZE);
+    return NULL;
+}
+
+static void s_mmap_block_free(mmap_block_t *block)
+{
+    if (block == NULL) {
+        return;
+    }
+    int idx = block - s_mmap_block_pool;
+    if (idx >= 0 && idx < MMAP_BLOCK_POOL_SIZE) {
+        s_mmap_block_used[idx] = false;
+    }
+}
 
 
 esp_err_t spi_flash_mmap(size_t src_addr, size_t size, spi_flash_mmap_memory_t memory,
@@ -76,18 +117,13 @@ esp_err_t spi_flash_mmap(size_t src_addr, size_t size, spi_flash_mmap_memory_t m
     mmap_block_t *block = NULL;
     uint32_t *vaddr_list = NULL;
 
-    block = heap_caps_calloc(1, sizeof(mmap_block_t), MALLOC_CAP_INTERNAL);
+    block = s_mmap_block_alloc();
     if (!block) {
         ret = ESP_ERR_NO_MEM;
         goto err;
     }
 
-    vaddr_list = heap_caps_calloc(1, 1 * sizeof(uint32_t), MALLOC_CAP_INTERNAL);
-    if (!vaddr_list) {
-        ret = ESP_ERR_NO_MEM;
-        goto err;
-    }
-
+    vaddr_list = block->vaddr_storage;
     block->vaddr_list = vaddr_list;
 
     if (memory == SPI_FLASH_MMAP_INST) {
@@ -118,11 +154,8 @@ esp_err_t spi_flash_mmap(size_t src_addr, size_t size, spi_flash_mmap_memory_t m
     return ESP_OK;
 
 err:
-    if (vaddr_list) {
-        k_free(vaddr_list);
-    }
     if (block) {
-        k_free(block);
+        s_mmap_block_free(block);
     }
     return ret;
 }
@@ -191,24 +224,22 @@ esp_err_t spi_flash_mmap_pages(const int *pages, size_t page_count, spi_flash_mm
     int successful_cnt = 0;
 
     int block_num = s_find_non_contiguous_block_nums(pages, page_count);
-    int (*paddr_blocks)[2] = k_calloc(block_num, sizeof(int[2]));
-    if (!paddr_blocks) {
+    if (block_num > MMAP_BLOCK_POOL_SIZE) {
+        ESP_LOGW("flash_mmap", "need %d mmap blocks but pool is %d; increase CONFIG_ESP32_FLASH_MMU_MAX_MAPPINGS",
+                 block_num, MMAP_BLOCK_POOL_SIZE);
         return ESP_ERR_NO_MEM;
     }
+    int (*paddr_blocks)[2] = s_mmap_paddr_scratch;
     s_merge_contiguous_pages(pages, page_count, block_num, paddr_blocks);
     s_pages_to_bytes(paddr_blocks, block_num);
 
-    block = heap_caps_calloc(1, sizeof(mmap_block_t), MALLOC_CAP_INTERNAL);
+    block = s_mmap_block_alloc();
     if (!block) {
         ret = ESP_ERR_NO_MEM;
         goto err;
     }
 
-    vaddr_list = heap_caps_calloc(1, block_num * sizeof(uint32_t), MALLOC_CAP_INTERNAL);
-    if (!vaddr_list) {
-        ret = ESP_ERR_NO_MEM;
-        goto err;
-    }
+    vaddr_list = block->vaddr_storage;
 
     if (memory == SPI_FLASH_MMAP_INST) {
         caps = MMU_MEM_CAP_EXEC | MMU_MEM_CAP_32BIT;
@@ -242,20 +273,15 @@ esp_err_t spi_flash_mmap_pages(const int *pages, size_t page_count, spi_flash_mm
     *out_ptr = (void *)vaddr_list[0];
     *out_handle = (uint32_t)block;
 
-    k_free(paddr_blocks);
     return ESP_OK;
 
 err:
     for (int i = 0; i < successful_cnt; i++) {
         esp_mmu_unmap((void *)vaddr_list[i]);
     }
-    if (vaddr_list) {
-        k_free(vaddr_list);
-    }
     if (block) {
-        k_free(block);
+        s_mmap_block_free(block);
     }
-    k_free(paddr_blocks);
     return ret;
 }
 
@@ -272,8 +298,7 @@ void spi_flash_munmap(spi_flash_mmap_handle_t handle)
         }
     }
 
-    k_free(block->vaddr_list);
-    k_free(block);
+    s_mmap_block_free(block);
 }
 
 

--- a/components/spi_flash/spi_flash_os_func_app.c
+++ b/components/spi_flash/spi_flash_os_func_app.c
@@ -35,6 +35,21 @@ K_MUTEX_DEFINE(s_spi1_flash_mutex);
 #endif  //  #if SPI_FLASH_CACHE_NO_DISABLE
 
 /*
+ * Bounce buffer used when reading into a destination that the flash host
+ * cannot reach directly (e.g. PSRAM). The read is chunked through this
+ * internal-RAM buffer instead of allocating one from the heap, so the SPI
+ * flash path has no runtime heap dependency. The chunk size trades RAM for
+ * the number of read iterations.
+ */
+#ifndef CONFIG_ESP32_FLASH_BOUNCE_BUFFER_SIZE
+#define CONFIG_ESP32_FLASH_BOUNCE_BUFFER_SIZE 256
+#endif
+static uint8_t s_flash_bounce_buf[CONFIG_ESP32_FLASH_BOUNCE_BUFFER_SIZE]
+	__attribute__((aligned(4)));
+
+K_MUTEX_DEFINE(s_flash_bounce_mutex);
+
+/*
  * OS functions providing delay service and arbitration among chips, and with the cache.
  *
  * The cache needs to be disabled when chips on the SPI1 bus is under operation, hence these functions need to be put
@@ -64,6 +79,31 @@ static inline void on_spi_released(app_func_arg_t* ctx);
 static inline void on_spi_acquired(app_func_arg_t* ctx);
 static inline void on_spi_yielded(app_func_arg_t* ctx);
 static inline bool on_spi_check_yield(app_func_arg_t* ctx);
+
+/* Static pool of per-chip OS function contexts (one per SPI flash host). */
+static app_func_arg_t s_os_func_data[SOC_SPI_PERIPH_NUM];
+static bool s_os_func_data_used[SOC_SPI_PERIPH_NUM];
+
+static app_func_arg_t *alloc_os_func_data(void)
+{
+    for (int i = 0; i < SOC_SPI_PERIPH_NUM; i++) {
+        if (!s_os_func_data_used[i]) {
+            s_os_func_data_used[i] = true;
+            return &s_os_func_data[i];
+        }
+    }
+    return NULL;
+}
+
+static void free_os_func_data(void *data)
+{
+    for (int i = 0; i < SOC_SPI_PERIPH_NUM; i++) {
+        if (&s_os_func_data[i] == data) {
+            s_os_func_data_used[i] = false;
+            return;
+        }
+    }
+}
 
 #if !SPI_FLASH_CACHE_NO_DISABLE
 IRAM_ATTR static void cache_enable(void* arg)
@@ -212,30 +252,23 @@ static esp_err_t delay_us(void *arg, uint32_t us)
 
 static void* get_buffer_malloc(void* arg, size_t reqest_size, size_t* out_size)
 {
-    /* Allocate temporary internal buffer for the actual read. If the preferred
-     * size doesn't fit in free memory, halve the request and retry so we
-     * degrade gracefully under memory pressure instead of failing outright.
-     * Zephyr's libc heap doesn't expose a "largest free block" query, so we
-     * use exponential backoff down to a minimum of 64 bytes.
+    /* Hand out the static internal-RAM bounce buffer. The read is chunked to
+     * its size, so larger reads simply take more iterations. The mutex
+     * serializes concurrent flash reads that need a bounce buffer.
      */
-    void* ret = NULL;
-    size_t read_chunk_size = (reqest_size + 3) & ~3;
+    (void)arg;
+    k_mutex_lock(&s_flash_bounce_mutex, K_FOREVER);
 
-    while (ret == NULL && read_chunk_size >= 64) {
-        ret = k_malloc(read_chunk_size);
-        if (ret == NULL) {
-            read_chunk_size = (read_chunk_size / 2) & ~3;
-        }
-    }
-
-    ESP_LOGV(TAG, "allocate temp buffer: %p (%d)", ret, read_chunk_size);
-    *out_size = (ret != NULL ? read_chunk_size : 0);
-    return ret;
+    *out_size = MIN(reqest_size & ~3, sizeof(s_flash_bounce_buf));
+    ESP_LOGV(TAG, "using static bounce buffer: %p (%d)", s_flash_bounce_buf, *out_size);
+    return s_flash_bounce_buf;
 }
 
 static void release_buffer_malloc(void* arg, void *temp_buf)
 {
-    k_free(temp_buf);
+    (void)arg;
+    (void)temp_buf;
+    k_mutex_unlock(&s_flash_bounce_mutex);
 }
 
 #ifndef __ZEPHYR__
@@ -326,7 +359,7 @@ esp_err_t esp_flash_init_os_functions(esp_flash_t *chip, int host_id, spi_bus_lo
         return ESP_ERR_INVALID_ARG;
     }
 
-    chip->os_func_data = k_malloc(sizeof(app_func_arg_t));
+    chip->os_func_data = alloc_os_func_data();
     if (chip->os_func_data == NULL) {
         return ESP_ERR_NO_MEM;
     }
@@ -361,7 +394,7 @@ esp_err_t esp_flash_deinit_os_functions(esp_flash_t* chip, spi_bus_lock_dev_hand
     if (chip->os_func_data) {
         // SPI bus lock is possibly not used on SPI1 bus
         *out_dev_handle = ((app_func_arg_t*)chip->os_func_data)->dev_lock;
-        k_free(chip->os_func_data);
+        free_os_func_data(chip->os_func_data);
     }
     chip->os_func = NULL;
     chip->os_func_data = NULL;


### PR DESCRIPTION
Convert the boot and driver-reachable allocations in the flash mmap, MMU mapping, SPI flash init, temperature sensor and ADC calibration paths from k_malloc/heap_caps to static storage. The MMU and flash mmap managers use fixed pools sized by config, the SPI flash device and temperature sensor use single static instances, and the ADC calibration schemes are carved from caller-owned storage. This lets a default build run without a system heap.