### PR TITLE
socs: rom: unbind reentrant functions from rom

### DIFF
--- a/components/esp_rom/esp32c2/ld/esp32c2.rom.libc.ld
+++ b/components/esp_rom/esp32c2/ld/esp32c2.rom.libc.ld
@@ -32,10 +32,9 @@ strsep = 0x40000540;
 strspn = 0x40000544;
 strtok_r = 0x40000548;
 
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( longjmp = 0x40000550 );
-PROVIDE ( setjmp = 0x40000554 );
-/*******************************************/
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* longjmp = 0x40000550; */
+/* setjmp  = 0x40000554; */
 
 abs = 0x40000558;
 div = 0x4000055c;
@@ -48,8 +47,9 @@ __match = 0x400005dc;
 __hexnan = 0x400005e0;
 __hexdig_fun = 0x400005e4;
 __gethex = 0x400005e8;
-_Balloc = 0x400005ec;
-_Bfree = 0x400005f0;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _Balloc = 0x400005ec; */
+/* _Bfree = 0x400005f0; */
 __multadd = 0x400005f4;
 __s2b = 0x400005f8;
 __hi0bits = 0x400005fc;

--- a/components/esp_rom/esp32c2/ld/esp32c2.rom.newlib.ld
+++ b/components/esp_rom/esp32c2/ld/esp32c2.rom.newlib.ld
@@ -15,34 +15,34 @@
  * multiple files to make it compatible with picolibc.
  */
 
-
 /***************************************
  Group newlib
  ***************************************/
 
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( strdup = 0x40000510 );
-PROVIDE ( strndup = 0x40000534 );
-PROVIDE ( rand_r = 0x4000056c );
-PROVIDE ( rand = 0x40000570 );
-PROVIDE ( srand = 0x40000574 );
-PROVIDE ( atoi = 0x40000580 );
-PROVIDE ( atol = 0x40000584 );
-PROVIDE ( strtol = 0x40000588 );
-PROVIDE ( strtoul = 0x4000058c );
-PROVIDE ( fflush = 0x40000590 );
-PROVIDE ( _fflush_r = 0x40000594 );
-PROVIDE ( _fwalk = 0x40000598 );
-PROVIDE ( _fwalk_reent = 0x4000059c );
-PROVIDE ( __swbuf_r = 0x400005a8 );
-/*******************************************/
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* strdup       = 0x40000510; */
+/* strndup      = 0x40000534; */
+/* rand_r       = 0x4000056c; */
+/* rand         = 0x40000570; */
+/* srand        = 0x40000574; */
+/* atoi         = 0x40000580; */
+/* atol         = 0x40000584; */
+/* strtol       = 0x40000588; */
+/* strtoul      = 0x4000058c; */
+/* fflush       = 0x40000590; */
+/* _fflush_r    = 0x40000594; */
+/* _fwalk       = 0x40000598; */
+/* _fwalk_reent = 0x4000059c; */
+/* __swbuf_r    = 0x400005a8; */
 
 /* Functions */
-_isatty_r = 0x400004b4;
-__smakebuf_r = 0x400005a0;
-__swhatbuf_r = 0x400005a4;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _isatty_r = 0x400004b4; */
+/* __smakebuf_r = 0x400005a0; */
+/* __swhatbuf_r = 0x400005a4; */
 __swbuf = 0x400005ac;
-__swsetup_r = 0x400005b0;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swsetup_r = 0x400005b0; */
 toupper = 0x400004ec;
 tolower = 0x400004f0;
 isalnum = 0x400004bc;

