### PR TITLE
west: cleanup tools.py and remove deprecated west.log module

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+
+line-length = 100
+target-version = "py312"
+
+[lint]
+select = [
+    "B",      # flake8-bugbear
+    "E",      # pycodestyle
+    "F",      # pyflakes
+    "I",      # isort
+    "SIM",    # flake8-simplify
+    "TID251", # flake8-tidy-imports: banned-api (deprecated west APIs)
+    "UP",     # pyupgrade
+    "W",      # pycodestyle warnings
+]
+
+ignore = [
+    "SIM108", # Allow if-else blocks instead of forcing ternary operator
+]
+
+[lint.flake8-tidy-imports.banned-api]
+# Deprecated west APIs.
+"west.log".msg = """\
+    west.log is deprecated; use logging.getLogger(__name__) \
+    and bridge to the command via forward_logging_to_west() \
+    from scripts/west_commands/build_helpers.py. \
+    See details in https://github.com/zephyrproject-rtos/west/issues/952"""
+
+"west.configuration.config".msg = """\
+    The west.configuration `config` module-level global is deprecated; \
+    use the Configuration class (typically `self.config` inside a WestCommand)."""
+
+"west.configuration.read_config".msg = """\
+    west.configuration.read_config is deprecated; \
+    instantiate Configuration(topdir=...) and use its get method."""
+
+"west.configuration.update_config".msg = """\
+    west.configuration.update_config is deprecated; \
+    instantiate Configuration(topdir=...) and use its set method."""
+
+"west.configuration.delete_config".msg = """\
+    west.configuration.delete_config is deprecated; \
+    instantiate Configuration(topdir=...) and use its delete method."""
+
+[format]
+quote-style = "preserve"
+line-ending = "lf"

--- a/tools/idf_monitor/idf_monitor_base/output_helpers.py
+++ b/tools/idf_monitor/idf_monitor_base/output_helpers.py
@@ -17,10 +17,6 @@ import subprocess
 import sys
 from typing import BinaryIO, Callable, Optional, Union  # noqa: F401
 
-from west.commands import WestCommand
-from west.configuration import config
-from west import log
-
 # This relies on this file being in hal_espressif/tools/idf_monitor_base/output_helpers.py
 # If you move this file, you'll break it, so be careful.
 from pathlib import Path

--- a/west/tools.py
+++ b/west/tools.py
@@ -35,14 +35,6 @@ baud_rate = None
 target_soc = None
 
 
-def cmd_check(cmd, cwd=None, stderr=subprocess.STDOUT):
-    return subprocess.check_output(cmd, cwd=cwd, stderr=stderr)
-
-
-def cmd_exec(cmd, cwd=None, shell=False):
-    return subprocess.check_call(cmd, cwd=cwd, shell=shell)
-
-
 def _normalize_chip(name):
     return name.lower().replace('-', '')
 
@@ -271,4 +263,4 @@ class Tools(WestCommand):
         if not args.enable_address_decoding:
             cmd.append("-d")
 
-        cmd_exec(cmd, cwd=cmd_path)
+        subprocess.check_call(cmd, cwd=cmd_path)

--- a/west/tools.py
+++ b/west/tools.py
@@ -35,6 +35,7 @@ build_elf_path = None
 baud_rate = None
 target_soc = None
 
+
 def cmd_check(cmd, cwd=None, stderr=subprocess.STDOUT):
     return subprocess.check_output(cmd, cwd=cwd, stderr=stderr)
 
@@ -50,6 +51,7 @@ def _normalize_chip(name):
 def get_esp_serial_port(module_path, skip_soc_match=False):
     try:
         import serial.tools.list_ports
+
         esptool_path = os.path.join(module_path, 'tools', 'esptool_py')
         sys.path.insert(0, esptool_path)
         import esptool
