### PR TITLE
esp32p4: add multi-silicon-revision build support

### DIFF
--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.ld
@@ -328,6 +328,12 @@ esprv_intc_int_set_priority = 0x4fc005b8;
 esprv_intc_int_set_threshold = 0x4fc005bc;
 esprv_intc_int_enable = 0x4fc005c0;
 esprv_intc_int_disable = 0x4fc005c4;
+/*
+ * ZEPHYR: the pre-v3 ROM does not export esprv_intc_int_set_type. The ROM
+ * function it would alias is also buggy for edge-type interrupts. Zephyr
+ * builds esp_rom_clic.c, which provides a C implementation of esprv_int_set_type
+ * for pre-v3 silicon, so no ROM symbol is needed here.
+ */
 PROVIDE( intr_handler_set = 0x4fc005cc );
 intr_matrix_set = 0x4fc005d0;
 ets_intr_lock = 0x4fc005d4;

--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.libc.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.libc.ld
@@ -31,8 +31,9 @@ strrchr = 0x4fc0031c;
 strsep = 0x4fc00320;
 strspn = 0x4fc00324;
 strtok_r = 0x4fc00328;
-longjmp = 0x4fc00330;
-setjmp = 0x4fc00334;
+/* ZEPHYR: Keep PROVIDE for these symbols: */
+PROVIDE ( longjmp = 0x4fc00330 );
+PROVIDE ( setjmp = 0x4fc00334 );
 abs = 0x4fc00338;
 div = 0x4fc0033c;
 labs = 0x4fc00340;

--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.newlib.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.newlib.ld
@@ -21,22 +21,23 @@
 
 /* Functions */
 _isatty_r = 0x4fc00294;
-strdup = 0x4fc002f0;
-strndup = 0x4fc00314;
-rand_r = 0x4fc0034c;
-rand = 0x4fc00350;
-srand = 0x4fc00354;
-atoi = 0x4fc00360;
-atol = 0x4fc00364;
-strtol = 0x4fc00368;
-strtoul = 0x4fc0036c;
-fflush = 0x4fc00370;
-_fflush_r = 0x4fc00374;
-_fwalk = 0x4fc00378;
-_fwalk_reent = 0x4fc0037c;
+/* ZEPHYR: Keep PROVIDE for these symbols: */
+PROVIDE ( strdup = 0x4fc002f0 );
+PROVIDE ( strndup = 0x4fc00314 );
+PROVIDE ( rand_r = 0x4fc0034c );
+PROVIDE ( rand = 0x4fc00350 );
+PROVIDE ( srand = 0x4fc00354 );
+PROVIDE ( atoi = 0x4fc00360 );
+PROVIDE ( atol = 0x4fc00364 );
+PROVIDE ( strtol = 0x4fc00368 );
+PROVIDE ( strtoul = 0x4fc0036c );
+PROVIDE ( fflush = 0x4fc00370 );
+PROVIDE ( _fflush_r = 0x4fc00374 );
+PROVIDE ( _fwalk = 0x4fc00378 );
+PROVIDE ( _fwalk_reent = 0x4fc0037c );
 __smakebuf_r = 0x4fc00380;
 __swhatbuf_r = 0x4fc00384;
-__swbuf_r = 0x4fc00388;
+PROVIDE ( __swbuf_r = 0x4fc00388 );
 __swbuf = 0x4fc0038c;
 __swsetup_r = 0x4fc00390;
 toupper = 0x4fc002cc;

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -44,6 +44,19 @@ endif
 
 if SOC_SERIES_ESP32P4
 rsource "../components/soc/esp32p4/include/soc/Kconfig.soc_caps.in"
