### PR TITLE
hal: fix misc sync souces

### DIFF
--- a/components/efuse/esp32/esp_efuse_table.c
+++ b/components/efuse/esp32/esp_efuse_table.c
@@ -15,7 +15,7 @@
 // then run `efuse_common_table` or `efuse_custom_table` command it will generate this file.
 // To show efuse_table run the command 'show_efuse_table'.
 
-#define MAX_BLK_LEN 256
+#define MAX_BLK_LEN CONFIG_ESP32_EFUSE_MAX_BLK_LEN
 
 // The last free bit in the block is counted over the entire file.
 #define LAST_FREE_BIT_BLK1 MAX_BLK_LEN

--- a/components/esp_hal_pmu/include/hal/pmu_types.h
+++ b/components/esp_hal_pmu/include/hal/pmu_types.h
@@ -55,6 +55,15 @@ typedef enum {
     PMU_HP_PD_HPMEM = 2,
     PMU_HP_PD_CPU = 3,
 } pmu_hp_power_domain_t;
+#elif SOC_IS(ESP32S31)
+typedef enum {
+    PMU_HP_PD_TOP = 0,      /*!< Power domain of digital top */
+    PMU_HP_PD_HPALIVE,
+    PMU_HP_PD_MODEMPWR,
+    PMU_HP_PD_HPCPU,
+    PMU_HP_PD_HPCNNT,
+    PMU_HP_PD_MODEM
+} pmu_hp_power_domain_t;
 #else
 typedef enum {
     PMU_HP_PD_TOP = 0,      /*!< Power domain of digital top */

--- a/components/esp_hal_twai/include/hal/twai_hal.h
+++ b/components/esp_hal_twai/include/hal/twai_hal.h
@@ -281,7 +281,9 @@ twai_error_state_t twai_hal_get_err_state(twai_hal_context_t *hal_ctx);
 __attribute__((always_inline))
 static inline twai_error_flags_t twai_hal_get_err_flags(twai_hal_context_t *hal_ctx)
 {
-    return hal_ctx->errors;
+    twai_error_flags_t error_flags = hal_ctx->errors;
+    hal_ctx->errors.val = 0;    // clear ctx for next errors
+    return error_flags;
 }
 
 /* ------------------------------- TX and RX -------------------------------- */

--- a/components/esp_timer/src/esp_timer_impl_lac.c
+++ b/components/esp_timer/src/esp_timer_impl_lac.c
@@ -254,7 +254,12 @@ esp_err_t esp_timer_impl_init(intr_handler_t alarm_handler)
         return ESP_ERR_INVALID_STATE;
     }
 
-    int isr_flags = 0;
+    int isr_flags = ESP_INTR_FLAG_INTRDISABLED
+                    | ((1 << CONFIG_ESP_TIMER_INTERRUPT_LEVEL) & ESP_INTR_FLAG_LEVELMASK)
+#if CONFIG_ESP_TIMER_IN_IRAM
+                    | ESP_INTR_FLAG_IRAM
+#endif
+                    ;
 
     esp_err_t err = esp_intr_alloc(INTR_SOURCE_LACT, isr_flags,
                                    &timer_alarm_isr, NULL,


### PR DESCRIPTION
New sources present in esp-idf were removed during sync and should be restored.