@@ -57,17 +59,22 @@ def get_esp_serial_port(module_path, skip_soc_match=False):
         # Probe native Espressif USB devices (VID 0x303A) first to avoid
         # resetting unrelated serial adapters.
         ESPRESSIF_VID = 0x303A
-        port_infos = sorted(serial.tools.list_ports.comports(),
-                            key=lambda p: (p.vid != ESPRESSIF_VID, p.device))
+        port_infos = sorted(
+            serial.tools.list_ports.comports(), key=lambda p: (p.vid != ESPRESSIF_VID, p.device)
+        )
 
         # Drop macOS nodes that block on open so neither the SoC-match probe
         # nor the fallback below stalls on them. /dev/cu.* and /dev/tty.* are
         # twins of the same device, so probe only the cu.* form.
         if sys.platform == 'darwin':
-            port_infos = [p for p in port_infos
-                          if not p.device.startswith('/dev/tty.')
-                          and not p.device.endswith(
-                              ('Bluetooth-Incoming-Port', 'wlan-debug', 'cu.debug-console'))]
+            port_infos = [
+                p
+                for p in port_infos
+                if not p.device.startswith('/dev/tty.')
+                and not p.device.endswith(
+                    ('Bluetooth-Incoming-Port', 'wlan-debug', 'cu.debug-console')
+                )
+            ]
 
         # When the build target is known, return the first port whose chip
         # matches CONFIG_SOC instead of the first device that responds.
@@ -94,16 +101,22 @@ def get_esp_serial_port(module_path, skip_soc_match=False):
                 finally:
                     if esp._port:
                         esp._port.close()
-            log.wrn("No port with a {} chip found; "
-                    "falling back to esptool auto-detection".format(target_soc))
+            log.wrn(
+                "No port with a {} chip found; falling back to esptool auto-detection".format(
+                    target_soc
+                )
+            )
 
         ports = [info.device for info in port_infos]
         # high baud rate could cause the failure of creation of the connection
-        esp = esptool.get_default_connected_device(serial_list=ports, port=None, connect_attempts=4,
-                                                   initial_baud=115200)
+        esp = esptool.get_default_connected_device(
+            serial_list=ports, port=None, connect_attempts=4, initial_baud=115200
+        )
         if esp is None:
-            log.die("No serial ports found. Connect a device, or use '-p PORT' "
-                    "option to set a specific port.")
+            log.die(
+                "No serial ports found. Connect a device, or use '-p PORT' "
+                "option to set a specific port."
+            )
 
         serial_port = esp.serial_port
         esp._port.close()
@@ -131,8 +144,7 @@ def parse_runners_yaml():
             log.die("runners.yaml file open error: {}".format(e))
 
         if not content.get('runners'):
-            log.wrn("no pre-configured runners in {}; "
-                    "this probably won't work".format(path))
+            log.wrn("no pre-configured runners in {}; this probably won't work".format(path))
 
         return content
 
@@ -174,26 +186,25 @@ def parse_runners_yaml():
     if not baud_rate:
         baud_rate = "115200"
 
-class Tools(WestCommand):
 
+class Tools(WestCommand):
     def __init__(self):
         super().__init__(
             'espressif',
             '',
             dedent('''
             This interface allows having esp-idf monitor support.'''),
-            accepts_unknown_args=False)
+            accepts_unknown_args=False,
+        )
 
     def do_add_parser(self, parser_adder):
-
         parse_runners_yaml()
 
-        parser = parser_adder.add_parser(self.name,
-                                         help=self.help,
-                                         description=self.description)
+        parser = parser_adder.add_parser(self.name, help=self.help, description=self.description)
 
-        parser.add_argument('command', choices=['monitor'],
-                            help='open serial port based on esp-idf monitor')
+        parser.add_argument(
+            'command', choices=['monitor'], help='open serial port based on esp-idf monitor'
+        )
 
         # monitor arguments
         group = parser.add_argument_group('monitor optional arguments')