--- a/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld
+++ b/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld
@@ -19,22 +19,21 @@
  Group newlib
  ***************************************/
 
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( strdup = 0x400003dc );
-PROVIDE ( strndup = 0x40000400 );
-PROVIDE ( rand = 0x4000043c );
-PROVIDE ( srand = 0x40000440 );
-PROVIDE ( rand_r = 0x40000438 );
-PROVIDE ( atoi = 0x4000044c );
-PROVIDE ( atol = 0x40000450 );
-PROVIDE ( strtol = 0x40000454 );
-PROVIDE ( strtoul = 0x40000458 );
-PROVIDE( fflush = 0x4000045c );
-PROVIDE( _fflush_r = 0x40000460 );
-PROVIDE( _fwalk = 0x40000464 );
-PROVIDE( _fwalk_reent = 0x40000468 );
-PROVIDE( __swbuf_r = 0x40000474 );
-/*******************************************/
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* strdup  = 0x400003dc; */
+/* strndup = 0x40000400; */
+/* rand    = 0x4000043c; */
+/* srand   = 0x40000440; */
+/* rand_r  = 0x40000438; */
+/* atoi    = 0x4000044c; */
+/* atol    = 0x40000450; */
+/* strtol  = 0x40000454; */
+/* strtoul = 0x40000458; */
+/* fflush       = 0x4000045c; */
+/* _fflush_r    = 0x40000460; */
+/* _fwalk       = 0x40000464; */
+/* _fwalk_reent = 0x40000468; */
+/* __swbuf_r    = 0x40000474; */
 
 /* Functions */
 __swbuf = 0x40000478;

--- a/components/esp_rom/esp32c5/ld/esp32c5.rom.libc.ld
+++ b/components/esp_rom/esp32c5/ld/esp32c5.rom.libc.ld
@@ -17,10 +17,9 @@
  Group libc
  ***************************************/
 
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( longjmp = 0x40000580 );
-PROVIDE ( setjmp = 0x40000584 );
-/*******************************************/
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* longjmp = 0x40000580; */
+/* setjmp  = 0x40000584; */
 
 /* Functions */
 esp_rom_newlib_init_common_mutexes = 0x400004b4;

--- a/components/esp_rom/esp32c5/ld/esp32c5.rom.newlib.ld
+++ b/components/esp_rom/esp32c5/ld/esp32c5.rom.newlib.ld
@@ -17,29 +17,30 @@
  Group newlib
  ***************************************/
 
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( strdup = 0x40000540 );
-PROVIDE ( strndup = 0x40000564 );
-PROVIDE ( rand = 0x400005a0 );
-PROVIDE ( srand = 0x400005a4 );
-PROVIDE ( rand_r = 0x4000059c );
-PROVIDE ( atoi = 0x400005b0 );
-PROVIDE ( atol = 0x400005b4 );
-PROVIDE ( strtol = 0x400005b8 );
-PROVIDE ( strtoul = 0x400005bc );
-PROVIDE ( fflush = 0x400005c0 );
-PROVIDE ( _fflush_r = 0x400005c4 );
-PROVIDE ( _fwalk = 0x400005c8 );
-PROVIDE ( _fwalk_reent = 0x400005cc );
-PROVIDE ( __swbuf_r = 0x400005d8 );
-/*******************************************/
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* strdup       = 0x40000540; */
+/* strndup      = 0x40000564; */
+/* rand         = 0x400005a0; */
+/* srand        = 0x400005a4; */
+/* rand_r       = 0x4000059c; */
+/* atoi         = 0x400005b0; */
+/* atol         = 0x400005b4; */
+/* strtol       = 0x400005b8; */
+/* strtoul      = 0x400005bc; */
+/* fflush       = 0x400005c0; */
+/* _fflush_r    = 0x400005c4; */
+/* _fwalk       = 0x400005c8; */
+/* _fwalk_reent = 0x400005cc; */
+/* __swbuf_r    = 0x400005d8; */
 
 /* Functions */
-_isatty_r = 0x400004e4;
-__smakebuf_r = 0x400005d0;
-__swhatbuf_r = 0x400005d4;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _isatty_r = 0x400004e4; */
+/* __smakebuf_r = 0x400005d0; */
+/* __swhatbuf_r = 0x400005d4; */
 __swbuf = 0x400005dc;
-__swsetup_r = 0x400005e0;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swsetup_r = 0x400005e0; */
 toupper = 0x4000051c;
 tolower = 0x40000520;
 isalnum = 0x400004ec;

--- a/components/esp_rom/esp32c6/ld/esp32c6.rom.libc.ld
+++ b/components/esp_rom/esp32c6/ld/esp32c6.rom.libc.ld
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( longjmp = 0x40000570 );
-PROVIDE ( setjmp = 0x40000574 );
-/*******************************************/
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* longjmp = 0x40000570; */
+/* setjmp  = 0x40000574; */
 
 esp_rom_newlib_init_common_mutexes = 0x400004a4;
 memset = 0x400004a8;