+
+config SOC_ESP32P4_REV_MIN_FULL
+	int
+	default 103 if SOC_ESP32P4_REV_1_3
+	default 300 if SOC_ESP32P4_REV_3_0
+	default 301 if SOC_ESP32P4_REV_3_1
+	default 301
+	help
+	  Minimum supported ESP32-P4 chip revision in major * 100 + minor
+	  format, matching what efuse_hal_chip_revision() returns at runtime.
+	  Derived from the SOC_ESP32P4_REV_* symbol the board selects; defaults
+	  to v3.1 (301), the floor of the v3.x family, when none is selected.
+	  Consumed by the hal_espressif build to set CONFIG_ESP_REV_MIN_FULL.
 endif
 
 # XTAL frequency in Hz from devicetree
@@ -83,6 +96,7 @@ config BOOTLOADER_OFFSET_IN_FLASH
 config BOOTLOADER_CPU_CLK_FREQ_MHZ
 	int
 	default 64 if SOC_SERIES_ESP32H2
+	default 90 if SOC_SERIES_ESP32P4 && SOC_ESP32P4_REV_1_3
 	default 100 if SOC_SERIES_ESP32P4
 	default 80
 
@@ -104,19 +118,10 @@ config ESP_SYSTEM_RTC_EXT_XTAL_BOOTSTRAP_CYCLES
 	  To accurately determine if the crystal has started,
 	  set a larger "Number of cycles for RTC_SLOW_CLK calibration" (about 3000).
 
-# CPU frequency in MHz derived from devicetree clock-frequency property
+# CPU frequency in MHz derived from the devicetree clock-frequency property
 config ESP_DEFAULT_CPU_FREQ_MHZ
 	int
-	default 96 if ESP_CLK_FREQ_HZ = 96000000
-	default 120 if ESP_CLK_FREQ_HZ = 120000000
-	default 160 if ESP_CLK_FREQ_HZ = 160000000
-	default 240 if ESP_CLK_FREQ_HZ = 240000000
-	default 400 if ESP_CLK_FREQ_HZ = 400000000
-
-# CPU clock frequency in Hz from devicetree
-config ESP_CLK_FREQ_HZ
-	int
-	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+	default $(div,$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency),1000000)
 
 # Console serial port number for ESP-IDF ROM functions.
 # Set to -1 for USB Serial JTAG console (no UART TX wait needed).

--- a/zephyr/esp32p4/CMakeLists.txt
+++ b/zephyr/esp32p4/CMakeLists.txt
@@ -421,6 +421,7 @@ if(CONFIG_SOC_SERIES_ESP32P4)
     ../../components/esp_rom/patches/esp_rom_efuse.c
     ../../components/esp_rom/patches/esp_rom_gpio.c
     ../../components/esp_hal_regi2c/${CONFIG_SOC_SERIES}/regi2c_impl.c
+    ../../components/esp_rom/patches/esp_rom_clic.c
     ../../components/esp_rom/patches/esp_rom_print.c
     ../../components/esp_rom/patches/esp_rom_serial_output.c
     ../../components/esp_rom/patches/esp_rom_spiflash.c

--- a/zephyr/esp32p4/CMakeLists.txt
+++ b/zephyr/esp32p4/CMakeLists.txt
@@ -6,7 +6,26 @@ if(CONFIG_SOC_SERIES_ESP32P4)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
   zephyr_compile_definitions_ifndef(typeof typeof=__typeof__)