@@ -201,23 +212,25 @@ class Tools(WestCommand):
         group.add_argument('-p', '--port', help='Serial port address')
         group.add_argument('-e', '--elf', help='ELF file')
         group.add_argument('-n', '--eol', default='CRLF', help='EOL to use')
-        group.add_argument('-d', '--enable-address-decoding', action='store_true',
-                           help='Enable address decoding in the monitor')
-        group.add_argument('--no-soc-match', action='store_true',
-                           help='Skip the SoC-matching probe during port '
-                                'auto-detection. Probing resets each candidate '
-                                'board, so this leaves a running board untouched')
+        group.add_argument(
+            '-d',
+            '--enable-address-decoding',
+            action='store_true',
+            help='Enable address decoding in the monitor',
+        )
+        group.add_argument(
+            '--no-soc-match',
+            action='store_true',
+            help='Skip the SoC-matching probe during port '
+            'auto-detection. Probing resets each candidate '
+            'board, so this leaves a running board untouched',
+        )
 
         return parser
 
     def do_run(self, args, unknown_args):
-
         module_path = (
-            Path(os.getenv("ZEPHYR_BASE")).absolute()
-            / r".."
-            / "modules"
-            / "hal"
-            / "espressif"
+            Path(os.getenv("ZEPHYR_BASE")).absolute() / r".." / "modules" / "hal" / "espressif"
         )
 
         if not module_path.exists():
@@ -227,7 +240,6 @@ class Tools(WestCommand):
             self.monitor(module_path, args)
 
     def monitor(self, module_path, args):
-
         elf_path = args.elf
         if elf_path:
             elf_path = os.path.abspath(elf_path)
@@ -242,7 +254,17 @@ class Tools(WestCommand):
         monitor_path = Path(module_path, "tools/idf_monitor/idf_monitor.py")
         cmd_path = Path(os.getcwd())
 
-        cmd = [sys.executable, str(monitor_path), "-p", esp_port, "-b", args.baud, str(elf_path), "--eol", args.eol]
+        cmd = [
+            sys.executable,
+            str(monitor_path),
+            "-p",
+            esp_port,
+            "-b",
+            args.baud,
+            str(elf_path),
+            "--eol",
+            args.eol,
+        ]
 
         # Adding "-d" argument for idf_monitor.py disables the address decoding
         if not args.enable_address_decoding:

--- a/west/tools.py
+++ b/west/tools.py
@@ -231,9 +231,7 @@ class Tools(WestCommand):
     def do_run(self, args, unknown_args):
         forward_logging_to_west(self, "esp_monitor")
 
-        module_path = (
-            Path(os.getenv("ZEPHYR_BASE")).absolute() / r".." / "modules" / "hal" / "espressif"
-        )
+        module_path = ZEPHYR_BASE.absolute() / r".." / "modules" / "hal" / "espressif"
 
         if not module_path.exists():
             _logger.error('cannot find espressif hal in $ZEPHYR_BASE/../modules/hal/ path')

