### PR TITLE
pm: hal: Port esp_pm_lock API for Zephyr

### DIFF
--- a/components/esp_wifi/src/wifi_init.c
+++ b/components/esp_wifi/src/wifi_init.c
@@ -5,8 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/pm/policy.h>
-#include "esp_private/critical_section.h"
 
 #include <esp_event.h>
 #include <esp_wifi.h>
@@ -48,8 +46,7 @@
 static bool s_wifi_inited = false;
 
 #ifdef CONFIG_PM
-DEFINE_CRIT_SECTION_LOCK_STATIC(s_pm_lock);
-static uint32_t s_pm_lock_refcnt;
+static esp_pm_lock_handle_t s_wifi_modem_sleep_lock;
 #endif
 
 #if (CONFIG_ESP_WIFI_RX_BA_WIN > CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM)
@@ -110,26 +107,6 @@ wifi_mac_time_update_cb_t s_wifi_mac_time_update_cb = NULL;
 }
 
 static const char *TAG = "wifi_init";
-
-#if CONFIG_PM
-static void esp_wifi_pm_policy_state_lock_get(void)
-{
-    esp_os_enter_critical(&s_pm_lock);
-    if (s_pm_lock_refcnt++ == 0) {
-        pm_policy_state_all_lock_get();
-    }
-    esp_os_exit_critical(&s_pm_lock);
-}
-
-static void esp_wifi_pm_policy_state_lock_put(void)
-{
-    esp_os_enter_critical(&s_pm_lock);
-    if (s_pm_lock_refcnt > 0 && --s_pm_lock_refcnt == 0) {
-        pm_policy_state_all_lock_put();
-    }
-    esp_os_exit_critical(&s_pm_lock);
-}
-#endif
 
 static void esp_wifi_set_log_level(void)
 {
@@ -247,6 +224,12 @@ static esp_err_t wifi_deinit_internal(void)
         ESP_LOGE(TAG, "Failed to deinit Wi-Fi driver (0x%x)", err);
         return err;
     }
+#ifdef CONFIG_PM
+    if (s_wifi_modem_sleep_lock) {
+        esp_pm_lock_delete(s_wifi_modem_sleep_lock);
+        s_wifi_modem_sleep_lock = NULL;
+    }
+#endif
 
 #ifdef CONFIG_ESP_PHY_ENABLED
     esp_wifi_power_domain_off();
@@ -481,6 +464,17 @@ esp_err_t esp_wifi_init(const wifi_init_config_t *config)
         s_wifi_mac_time_update_cb = esp_wifi_internal_update_mac_time;
 #endif
 