--- a/components/esp_rom/esp32c6/ld/esp32c6.rom.newlib.ld
+++ b/components/esp_rom/esp32c6/ld/esp32c6.rom.newlib.ld
@@ -19,29 +19,30 @@
  Group newlib
  ***************************************/
 
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( strdup = 0x40000530 );
-PROVIDE ( strndup = 0x40000554 );
-PROVIDE ( rand = 0x40000590 );
-PROVIDE ( srand = 0x40000594 );
-PROVIDE ( rand_r = 0x4000058c );
-PROVIDE ( atoi = 0x400005a0 );
-PROVIDE ( atol = 0x400005a4 );
-PROVIDE ( strtol = 0x400005a8 );
-PROVIDE ( strtoul = 0x400005ac );
-PROVIDE ( fflush = 0x400005b0 );
-PROVIDE ( _fflush_r = 0x400005b4 );
-PROVIDE ( _fwalk = 0x400005b8 );
-PROVIDE ( _fwalk_reent = 0x400005bc );
-PROVIDE ( __swbuf_r = 0x400005c8 );
-/*******************************************/
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* strdup       = 0x40000530; */
+/* strndup      = 0x40000554; */
+/* rand         = 0x40000590; */
+/* srand        = 0x40000594; */
+/* rand_r       = 0x4000058c; */
+/* atoi         = 0x400005a0; */
+/* atol         = 0x400005a4; */
+/* strtol       = 0x400005a8; */
+/* strtoul      = 0x400005ac; */
+/* fflush       = 0x400005b0; */
+/* _fflush_r    = 0x400005b4; */
+/* _fwalk       = 0x400005b8; */
+/* _fwalk_reent = 0x400005bc; */
+/* __swbuf_r    = 0x400005c8; */
 
 /* Functions */
-_isatty_r = 0x400004d4;
-__smakebuf_r = 0x400005c0;
-__swhatbuf_r = 0x400005c4;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _isatty_r = 0x400004d4; */
+/* __smakebuf_r = 0x400005c0; */
+/* __swhatbuf_r = 0x400005c4; */
 __swbuf = 0x400005cc;
-__swsetup_r = 0x400005d0;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swsetup_r = 0x400005d0; */
 toupper = 0x4000050c;
 tolower = 0x40000510;
 isalnum = 0x400004dc;

--- a/components/esp_rom/esp32h2/ld/esp32h2.rom.libc.ld
+++ b/components/esp_rom/esp32h2/ld/esp32h2.rom.libc.ld
@@ -31,9 +31,10 @@ strrchr = 0x40000554;
 strsep = 0x40000558;
 strspn = 0x4000055c;
 strtok_r = 0x40000560;
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( longjmp = 0x40000568 );
-PROVIDE ( setjmp = 0x4000056c );
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* longjmp = 0x40000568; */
+/* setjmp  = 0x4000056c; */
+
 abs = 0x40000570;
 div = 0x40000574;
 labs = 0x40000578;

--- a/components/esp_rom/esp32h2/ld/esp32h2.rom.newlib.ld
+++ b/components/esp_rom/esp32h2/ld/esp32h2.rom.newlib.ld
@@ -20,26 +20,32 @@
  ***************************************/
 
 /* Functions */
