### PR TITLE
soc: espressif: always build custom bootloader_clock_configure

### DIFF
--- a/zephyr/esp32/src/soc_init.c
+++ b/zephyr/esp32/src/soc_init.c
@@ -128,7 +128,6 @@ void ana_clock_glitch_reset_config(bool enable)
 	(void)enable;
 }
 
-#if defined(CONFIG_ESP_SIMPLE_BOOT)
 #include "soc/rtc.h"
 #include "soc/rtc_cntl_reg.h"
 #include "hal/regi2c_ctrl_ll.h"
@@ -168,4 +167,3 @@ void bootloader_clock_configure(void)
 	REG_WRITE(RTC_CNTL_INT_ENA_REG, 0);
 	REG_WRITE(RTC_CNTL_INT_CLR_REG, UINT32_MAX);
 }
-#endif /* CONFIG_ESP_SIMPLE_BOOT */

--- a/zephyr/esp32c2/src/soc_init.c
+++ b/zephyr/esp32c2/src/soc_init.c
@@ -84,7 +84,6 @@ void ana_clock_glitch_reset_config(bool enable)
 	(void)enable;
 }
 
-#if defined(CONFIG_ESP_SIMPLE_BOOT)
 #include "soc/soc.h"
 #include "soc/rtc.h"
 #include "soc/rtc_cntl_reg.h"
@@ -148,5 +147,4 @@ void bootloader_clock_configure(void)
 	REG_WRITE(RTC_CNTL_INT_ENA_REG, 0);
 	REG_WRITE(RTC_CNTL_INT_CLR_REG, UINT32_MAX);
 }
-#endif /* CONFIG_ESP_SIMPLE_BOOT */
 

--- a/zephyr/esp32c3/src/soc_init.c
+++ b/zephyr/esp32c3/src/soc_init.c
@@ -122,7 +122,6 @@ void check_wdt_reset(void)
 	wdt_reset_cpu0_info_enable();
 }
 
-#if defined(CONFIG_ESP_SIMPLE_BOOT)
 #include "soc/rtc.h"
 #include "soc/rtc_cntl_reg.h"
 #include "hal/regi2c_ctrl_ll.h"
@@ -160,4 +159,3 @@ void bootloader_clock_configure(void)
 	REG_WRITE(RTC_CNTL_INT_ENA_REG, 0);
 	REG_WRITE(RTC_CNTL_INT_CLR_REG, UINT32_MAX);
 }
-#endif /* CONFIG_ESP_SIMPLE_BOOT */

--- a/zephyr/esp32c5/src/soc_init.c
+++ b/zephyr/esp32c5/src/soc_init.c
@@ -123,7 +123,6 @@ void ana_clock_glitch_reset_config(bool enable)
 	(void)enable;
 }
 
-#if defined(CONFIG_ESP_SIMPLE_BOOT)
 #include "soc/pmu_reg.h"
 #include "soc/rtc.h"
 #include "soc/lp_clkrst_reg.h"
@@ -134,10 +133,14 @@ void ana_clock_glitch_reset_config(bool enable)
 #include "pmu_param.h"
 
 /*
- * Custom bootloader_clock_configure() for ESP32-C5 simple boot mode.
+ * Custom bootloader_clock_configure() for the ESP32-C5 bootloader stage.
  *
- * In simple boot mode, we enable PLL and switch CPU clock source so that
- * flash can run at higher speeds. The ROM bootloader leaves CPU on XTAL.
+ * The bootloader (simple boot or MCUboot) enables PLL and switches the CPU
+ * clock source so that flash can run at higher speeds. The ROM bootloader
+ * leaves the CPU on XTAL. The default weak bootloader_clock_configure()
+ * skips this on a software reset, which would leave the BBPLL un-brought-up
+ * and hang the application clock driver's REGI2C re-calibration; this
+ * override always brings the PLL up so a software reboot recovers cleanly.
  *
  * Cannot use rtc_clk_init() or REGI2C_WRITE/REGI2C_WRITE_MASK here
  * because without BOOTLOADER_BUILD they go through
@@ -276,4 +279,3 @@ void bootloader_clock_configure(void)
 	SET_PERI_REG_MASK(PMU_HP_INT_CLR_REG, PMU_SOC_WAKEUP_INT_CLR);
 	SET_PERI_REG_MASK(PMU_HP_INT_CLR_REG, PMU_SOC_SLEEP_REJECT_INT_CLR);
 }
-#endif /* CONFIG_ESP_SIMPLE_BOOT */

--- a/zephyr/esp32c6/src/soc_init.c
+++ b/zephyr/esp32c6/src/soc_init.c
@@ -117,7 +117,6 @@ void ana_clock_glitch_reset_config(bool enable)
 	(void)enable;
 }
 
-#if defined(CONFIG_ESP_SIMPLE_BOOT)
 #include "soc/pmu_reg.h"
 #include "soc/lp_clkrst_reg.h"
 #include "soc/regi2c_dig_reg.h"
