### PR TITLE
zephyr: mark cmake and Kconfig as extern

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -4,8 +4,8 @@ package-managers:
     requirement-files:
       - zephyr/requirements.txt
 build:
-  cmake: zephyr
-  kconfig: zephyr/Kconfig
+  cmake-ext: True
+  kconfig-ext: True
   settings:
     dts_root: .
 blobs:


### PR DESCRIPTION
Since
github.com/zephyrproject-rtos/zephyr/pull/105840
the main Kconfig and CMake file of this module is
in zephyrs main, so change this here too, otherwise these files are ignored.