-_isatty_r = 0x400004cc;
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( strdup = 0x40000528 );
-PROVIDE ( strndup = 0x4000054c );
-PROVIDE ( rand_r = 0x40000584 );
-PROVIDE ( rand = 0x40000588 );
-PROVIDE ( srand = 0x4000058c );
-PROVIDE ( atoi = 0x40000598 );
-PROVIDE ( atol = 0x4000059c );
-PROVIDE ( strtol = 0x400005a0 );
-PROVIDE ( strtoul = 0x400005a4 );
-PROVIDE ( fflush = 0x400005a8 );
-PROVIDE ( _fflush_r = 0x400005ac );
-PROVIDE ( _fwalk = 0x400005b0 );
-PROVIDE ( _fwalk_reent = 0x400005b4 );
-__smakebuf_r = 0x400005b8;
-__swhatbuf_r = 0x400005bc;
-PROVIDE ( __swbuf_r = 0x400005c0 );
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _isatty_r = 0x400004cc; */
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* strdup       = 0x40000528; */
+/* strndup      = 0x4000054c; */
+/* rand_r       = 0x40000584; */
+/* rand         = 0x40000588; */
+/* srand        = 0x4000058c; */
+/* atoi         = 0x40000598; */
+/* atol         = 0x4000059c; */
+/* strtol       = 0x400005a0; */
+/* strtoul      = 0x400005a4; */
+/* fflush       = 0x400005a8; */
+/* _fflush_r    = 0x400005ac; */
+/* _fwalk       = 0x400005b0; */
+/* _fwalk_reent = 0x400005b4; */
+
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __smakebuf_r = 0x400005b8; */
+/* __swhatbuf_r = 0x400005bc; */
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swbuf_r = 0x400005c0; */
+
 __swbuf = 0x400005c4;
-__swsetup_r = 0x400005c8;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swsetup_r = 0x400005c8; */
 toupper = 0x40000504;
 tolower = 0x40000508;
 isalnum = 0x400004d4;

--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.libc.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.libc.ld
@@ -31,9 +31,10 @@ strrchr = 0x4fc0031c;
 strsep = 0x4fc00320;
 strspn = 0x4fc00324;
 strtok_r = 0x4fc00328;
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( longjmp = 0x4fc00330 );
-PROVIDE ( setjmp = 0x4fc00334 );
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* longjmp = 0x4fc00330; */
+/* setjmp  = 0x4fc00334; */
+
 abs = 0x4fc00338;
 div = 0x4fc0033c;
 labs = 0x4fc00340;

--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.newlib.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.newlib.ld
@@ -20,26 +20,32 @@
  ***************************************/
 
 /* Functions */
-_isatty_r = 0x4fc00294;
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( strdup = 0x4fc002f0 );
-PROVIDE ( strndup = 0x4fc00314 );
-PROVIDE ( rand_r = 0x4fc0034c );
-PROVIDE ( rand = 0x4fc00350 );
-PROVIDE ( srand = 0x4fc00354 );
-PROVIDE ( atoi = 0x4fc00360 );
-PROVIDE ( atol = 0x4fc00364 );
-PROVIDE ( strtol = 0x4fc00368 );
-PROVIDE ( strtoul = 0x4fc0036c );
-PROVIDE ( fflush = 0x4fc00370 );
-PROVIDE ( _fflush_r = 0x4fc00374 );
-PROVIDE ( _fwalk = 0x4fc00378 );
-PROVIDE ( _fwalk_reent = 0x4fc0037c );
-__smakebuf_r = 0x4fc00380;
-__swhatbuf_r = 0x4fc00384;
-PROVIDE ( __swbuf_r = 0x4fc00388 );
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _isatty_r = 0x4fc00294; */
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* strdup       = 0x4fc002f0; */
+/* strndup      = 0x4fc00314; */
+/* rand_r       = 0x4fc0034c; */
+/* rand         = 0x4fc00350; */
+/* srand        = 0x4fc00354; */
+/* atoi         = 0x4fc00360; */
+/* atol         = 0x4fc00364; */
+/* strtol       = 0x4fc00368; */
+/* strtoul      = 0x4fc0036c; */
+/* fflush       = 0x4fc00370; */
+/* _fflush_r    = 0x4fc00374; */
+/* _fwalk       = 0x4fc00378; */
+/* _fwalk_reent = 0x4fc0037c; */
+
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __smakebuf_r = 0x4fc00380; */
+/* __swhatbuf_r = 0x4fc00384; */
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swbuf_r = 0x4fc00388; */
+
 __swbuf = 0x4fc0038c;
-__swsetup_r = 0x4fc00390;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swsetup_r = 0x4fc00390; */
 toupper = 0x4fc002cc;
 tolower = 0x4fc002d0;
 isalnum = 0x4fc0029c;