@@ -131,11 +130,17 @@ void ana_clock_glitch_reset_config(bool enable)
 #include "pmu_param.h"
 
 /*
- * Custom bootloader_clock_configure() for ESP32-C6 simple boot mode.
+ * Custom bootloader_clock_configure() for ESP32-C6 bootloader stage.
  *
- * In simple boot mode, we need to enable PLL and switch CPU clock source
- * so that flash can run at 80MHz (requires 480MHz PLL with divider 6).
- * The ROM bootloader leaves CPU running on XTAL (40MHz).
+ * The bootloader (simple boot or MCUboot) must enable PLL and switch the
+ * CPU clock source so flash can run at 80MHz (requires 480MHz PLL with
+ * divider 6). The ROM bootloader leaves the CPU running on XTAL (40MHz).
+ *
+ * The default weak bootloader_clock_configure() skips this on a software
+ * reset (RESET_REASON_CPU0_SW), which would leave the CPU on XTAL with the
+ * BBPLL not brought up. The application clock driver would then try to
+ * re-calibrate the BBPLL over REGI2C and hang. This override always brings
+ * the PLL up, so a software reboot recovers cleanly.
  */
 void bootloader_clock_configure(void)
 {
@@ -214,4 +219,3 @@ void bootloader_clock_configure(void)
 	SET_PERI_REG_MASK(LP_ANALOG_PERI_LP_ANA_LP_INT_CLR_REG, LP_ANALOG_PERI_LP_ANA_BOD_MODE0_LP_INT_CLR);
 	SET_PERI_REG_MASK(LP_WDT_INT_CLR_REG, LP_WDT_LP_WDT_INT_CLR);
 }
-#endif /* CONFIG_ESP_SIMPLE_BOOT */

--- a/zephyr/esp32h2/src/soc_init.c
+++ b/zephyr/esp32h2/src/soc_init.c
@@ -104,7 +104,6 @@ void ana_clock_glitch_reset_config(bool enable)
 	(void)enable;
 }
 
-#if defined(CONFIG_ESP_SIMPLE_BOOT)
 #include "soc/rtc.h"
 #include "soc/lp_clkrst_reg.h"
 #include "soc/regi2c_pmu.h"
@@ -112,6 +111,15 @@ void ana_clock_glitch_reset_config(bool enable)
 #include "modem/modem_lpcon_struct.h"
 #include "pmu_param.h"
 
+/*
+ * Custom bootloader_clock_configure() for the ESP32-H2 bootloader stage.
+ *
+ * The bootloader (simple boot or MCUboot) brings up the PLL and switches
+ * the CPU clock source. The default weak bootloader_clock_configure() skips
+ * this on a software reset, which would leave the BBPLL un-brought-up and
+ * hang the application clock driver's REGI2C re-calibration; this override
+ * always brings the PLL up so a software reboot recovers cleanly.
+ */
 void bootloader_clock_configure(void)
 {
 	esp_rom_output_tx_wait_idle(0);
@@ -184,4 +192,3 @@ void bootloader_clock_configure(void)
 	SET_PERI_REG_MASK(PMU_HP_INT_CLR_REG, PMU_SOC_WAKEUP_INT_CLR);
 	SET_PERI_REG_MASK(PMU_HP_INT_CLR_REG, PMU_SOC_SLEEP_REJECT_INT_CLR);
 }
-#endif /* CONFIG_ESP_SIMPLE_BOOT */

--- a/zephyr/esp32p4/src/soc_init.c
+++ b/zephyr/esp32p4/src/soc_init.c
@@ -86,7 +86,6 @@ void ana_clock_glitch_reset_config(bool enable)
 	(void)enable;
 }
 
-#if defined(CONFIG_ESP_SIMPLE_BOOT) || defined(CONFIG_MCUBOOT)
 #include "soc/pmu_reg.h"
 #include "soc/lp_system_reg.h"
 #include "soc/chip_revision.h"
@@ -189,7 +188,6 @@ void bootloader_clock_configure(void)
 	SET_PERI_REG_MASK(LP_WDT_INT_CLR_REG, LP_WDT_SUPER_WDT_INT_CLR);
 	SET_PERI_REG_MASK(LP_WDT_INT_CLR_REG, LP_WDT_LP_WDT_INT_CLR);
 }
-#endif /* CONFIG_ESP_SIMPLE_BOOT || CONFIG_MCUBOOT */
 
 #include "esp_sleep.h"
 __attribute__((weak)) esp_err_t esp_sleep_pd_config(esp_sleep_pd_domain_t domain,

--- a/zephyr/esp32s2/src/soc_init.c
+++ b/zephyr/esp32s2/src/soc_init.c
@@ -102,7 +102,6 @@ void ana_clock_glitch_reset_config(bool enable)
 	(void)enable;
 }
 
-#if defined(CONFIG_ESP_SIMPLE_BOOT)
 #include "soc/rtc.h"
 #include "hal/regi2c_ctrl_ll.h"
 #include "hal/clk_tree_ll.h"
@@ -144,4 +143,3 @@ void bootloader_clock_configure(void)
 	REG_WRITE(RTC_CNTL_INT_ENA_REG, 0);
 	REG_WRITE(RTC_CNTL_INT_CLR_REG, UINT32_MAX);
 }
-#endif /* CONFIG_ESP_SIMPLE_BOOT */

--- a/zephyr/esp32s3/src/soc_init.c
+++ b/zephyr/esp32s3/src/soc_init.c
@@ -126,7 +126,6 @@ void check_wdt_reset(void)
 	wdt_reset_cpu0_info_enable();
 }
 
-#if defined(CONFIG_ESP_SIMPLE_BOOT)
 #include "soc/rtc.h"
 #include "hal/regi2c_ctrl_ll.h"
 #include "hal/clk_tree_ll.h"
@@ -167,4 +166,3 @@ void bootloader_clock_configure(void)
 	REG_WRITE(RTC_CNTL_INT_ENA_REG, 0);
 	REG_WRITE(RTC_CNTL_INT_CLR_REG, UINT32_MAX);
 }
-#endif /* CONFIG_ESP_SIMPLE_BOOT */


### PR DESCRIPTION
Compile the custom bootloader_clock_configure for every image so it overrides the weak default, fixing a software-reboot hang on mcuboot.