-  zephyr_compile_definitions(CONFIG_ESP_REV_MIN_FULL=500)
+
+  # Derive the hal revision macros from CONFIG_SOC_ESP32P4_REV_MIN_FULL, the
+  # minimum supported chip revision in major * 100 + minor format. That symbol
+  # is defined in this module's Kconfig from the board-selected
+  # SOC_ESP32P4_REV_* symbols, with an unconditional default, so it is always
+  # set for an ESP32-P4 build.
+  set(esp32p4_rev_min_full ${CONFIG_SOC_ESP32P4_REV_MIN_FULL})
+
+  zephyr_compile_definitions(CONFIG_ESP_REV_MIN_FULL=${esp32p4_rev_min_full})
+  zephyr_compile_definitions(CONFIG_ESP32P4_REV_MIN_FULL=${esp32p4_rev_min_full})
+
+  # Revisions below v3.0 use a hardware-incompatible code path in the hal,
+  # gated by CONFIG_ESP32P4_SELECTS_REV_LESS_V3, and a different register
+  # layout (hw_ver1 vs hw_ver3).
+  if(esp32p4_rev_min_full LESS 300)
+    zephyr_compile_definitions(CONFIG_ESP32P4_SELECTS_REV_LESS_V3=1)
+    set(esp32p4_hw_ver_dir hw_ver1)
+  else()
+    set(esp32p4_hw_ver_dir hw_ver3)
+  endif()
 
   if(CONFIG_MCUBOOT)
     zephyr_compile_options(-fdump-rtl-expand)
@@ -134,7 +153,7 @@ if(CONFIG_SOC_SERIES_ESP32P4)
     ../../components/soc/include
     ../../components/soc/${CONFIG_SOC_SERIES}/ld
     ../../components/soc/${CONFIG_SOC_SERIES}/register
-    ../../components/soc/${CONFIG_SOC_SERIES}/register/hw_ver3
+    ../../components/soc/${CONFIG_SOC_SERIES}/register/${esp32p4_hw_ver_dir}
     ../../components/spi_flash/include
     ../../components/spi_flash/include/esp_private
     ../../components/ulp/lp_core/include
@@ -149,17 +168,33 @@ if(CONFIG_SOC_SERIES_ESP32P4)
   )
 
   if(NOT CONFIG_SOC_ESP32P4_LPCORE)
+    # Revision-specific ROM symbol set: pre-v3 silicon uses the eco0_4
+    # scripts, v3.x uses the default ones.
+    if(esp32p4_rev_min_full LESS 300)
+      zephyr_link_libraries(
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.rvfp.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.newlib.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.libc.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.libgcc.ld
+      )
+    else()
+      zephyr_link_libraries(
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.rvfp.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.newlib.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.libc.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.libgcc.ld
+      )
+    endif()
+
+    # ROM scripts shared by all revisions.
     zephyr_link_libraries(
-      -T${CMAKE_CURRENT_SOURCE_DIR}/src/linker/${CONFIG_SOC_SERIES}.rom.alias.ld
-      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.ld
-      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.api.ld
-      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.rvfp.ld
-      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.newlib.ld
-      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.version.ld
-      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.libc.ld
-      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.libc-suboptimal_for_misaligned_mem.ld
-      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.libgcc.ld
-      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_hal_wdt/${CONFIG_SOC_SERIES}/rom.wdt.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/src/linker/esp32p4.rom.alias.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.api.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.version.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/esp32p4/ld/esp32p4.rom.libc-suboptimal_for_misaligned_mem.ld
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_hal_wdt/esp32p4/rom.wdt.ld
       -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/riscv/ld/rom.api.ld
     )
   endif()

--- a/zephyr/esp32p4/src/soc_init.c
+++ b/zephyr/esp32p4/src/soc_init.c
@@ -19,6 +19,10 @@
 #include "soc/assist_debug_reg.h"
 #include "soc/lp_wdt_reg.h"
 #include "soc/regi2c_bias.h"
+#include "soc/regi2c_cpll.h"
+#include "soc/regi2c_syspll.h"
+#include "soc/chip_revision.h"
+#include "hal/efuse_hal.h"
 #include "esp_log.h"
 #include "esp_rom_sys.h"
 #include "esp_rom_regi2c.h"