--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.libc.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.libc.ld
@@ -3,10 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( longjmp = 0x4fc00330 );
-PROVIDE ( setjmp = 0x4fc00334 );
-/*******************************************/
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* longjmp = 0x4fc00330; */
+/* setjmp  = 0x4fc00334; */
 
 /* Functions */
 esp_rom_newlib_init_common_mutexes = 0x4fc00264;

--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.newlib.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.newlib.ld
@@ -19,26 +19,27 @@
  Group newlib
  ***************************************/
 
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( strdup = 0x4fc002f0 );
-PROVIDE ( strndup = 0x4fc00314 );
-PROVIDE ( rand_r = 0x4fc0034c );
-PROVIDE ( rand = 0x4fc00350 );
-PROVIDE ( srand = 0x4fc00354 );
-PROVIDE ( atoi = 0x4fc00360 );
-PROVIDE ( atol = 0x4fc00364 );
-PROVIDE ( strtol = 0x4fc00368 );
-PROVIDE ( strtoul = 0x4fc0036c );
-PROVIDE ( fflush = 0x4fc00370 );
-PROVIDE ( _fflush_r = 0x4fc00374 );
-PROVIDE ( _fwalk = 0x4fc00378 );
-PROVIDE ( _fwalk_reent = 0x4fc0037c );
-PROVIDE ( __swbuf_r = 0x4fc00388 );
-/*******************************************/
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* strdup       = 0x4fc002f0; */
+/* strndup      = 0x4fc00314; */
+/* rand_r       = 0x4fc0034c; */
+/* rand         = 0x4fc00350; */
+/* srand        = 0x4fc00354; */
+/* atoi         = 0x4fc00360; */
+/* atol         = 0x4fc00364; */
+/* strtol       = 0x4fc00368; */
+/* strtoul      = 0x4fc0036c; */
+/* fflush       = 0x4fc00370; */
+/* _fflush_r    = 0x4fc00374; */
+/* _fwalk       = 0x4fc00378; */
+/* _fwalk_reent = 0x4fc0037c; */
+/* __swbuf_r    = 0x4fc00388; */
 
 /* Functions */
-_isatty_r = 0x4fc00294;
-__smakebuf_r = 0x4fc00380;
-__swhatbuf_r = 0x4fc00384;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _isatty_r = 0x4fc00294; */
+/* __smakebuf_r = 0x4fc00380; */
+/* __swhatbuf_r = 0x4fc00384; */
 __swbuf = 0x4fc0038c;
-__swsetup_r = 0x4fc00390;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swsetup_r = 0x4fc00390; */

--- a/components/esp_rom/esp32p4/ld/esp32p4lp.rom.newlib.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4lp.rom.newlib.ld
@@ -64,12 +64,12 @@ strsep = 0x501001dc;
 strspn = 0x501001e0;
 strtok_r = 0x501001e4;
 strupr = 0x501001e8;
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( longjmp = 0x501001ec );
-PROVIDE ( setjmp = 0x501001f0 );
-PROVIDE ( atoi = 0x50100208 );
-PROVIDE ( atol = 0x5010020c );
-/*******************************************/
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* longjmp = 0x501001ec; */
+/* setjmp  = 0x501001f0; */
+/* atoi    = 0x50100208; */
+/* atol    = 0x5010020c; */
+
 abs = 0x501001f4;
 div = 0x501001f8;
 labs = 0x501001fc;

--- a/components/esp_rom/esp32s2/ld/esp32s2.rom.libc-funcs.ld
+++ b/components/esp_rom/esp32s2/ld/esp32s2.rom.libc-funcs.ld
@@ -25,8 +25,10 @@ isprint = 0x40007980;
 ispunct = 0x40007994;
 labs = 0x40000648;
 ldiv = 0x40000650;
-PROVIDE ( longjmp = 0x400005a4 );
-PROVIDE ( setjmp = 0x40000540 );
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* longjmp = 0x400005a4; */
+/* setjmp  = 0x40000540; */
+
 memccpy = 0x4001ab00;
 memchr = 0x4001ab24;
 memcmp = 0x4001ab40;
@@ -51,6 +53,8 @@ strrchr = 0x40008040;
 strsep = 0x4000806c;
 strspn = 0x4001aebc;
 strstr = 0x4001aee8;