+#ifdef CONFIG_PM
+        if (s_wifi_modem_sleep_lock == NULL) {
+            result = esp_pm_lock_create(ESP_PM_APB_FREQ_MAX, 0, "wifi",
+                                        &s_wifi_modem_sleep_lock);
+            if (result != ESP_OK) {
+                ESP_LOGE(TAG, "Failed to create pm lock (0x%x)", result);
+                goto _deinit;
+            }
+        }
+#endif
+
         result = esp_supplicant_init();
         if (result != ESP_OK) {
             ESP_LOGE(TAG, "Failed to init supplicant (0x%x)", result);
@@ -551,12 +545,14 @@ esp_err_t esp_wifi_disconnect(void)
 #ifdef CONFIG_PM
 void wifi_apb80m_request(void)
 {
-    esp_wifi_pm_policy_state_lock_get();
+    assert(s_wifi_modem_sleep_lock);
+    esp_pm_lock_acquire(s_wifi_modem_sleep_lock);
 }
 
 void wifi_apb80m_release(void)
 {
-    esp_wifi_pm_policy_state_lock_put();
+    assert(s_wifi_modem_sleep_lock);
+    esp_pm_lock_release(s_wifi_modem_sleep_lock);
 }
 #endif
 

--- a/zephyr/common/pm_impl_zephyr.c
+++ b/zephyr/common/pm_impl_zephyr.c
@@ -9,9 +9,33 @@
  * These stubs are needed when pm_impl.c is not compiled (it requires FreeRTOS).
  */
 
+#include <zephyr/pm/policy.h>
+#include "esp_pm.h"
 #include "esp_private/pm_impl.h"
 #include "soc/rtc.h"
 #include "soc/soc_caps.h"
+
+esp_err_t esp_pm_get_configuration(void *vconfig)
+{
+    if (vconfig == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    esp_pm_config_t *config = (esp_pm_config_t *)vconfig;
+    rtc_cpu_freq_config_t freq_config;
+
+    rtc_clk_cpu_freq_get_config(&freq_config);
+
+    config->max_freq_mhz = freq_config.freq_mhz;
+    config->min_freq_mhz = freq_config.freq_mhz;
+#if CONFIG_PM
+    config->light_sleep_enable = true;
+#else
+    config->light_sleep_enable = false;
+#endif
+
+    return ESP_OK;
+}
 
 int esp_pm_impl_get_cpu_freq(pm_mode_t mode)
 {
@@ -19,6 +43,40 @@ int esp_pm_impl_get_cpu_freq(pm_mode_t mode)
     rtc_cpu_freq_config_t config;
     rtc_clk_cpu_freq_get_config(&config);
     return config.freq_mhz;
+}
+
+pm_mode_t esp_pm_impl_get_mode(esp_pm_lock_type_t type, int arg)
+{
+    (void)arg;
+
+    switch (type) {
+    case ESP_PM_CPU_FREQ_MAX:
+        return PM_MODE_CPU_MAX;
+    case ESP_PM_APB_FREQ_MAX:
+        return PM_MODE_APB_MAX;
+    case ESP_PM_NO_LIGHT_SLEEP:
+        return PM_MODE_LIGHT_SLEEP;
+    default:
+        return PM_MODE_COUNT;
+    }
+}
+
+void esp_pm_impl_switch_mode(pm_mode_t mode, pm_mode_switch_t lock_or_unlock, pm_time_t now)
+{
+    (void)mode;
+    (void)now;
+
+    /*
+     * This function is kept in this file (not pm_locks_zephyr.c) to allow PM
+     * policy to expand when we port IDF pm_impl: track locks per power mode,
+     * pick the lowest allowed mode, then change CPU/APB clocks or sleep
+     * policy — WiFi/BLE keep calling esp_pm_lock_* only.
+     */
+    if (lock_or_unlock == MODE_LOCK) {
+        pm_policy_state_all_lock_get();
+    } else {
+        pm_policy_state_all_lock_put();
+    }
 }
 
 #if SOC_VBAT_SUPPORTED

--- a/zephyr/common/pm_locks_zephyr.c
+++ b/zephyr/common/pm_locks_zephyr.c
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdlib.h>
+#include <zephyr/kernel.h>
+
+#include "esp_pm.h"
+#include "esp_attr.h"
+#include "esp_private/pm_impl.h"
+
+
+typedef struct esp_pm_lock {
+    esp_pm_lock_type_t type;
+    int arg;
+    pm_mode_t mode;
+    const char *name;
+    size_t count;
+    struct k_spinlock spinlock;
+} esp_pm_lock_t;
+
+
+esp_err_t esp_pm_lock_create(esp_pm_lock_type_t lock_type, int arg,
+                             const char *name, esp_pm_lock_handle_t *out_handle)
+{
+#ifndef CONFIG_PM
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+
+    if (out_handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    esp_pm_lock_t *new_lock = (esp_pm_lock_t *)calloc(1, sizeof(*new_lock));
+
+    if (!new_lock) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    new_lock->type = lock_type;
+    new_lock->arg = arg;
+    new_lock->mode = esp_pm_impl_get_mode(lock_type, arg);
+    new_lock->name = name;
+    *out_handle = new_lock;
+
+    return ESP_OK;
+}
+
+esp_err_t esp_pm_lock_delete(esp_pm_lock_handle_t handle)
+{
+#ifndef CONFIG_PM
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (handle->count > 0) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    free(handle);
+
+    return ESP_OK;
+}
+
+esp_err_t IRAM_ATTR esp_pm_lock_acquire(esp_pm_lock_handle_t handle)
+{
+#ifndef CONFIG_PM
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    k_spinlock_key_t key = k_spin_lock(&handle->spinlock);
+
+    if (handle->count++ == 0) {
+        esp_pm_impl_switch_mode(handle->mode, MODE_LOCK, 0);
+    }
+
+    k_spin_unlock(&handle->spinlock, key);
+
+    return ESP_OK;
+}
+
+esp_err_t IRAM_ATTR esp_pm_lock_release(esp_pm_lock_handle_t handle)
+{
+#ifndef CONFIG_PM
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    k_spinlock_key_t key = k_spin_lock(&handle->spinlock);
+
+    if (handle->count == 0) {
+        k_spin_unlock(&handle->spinlock, key);
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (--handle->count == 0) {
+        esp_pm_impl_switch_mode(handle->mode, MODE_UNLOCK, 0);
+    }
+
+    k_spin_unlock(&handle->spinlock, key);
+
+    return ESP_OK;
+}

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -289,6 +289,8 @@ if(CONFIG_SOC_SERIES_ESP32)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+      ../common/pm_impl_zephyr.c
+      ../common/pm_locks_zephyr.c
       ../../components/esp_hw_support/sleep_gpio.c
       ../../components/esp_hw_support/sleep_event.c
       ../../components/esp_driver_gpio/src/gpio.c

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -218,6 +218,8 @@ if(CONFIG_SOC_SERIES_ESP32C2)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+    ../common/pm_impl_zephyr.c
+    ../common/pm_locks_zephyr.c
     ../../components/esp_hw_support/sleep_gpio.c
     ../../components/esp_hw_support/sleep_event.c
     ../../components/esp_driver_gpio/src/gpio.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -256,6 +256,8 @@ if(CONFIG_SOC_SERIES_ESP32C3)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+      ../common/pm_impl_zephyr.c
+      ../common/pm_locks_zephyr.c
       ../../components/esp_hw_support/sleep_gpio.c
       ../../components/esp_hw_support/sleep_event.c
       ../../components/esp_hw_support/sleep_console.c

--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -260,6 +260,8 @@ if(CONFIG_SOC_SERIES_ESP32C5)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
   zephyr_sources(
+    ../common/pm_impl_zephyr.c
+    ../common/pm_locks_zephyr.c
     ../../components/esp_driver_gpio/src/gpio.c
     ../../components/esp_driver_gpio/src/rtc_io.c
     ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_sleep.c
@@ -281,7 +283,6 @@ if(CONFIG_SOC_SERIES_ESP32C5)
     ../../components/esp_hw_support/clk_utils.c
     ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_modem_state.c
     ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/peripheral_domain_pd.c
-    ../common/pm_impl_zephyr.c
     )
 
     if(CONFIG_ESP32_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP)

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -259,6 +259,8 @@ if(CONFIG_SOC_SERIES_ESP32C6)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+      ../common/pm_impl_zephyr.c
+      ../common/pm_locks_zephyr.c
       ../../components/esp_driver_gpio/src/gpio.c
       ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_sleep.c
       ../../components/esp_hw_support/port/pau_regdma.c
@@ -279,7 +281,6 @@ if(CONFIG_SOC_SERIES_ESP32C6)
       ../../components/esp_hw_support/clk_utils.c
       ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_modem_state.c
       ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/peripheral_domain_pd.c
-      ../common/pm_impl_zephyr.c
       )
 
     if(CONFIG_ESP32_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP)

--- a/zephyr/esp32h2/CMakeLists.txt
+++ b/zephyr/esp32h2/CMakeLists.txt
@@ -429,6 +429,8 @@ if(CONFIG_SOC_SERIES_ESP32H2)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+      ../common/pm_impl_zephyr.c
+      ../common/pm_locks_zephyr.c
       ../../components/esp_driver_gpio/src/gpio.c
       ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_sleep.c
       ../../components/esp_hw_support/port/pau_regdma.c
@@ -448,7 +450,6 @@ if(CONFIG_SOC_SERIES_ESP32H2)
       ../../components/esp_hw_support/sleep_uart.c
       ../../components/esp_hw_support/clk_utils.c
       ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/peripheral_domain_pd.c
-      ../common/pm_impl_zephyr.c
       )
 
     if(CONFIG_ESP32_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP)

--- a/zephyr/esp32p4/CMakeLists.txt
+++ b/zephyr/esp32p4/CMakeLists.txt
@@ -244,6 +244,8 @@ if(CONFIG_SOC_SERIES_ESP32P4)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+      ../common/pm_impl_zephyr.c
+      ../common/pm_locks_zephyr.c
       ../../components/esp_driver_gpio/src/gpio.c
       ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_sleep.c
       ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_sleep_clock_icg.c
@@ -261,7 +263,6 @@ if(CONFIG_SOC_SERIES_ESP32P4)
       ../../components/esp_hw_support/sleep_uart.c
       ../../components/esp_hw_support/clk_utils.c
       ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/peripheral_domain_pd.c
-      ../common/pm_impl_zephyr.c
       )
     if(CONFIG_ESP32_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP)
       zephyr_sources(

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -298,6 +298,8 @@ if(CONFIG_SOC_SERIES_ESP32S2)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+      ../common/pm_impl_zephyr.c
+      ../common/pm_locks_zephyr.c
       ../../components/esp_hw_support/sleep_gpio.c
       ../../components/esp_hw_support/sleep_event.c
       ../../components/esp_driver_gpio/src/gpio.c

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -350,6 +350,8 @@ if(CONFIG_SOC_SERIES_ESP32S3)
 
   if(CONFIG_PM OR CONFIG_POWEROFF)
     zephyr_sources(
+      ../common/pm_impl_zephyr.c
+      ../common/pm_locks_zephyr.c
       ../../components/esp_hw_support/sleep_gpio.c
       ../../components/esp_hw_support/sleep_event.c
       ../../components/esp_hw_support/sleep_console.c


### PR DESCRIPTION
Add a Zephyr ported implementation of pm_lock interface, so HAL components can use native esp_pm_lock_create/acquire/release calls directly and abstract OS workings. This keeps component code closer to original HAL and provides a single place to evolve PM behaviour (e.g. frequency scaling) as support grows.

Update Wi-Fi PM implementation to account for ported PM locks.