### PR TITLE
zephyr: compile touch sensor source files for newer SoCs

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -309,8 +309,7 @@ if(CONFIG_SOC_SERIES_ESP32)
 
   zephyr_sources_ifdef(CONFIG_INPUT_ESP32_TOUCH_SENSOR
     ../../components/esp_hal_touch_sens/esp32/touch_sensor_periph.c
-    ../../components/esp_hal_touch_sens/touch_sensor_legacy_hal.c
-    ../../components/esp_hal_touch_sens/esp32/touch_sensor_legacy_hal.c
+    ../../components/esp_hal_touch_sens/touch_sens_hal.c
     )
 
   if (CONFIG_ADC_ESP32)

--- a/zephyr/esp32p4/CMakeLists.txt
+++ b/zephyr/esp32p4/CMakeLists.txt
@@ -533,6 +533,7 @@ if(CONFIG_SOC_SERIES_ESP32P4)
 
   zephyr_sources_ifdef(CONFIG_INPUT_ESP32_TOUCH_SENSOR
     ../../components/esp_hal_touch_sens/esp32p4/touch_sensor_periph.c
+    ../../components/esp_hal_touch_sens/touch_sens_hal.c
     )
 
   if (CONFIG_ESP32_TEMP)

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -318,8 +318,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
 
   zephyr_sources_ifdef(CONFIG_INPUT_ESP32_TOUCH_SENSOR
     ../../components/esp_hal_touch_sens/esp32s2/touch_sensor_periph.c
-    ../../components/esp_hal_touch_sens/touch_sensor_legacy_hal.c
-    ../../components/esp_hal_touch_sens/esp32s2/touch_sensor_legacy_hal.c
+    ../../components/esp_hal_touch_sens/touch_sens_hal.c
     )
 
   if (CONFIG_ESP32_TEMP)

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -373,8 +373,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
 
   zephyr_sources_ifdef(CONFIG_INPUT_ESP32_TOUCH_SENSOR
     ../../components/esp_hal_touch_sens/esp32s3/touch_sensor_periph.c
-    ../../components/esp_hal_touch_sens/touch_sensor_legacy_hal.c
-    ../../components/esp_hal_touch_sens/esp32s3/touch_sensor_legacy_hal.c
+    ../../components/esp_hal_touch_sens/touch_sens_hal.c
     )
 
   if (CONFIG_ESP32_TEMP)


### PR DESCRIPTION
Compile the touch sensor source files for newer SoCs, removing the APIs used by the legacy driver on ESP32, ESP32-S2 and ESP32-S3 and adding support for touch sensor for ESP32-P4.

Please check testing procedure at https://github.com/zephyrproject-rtos/zephyr/pull/112644