-PROVIDE ( __strtok_r = 0x4001af18 );
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __strtok_r = 0x4001af18; */
+
 strtok_r = 0x4001af7c;
 toascii = 0x4001af90;

--- a/components/esp_rom/esp32s2/ld/esp32s2.rom.newlib-reent-funcs.ld
+++ b/components/esp_rom/esp32s2/ld/esp32s2.rom.newlib-reent-funcs.ld
@@ -3,51 +3,61 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-PROVIDE ( _cleanup_r = 0x4001a480 );
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _cleanup_r = 0x4001a480; */
+
 creat = 0x4000788c;
 open = 0x400080c4;
 fclose = 0x4001a804;
-PROVIDE ( _fclose_r = 0x4001a714 );
-PROVIDE ( fflush = 0x40001bb8 );
-PROVIDE ( _fflush_r = 0x40001b30 );
-PROVIDE ( __fp_unlock_all = 0x4001a64c );
-PROVIDE ( __fputwc = 0x40001770 );
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _fclose_r       = 0x4001a714; */
+/* fflush          = 0x40001bb8; */
+/* _fflush_r       = 0x40001b30; */
+/* __fp_unlock_all = 0x4001a64c; */
+/* __fputwc        = 0x40001770; */
+
 fputwc = 0x40001864;
-PROVIDE ( _fputwc_r = 0x400017f8 );
-PROVIDE ( _fwalk = 0x4001bcec );
-PROVIDE ( _fwalk_reent = 0x4001bd24 );
-PROVIDE ( __sflush_r = 0x400019dc );
-PROVIDE ( __swbuf = 0x4000167c );
-PROVIDE ( __swbuf_r = 0x400015bc );
-PROVIDE ( __swrite = 0x4001a698 );
-PROVIDE ( __sread = 0x4001a660 );
-PROVIDE ( __sseek = 0x4001a6cc );
-PROVIDE ( srand = 0x40007a24 );
-PROVIDE ( rand_r = 0x40007af4 );
-PROVIDE ( __ascii_mbtowc = 0x40007a04 );
-PROVIDE ( __ascii_wctomb = 0x400018d0 );
-PROVIDE ( _mbtowc_r = 0x400079e0 );
-PROVIDE ( __sclose = 0x4001a700 );
-PROVIDE ( __seofread = 0x4001a690 );
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _fputwc_r      = 0x400017f8; */
+/* _fwalk         = 0x4001bcec; */
+/* _fwalk_reent   = 0x4001bd24; */
+/* __sflush_r     = 0x400019dc; */
+/* __swbuf        = 0x4000167c; */
+/* __swbuf_r      = 0x400015bc; */
+/* __swrite       = 0x4001a698; */
+/* __sread        = 0x4001a660; */
+/* __sseek        = 0x4001a6cc; */
+/* srand          = 0x40007a24; */
+/* rand_r         = 0x40007af4; */
+/* __ascii_mbtowc = 0x40007a04; */
+/* __ascii_wctomb = 0x400018d0; */
+/* _mbtowc_r      = 0x400079e0; */
+/* __sclose       = 0x4001a700; */
+/* __seofread     = 0x4001a690; */
+
 setlocale = 0x40001c44;
-PROVIDE ( _setlocale_r = 0x40001bdc );
-PROVIDE ( __sfmoreglue = 0x4001a4c8 );
-PROVIDE ( __sfp = 0x4001a590 );
-PROVIDE ( __sfp_lock_acquire = 0x4001a508 );
-PROVIDE ( __sfp_lock_release = 0x4001a514 );
-PROVIDE ( __sinit = 0x4001a538 );
-PROVIDE ( __sinit_lock_acquire = 0x4001a520 );
-PROVIDE ( __sinit_lock_release = 0x4001a52c );
-PROVIDE ( strndup = 0x40007fe8 );
-PROVIDE ( strdup = 0x40007d84 );
-PROVIDE ( _strndup_r = 0x40007ffc );
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _setlocale_r         = 0x40001bdc; */
+/* __sfmoreglue         = 0x4001a4c8; */
+/* __sfp                = 0x4001a590; */
+/* __sfp_lock_acquire   = 0x4001a508; */
+/* __sfp_lock_release   = 0x4001a514; */
+/* __sinit              = 0x4001a538; */
+/* __sinit_lock_acquire = 0x4001a520; */
+/* __sinit_lock_release = 0x4001a52c; */
+/* strndup              = 0x40007fe8; */
+/* strdup               = 0x40007d84; */
+/* _strndup_r           = 0x40007ffc; */
+
 wcrtomb = 0x400012f4;