@@ -29,6 +33,20 @@ void soc_hw_init(void)
 {
 	_regi2c_ctrl_ll_master_enable_clock(true);
 	regi2c_ctrl_ll_master_configure_clock();
+
+	if (!ESP_CHIP_REV_ABOVE(efuse_hal_chip_revision(), 1)) {
+		/*
+		 * On ESP32-P4 ECO0 (rev < v1.0) the power-on-reset CPLL and
+		 * SYSPLL frequencies are very high, which can starve the bias
+		 * during early boot. Lower their output dividers before the
+		 * regulators are brought up. The lowest supported silicon is
+		 * v1.3, so this never runs on supported parts; it is kept to
+		 * match the reference boot sequence for v0.x silicon.
+		 */
+		REGI2C_WRITE_MASK(I2C_CPLL, I2C_CPLL_OC_DIV_7_0, 6);
+		REGI2C_WRITE_MASK(I2C_SYSPLL, I2C_SYSPLL_OC_DIV_7_0, 8);
+		esp_rom_delay_us(100);
+	}
 
 	REGI2C_WRITE_MASK(I2C_BIAS, I2C_BIAS_DREG_1P1, 10);
 	REGI2C_WRITE_MASK(I2C_BIAS, I2C_BIAS_DREG_1P1_PVT, 10);
@@ -159,10 +177,11 @@ void bootloader_clock_configure(void)
 	}
 	pmu_ll_hp_set_regulator_xpd(&PMU, PMU_MODE_HP_ACTIVE, false);
 
-	/* Upscale CPU to CONFIG_BOOTLOADER_CPU_CLK_FREQ_MHZ (100 MHz on
-	 * ECO >= 3.0), matching ESP-IDF rtc_clk_cpu_freq_to_cpll_mhz():
-	 *   CPLL = 400 MHz, cpu_div = 4 -> CPU = 100 MHz
-	 *   mem_div = 1, sys_div = 1, apb_div = 1
+	/* Upscale CPU to CONFIG_BOOTLOADER_CPU_CLK_FREQ_MHZ, mirroring the
+	 * reference rtc_clk_cpu_freq_to_cpll_mhz() with cpu_div = 4:
+	 *   rev >= v3.0: CPLL = 400 MHz -> CPU = 100 MHz
+	 *   rev <  v3.0: CPLL = 360 MHz -> CPU =  90 MHz
+	 * In both cases mem_div = sys_div = apb_div = 1.
 	 * Upscaling order: APB -> SYS -> MEM -> CPU -> src switch.
 	 */
 	clk_ll_apb_set_divider(1);
@@ -176,9 +195,16 @@ void bootloader_clock_configure(void)
 	clk_ll_cpu_set_src(SOC_CPU_CLK_SRC_CPLL);
 	esp_rom_set_cpu_ticks_per_us(CONFIG_BOOTLOADER_CPU_CLK_FREQ_MHZ);
 
-	/* MSPI flash: SPLL (480MHz) with core clock at 80MHz */
-	_mspi_timing_ll_set_flash_clk_src(0, FLASH_CLK_SRC_SPLL);
-	_mspi_timing_ll_set_flash_core_clock(0, 80);
+	/*
+	 * MSPI flash: SPLL (480 MHz) with core clock at 80 MHz. On ECO0
+	 * (rev < v1.0) the reference bootloader skips MSPI clock init and
+	 * keeps flash on the ROM default, because the SPLL is unstable on
+	 * that silicon; mirror that here.
+	 */
+	if (ESP_CHIP_REV_ABOVE(chip_version, 1)) {
+		_mspi_timing_ll_set_flash_clk_src(0, FLASH_CLK_SRC_SPLL);
+		_mspi_timing_ll_set_flash_core_clock(0, 80);
+	}
 
 	CLEAR_PERI_REG_MASK(LP_WDT_INT_ENA_REG, LP_WDT_SUPER_WDT_INT_ENA);
 	CLEAR_PERI_REG_MASK(LP_WDT_INT_ENA_REG, LP_WDT_LP_WDT_INT_ENA);


### PR DESCRIPTION
Derive the chip-revision build macros from the board-selected Kconfig and
select the eco0_4 ROM / hw_ver1 register set for pre-v3 silicon, including the
pre-v3 PLL/MSPI boot path and eco0_4 linker-script fixes.