### PR TITLE
kconfig: drop esp_console_rom_serial_port_num

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -33,6 +33,17 @@ if(CONFIG_ESP_USB_SERIAL_JTAG_ENABLED OR CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
   zephyr_compile_definitions(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG_ENABLED=1)
 endif()
 
+# Console serial port number for ROM output functions. Derived here from
+# the console selection so the value does not depend on a hal Kconfig
+# default that references symbols defined outside the hal. -1 selects a
+# USB Serial JTAG console, for which the ROM UART tx_wait_idle/flush
+# helpers are skipped (there is no UART TX to drain).
+if(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG OR NOT DEFINED CONFIG_ESP_CONSOLE_UART_NUM)
+  zephyr_compile_definitions(CONFIG_ESP_CONSOLE_ROM_SERIAL_PORT_NUM=-1)
+else()
+  zephyr_compile_definitions(CONFIG_ESP_CONSOLE_ROM_SERIAL_PORT_NUM=${CONFIG_ESP_CONSOLE_UART_NUM})
+endif()
+
 zephyr_sources_ifdef(
   CONFIG_CRYPTO_ESP32
   ../components/esp_hal_security/aes_hal.c

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -123,13 +123,6 @@ config ESP_DEFAULT_CPU_FREQ_MHZ
 	int
 	default $(div,$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency),1000000)
 
-# Console serial port number for ESP-IDF ROM functions.
-# Set to -1 for USB Serial JTAG console (no UART TX wait needed).
-config ESP_CONSOLE_ROM_SERIAL_PORT_NUM
-	int
-	default -1 if ESP_CONSOLE_USB_SERIAL_JTAG
-	default ESP_CONSOLE_UART_NUM
-
 # ESP timer interrupt level (only ESP32 supports 1-3, others only 1)
 config ESP_TIMER_INTERRUPT_LEVEL
 	int


### PR DESCRIPTION
Remove the console ROM serial port symbol from the hal Kconfig so it no longer references the zephyr console symbols. The symbol is now defined in the zephyr soc console Kconfig instead.