--- a/west/tools.py
+++ b/west/tools.py
@@ -6,6 +6,7 @@
 
 Espressif west extension for serial port monitor logging.'''
 
+import logging
 import os
 import subprocess
 import sys
@@ -15,7 +16,7 @@ from textwrap import dedent
 import yaml
 from west.commands import WestCommand
 
-from west import log
+_logger = logging.getLogger("esp_monitor")
 
 # This relies on this file being in hal_espressif/west/tools.py
 # If you move this file, you'll break it, so be careful.
@@ -24,7 +25,7 @@ ZEPHYR_BASE = Path(os.environ.get('ZEPHYR_BASE', THIS_ZEPHYR))
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "west_commands"))
 
-from build_helpers import find_build_dir, load_domains  # noqa: E402
+from build_helpers import find_build_dir, forward_logging_to_west, load_domains  # noqa: E402
 from runners.core import BuildConfiguration  # noqa: E402
 
 ESP_IDF_REMOTE = "https://github.com/zephyrproject-rtos/hal_espressif"
@@ -84,22 +85,22 @@ def get_esp_serial_port(module_path, skip_soc_match=False):
                 try:
                     esp = esptool.detect_chip(info.device, connect_attempts=2)
                 except Exception as e:
-                    log.dbg(f"{info.device}: skipped ({e})")
+                    _logger.debug(f"{info.device}: skipped ({e})")
                     continue
                 try:
                     if _normalize_chip(esp.CHIP_NAME) == wanted:
-                        log.inf(f"Auto-selected {info.device} for {target_soc}")
+                        _logger.info(f"Auto-selected {info.device} for {target_soc}")
                         # Probing left the chip in the bootloader; reset it so
                         # the application runs when the monitor attaches.
                         try:
                             esp.hard_reset()
                         except Exception as e:
-                            log.dbg(f"hard reset after detection failed ({e})")
+                            _logger.debug(f"hard reset after detection failed ({e})")
                         return info.device
                 finally:
                     if esp._port:
                         esp._port.close()
-            log.wrn(
+            _logger.warning(
                 f"No port with a {target_soc} chip found; falling back to esptool auto-detection"
             )
 
@@ -109,25 +110,27 @@ def get_esp_serial_port(module_path, skip_soc_match=False):
             serial_list=ports, port=None, connect_attempts=4, initial_baud=115200
         )
         if esp is None:
-            log.die(
+            _logger.error(
                 "No serial ports found. Connect a device, or use '-p PORT' "
                 "option to set a specific port."
             )
+            sys.exit(1)
 
         serial_port = esp.serial_port
         esp._port.close()
 
         return serial_port
-    except Exception as e:
-        log.die(f"Error detecting ESP serial port: {e}")
-        return None
+    except Exception:
+        _logger.exception("Error detecting ESP serial port")
+        sys.exit(1)
 
 
 def parse_runners_yaml():
     def runners_yaml_path(build_dir):
         ret = Path(build_dir) / 'zephyr' / 'runners.yaml'
         if not ret.is_file():
-            log.die("could not find build configuration")
+            _logger.error("could not find build configuration")
+            sys.exit(1)
         return ret
 
     def load_runners_yaml(path):
@@ -136,11 +139,12 @@ def parse_runners_yaml():
         try:
             with open(path) as f:
                 content = yaml.safe_load(f.read())
-        except Exception as e:
-            log.die(f"runners.yaml file open error: {e}")
+        except Exception:
+            _logger.exception("runners.yaml file open error")
+            sys.exit(1)
 
         if not content.get('runners'):
-            log.wrn(f"no pre-configured runners in {path}; this probably won't work")
+            _logger.warning(f"no pre-configured runners in {path}; this probably won't work")
 
         return content
 
@@ -166,7 +170,7 @@ def parse_runners_yaml():
         build_conf = BuildConfiguration(build_dir)
         target_soc = build_conf.get('CONFIG_SOC', None)
     except Exception as e:
-        log.dbg(f"could not read CONFIG_SOC, SoC port matching disabled ({e})")
+        _logger.debug(f"could not read CONFIG_SOC, SoC port matching disabled ({e})")
         target_soc = None
 
     # parse specific arguments for the tool
@@ -225,12 +229,15 @@ class Tools(WestCommand):
         return parser
 
     def do_run(self, args, unknown_args):
+        forward_logging_to_west(self, "esp_monitor")
+
         module_path = (
             Path(os.getenv("ZEPHYR_BASE")).absolute() / r".." / "modules" / "hal" / "espressif"
         )
 
         if not module_path.exists():
-            log.die('cannot find espressif hal in $ZEPHYR_BASE/../modules/hal/ path')
+            _logger.error('cannot find espressif hal in $ZEPHYR_BASE/../modules/hal/ path')
+            sys.exit(1)
 
         if args.command == "monitor":
             self.monitor(module_path, args)

--- a/west/tools.py
+++ b/west/tools.py
@@ -7,15 +7,14 @@
 Espressif west extension for serial port monitor logging.'''
 
 import os