-PROVIDE ( _wcrtomb_r = 0x400012a0 );
-PROVIDE ( _wctomb_r = 0x400018ac );
-PROVIDE ( _strdup_r = 0x40007d98 );
-PROVIDE ( __locale_ctype_ptr = 0x40001c2c );
-PROVIDE ( __locale_ctype_ptr_l = 0x40001c24 );
-PROVIDE ( __locale_mb_cur_max = 0x40001c0c );
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _wcrtomb_r           = 0x400012a0; */
+/* _wctomb_r            = 0x400018ac; */
+/* _strdup_r            = 0x40007d98; */
+/* __locale_ctype_ptr   = 0x40001c2c; */
+/* __locale_ctype_ptr_l = 0x40001c24; */
+/* __locale_mb_cur_max  = 0x40001c0c; */
+
 strcasecmp = 0x40007b38;
 strcasestr = 0x40007b7c;
 tolower = 0x40008158;

--- a/components/esp_rom/esp32s3/ld/esp32s3.rom.libc.ld
+++ b/components/esp_rom/esp32s3/ld/esp32s3.rom.libc.ld
@@ -45,7 +45,8 @@ div = 0x40001464;
 labs = 0x40001470;
 ldiv = 0x4000147c;
 qsort = 0x40001488;
-rand_r = 0x40001494;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* rand_r = 0x40001494; */
 utoa = 0x400014b8;
 itoa = 0x400014c4;
 /* Data (.data, .bss, .rodata) */

--- a/components/esp_rom/esp32s3/ld/esp32s3.rom.newlib.ld
+++ b/components/esp_rom/esp32s3/ld/esp32s3.rom.newlib.ld
@@ -15,25 +15,23 @@
  * multiple files to make it compatible with picolibc.
  */
 
-/* ZEPHYR: Keep PROVIDE for these symbols: */
-PROVIDE ( atoi = 0x400014d0 );
-PROVIDE ( atol = 0x400014dc );
-PROVIDE ( strdup = 0x40001380 );
-PROVIDE ( strndup = 0x400013ec );
-PROVIDE ( rand_r = 0x40001494 );
-PROVIDE ( rand = 0x400014a0 );
-PROVIDE ( srand = 0x400014ac );
-PROVIDE ( strtol = 0x400014e8 );
-PROVIDE ( strtoul = 0x400014f4 );
-PROVIDE ( longjmp = 0x40001440 );
-PROVIDE ( setjmp = 0x4000144c );
-/*******************************************/
-
-PROVIDE( fflush = 0x40001500 );
-PROVIDE( _fflush_r = 0x4000150c );
-PROVIDE( _fwalk = 0x40001518 );
-PROVIDE( _fwalk_reent = 0x40001524 );
-PROVIDE( __swbuf_r = 0x40001548 );
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* atoi    = 0x400014d0; */
+/* atol    = 0x400014dc; */
+/* strdup  = 0x40001380; */
+/* strndup = 0x400013ec; */
+/* rand_r  = 0x40001494; */
+/* rand    = 0x400014a0; */
+/* srand   = 0x400014ac; */
+/* strtol  = 0x400014e8; */
+/* strtoul = 0x400014f4; */
+/* longjmp = 0x40001440; */
+/* setjmp  = 0x4000144c; */
+/* fflush       = 0x40001500; */
+/* _fflush_r    = 0x4000150c; */
+/* _fwalk       = 0x40001518; */
+/* _fwalk_reent = 0x40001524; */
+/* __swbuf_r    = 0x40001548; */
 __swbuf = 0x40001554;
 toupper = 0x40001314;
 tolower = 0x40001320;


### PR DESCRIPTION
Let the selected libc provide the reentrant calls instead of
force-binding them to the rom. This avoids crashes when using
NEWLIB_LIBC.