### PR TITLE
pinmux: fix: correct pcnt2 ch0sig pinmux on esp32/s2/s3

### DIFF
--- a/zephyr/port/pincfgs/esp32.yml
+++ b/zephyr/port/pincfgs/esp32.yml
@@ -384,7 +384,7 @@ pcnt1:
 
 pcnt2:
   ch0sig:
-    sigi: pcnt_sig_ch0_in3
+    sigi: pcnt_sig_ch0_in2
     gpio: [[0, 23], [25, 27], [32, 39]]
   ch0ctrl:
     sigi: pcnt_ctrl_ch0_in2

--- a/zephyr/port/pincfgs/esp32s2.yml
+++ b/zephyr/port/pincfgs/esp32s2.yml
@@ -239,7 +239,7 @@ pcnt1:
 
 pcnt2:
   ch0sig:
-    sigi: pcnt_sig_ch0_in3
+    sigi: pcnt_sig_ch0_in2
     gpio: [[0, 21], [26, 46]]
   ch0ctrl:
     sigi: pcnt_ctrl_ch0_in2

--- a/zephyr/port/pincfgs/esp32s3.yml
+++ b/zephyr/port/pincfgs/esp32s3.yml
@@ -359,7 +359,7 @@ pcnt1:
 
 pcnt2:
   ch0sig:
-    sigi: pcnt_sig_ch0_in3
+    sigi: pcnt_sig_ch0_in2
     gpio: [[0, 21], [26, 48]]
   ch0ctrl:
     sigi: pcnt_ctrl_ch0_in2


### PR DESCRIPTION
Map pcnt unit 2 channel 0 input to its own signal index instead of unit 3's.