-import platform
 import subprocess
 import sys
-import yaml
 from pathlib import Path
-
 from textwrap import dedent
+
+import yaml
 from west.commands import WestCommand
-from west.configuration import config
+
 from west import log
 
 # This relies on this file being in hal_espressif/west/tools.py
@@ -25,8 +24,7 @@ ZEPHYR_BASE = Path(os.environ.get('ZEPHYR_BASE', THIS_ZEPHYR))
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "west_commands"))
 
-from build_helpers import load_domains
-from build_helpers import is_zephyr_build, find_build_dir  # noqa: E402
+from build_helpers import find_build_dir, load_domains  # noqa: E402
 from runners.core import BuildConfiguration  # noqa: E402
 
 ESP_IDF_REMOTE = "https://github.com/zephyrproject-rtos/hal_espressif"
@@ -86,25 +84,23 @@ def get_esp_serial_port(module_path, skip_soc_match=False):
                 try:
                     esp = esptool.detect_chip(info.device, connect_attempts=2)
                 except Exception as e:
-                    log.dbg("{}: skipped ({})".format(info.device, e))
+                    log.dbg(f"{info.device}: skipped ({e})")
                     continue
                 try:
                     if _normalize_chip(esp.CHIP_NAME) == wanted:
-                        log.inf("Auto-selected {} for {}".format(info.device, target_soc))
+                        log.inf(f"Auto-selected {info.device} for {target_soc}")
                         # Probing left the chip in the bootloader; reset it so
                         # the application runs when the monitor attaches.
                         try:
                             esp.hard_reset()
                         except Exception as e:
-                            log.dbg("hard reset after detection failed ({})".format(e))
+                            log.dbg(f"hard reset after detection failed ({e})")
                         return info.device
                 finally:
                     if esp._port:
                         esp._port.close()
             log.wrn(
-                "No port with a {} chip found; falling back to esptool auto-detection".format(
-                    target_soc
-                )
+                f"No port with a {target_soc} chip found; falling back to esptool auto-detection"
             )
 
         ports = [info.device for info in port_infos]
@@ -123,7 +119,7 @@ def get_esp_serial_port(module_path, skip_soc_match=False):
 
         return serial_port
     except Exception as e:
-        log.die("Error detecting ESP serial port: {}".format(e))
+        log.die(f"Error detecting ESP serial port: {e}")
         return None
 
 
@@ -138,13 +134,13 @@ def parse_runners_yaml():
         # Load runners.yaml and convert to Python object.
 
         try:
-            with open(path, 'r') as f:
+            with open(path) as f:
                 content = yaml.safe_load(f.read())
         except Exception as e:
-            log.die("runners.yaml file open error: {}".format(e))
+            log.die(f"runners.yaml file open error: {e}")
 
         if not content.get('runners'):
-            log.wrn("no pre-configured runners in {}; this probably won't work".format(path))
+            log.wrn(f"no pre-configured runners in {path}; this probably won't work")
 
         return content
 
@@ -170,7 +166,7 @@ def parse_runners_yaml():
         build_conf = BuildConfiguration(build_dir)
         target_soc = build_conf.get('CONFIG_SOC', None)
     except Exception as e:
-        log.dbg("could not read CONFIG_SOC, SoC port matching disabled ({})".format(e))
+        log.dbg(f"could not read CONFIG_SOC, SoC port matching disabled ({e})")
         target_soc = None
 
     # parse specific arguments for the tool


### PR DESCRIPTION
- Copied the `ruff` configuration from Zephyr
- Used `ruff` to cleanup some formatting/linter issues.
- Removed the deprecated `west.log` module

I tried to keep the changes as close to the original code as possible. There are some alternatives; move free functions inside the `WestCommand` class, or pass the command instance. But I'm not sure how the HAL tooling is considered public API.