### PR TITLE
zephyr: pincfg: add esp32p4 pcnt pin signals

### DIFF
--- a/zephyr/port/pincfgs/esp32p4.yml
+++ b/zephyr/port/pincfgs/esp32p4.yml
@@ -383,3 +383,59 @@ sdhc1:
     sigi: sd_card_cdata3_2_in
     sigo: sd_card_cdata3_2_out
     gpio: [[0, 54]]
+
+pcnt0:
+  ch0sig:
+    sigi: pcnt_sig_ch0_in0
+    gpio: [[0, 54]]
+  ch0ctrl:
+    sigi: pcnt_ctrl_ch0_in0
+    gpio: [[0, 54]]
+  ch1sig:
+    sigi: pcnt_sig_ch1_in0
+    gpio: [[0, 54]]
+  ch1ctrl:
+    sigi: pcnt_ctrl_ch1_in0
+    gpio: [[0, 54]]
+
+pcnt1:
+  ch0sig:
+    sigi: pcnt_sig_ch0_in1
+    gpio: [[0, 54]]
+  ch0ctrl:
+    sigi: pcnt_ctrl_ch0_in1
+    gpio: [[0, 54]]
+  ch1sig:
+    sigi: pcnt_sig_ch1_in1
+    gpio: [[0, 54]]
+  ch1ctrl:
+    sigi: pcnt_ctrl_ch1_in1
+    gpio: [[0, 54]]
+
+pcnt2:
+  ch0sig:
+    sigi: pcnt_sig_ch0_in2
+    gpio: [[0, 54]]
+  ch0ctrl:
+    sigi: pcnt_ctrl_ch0_in2
+    gpio: [[0, 54]]
+  ch1sig:
+    sigi: pcnt_sig_ch1_in2
+    gpio: [[0, 54]]
+  ch1ctrl:
+    sigi: pcnt_ctrl_ch1_in2
+    gpio: [[0, 54]]
+
+pcnt3:
+  ch0sig:
+    sigi: pcnt_sig_ch0_in3
+    gpio: [[0, 54]]
+  ch0ctrl:
+    sigi: pcnt_ctrl_ch0_in3
+    gpio: [[0, 54]]
+  ch1sig:
+    sigi: pcnt_sig_ch1_in3
+    gpio: [[0, 54]]
+  ch1ctrl:
+    sigi: pcnt_ctrl_ch1_in3
+    gpio: [[0, 54]]


### PR DESCRIPTION
Add pcnt0-3 channel signal and control entries to the esp32p4 pin configuration so the generator can emit PCNT pinmux macros.