### PR TITLE
hal: i2c: Add PM support

### DIFF
--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -444,10 +444,18 @@ if(CONFIG_SOC_SERIES_ESP32C5)
     ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_pvt.c
     )
 
-  zephyr_sources_ifdef(CONFIG_I2C_ESP32
-    ../../components/esp_hal_i2c/i2c_hal_iram.c
-    ../../components/esp_hal_i2c/i2c_hal.c
-    )
+  if(CONFIG_I2C_ESP32)
+    zephyr_sources(
+      ../../components/esp_hal_i2c/i2c_hal_iram.c
+      ../../components/esp_hal_i2c/i2c_hal.c
+      )
+
+    if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_sources(
+        ../../components/esp_hal_i2c/${CONFIG_SOC_SERIES}/i2c_periph.c
+        )
+    endif()
+  endif()
 
   zephyr_sources_ifdef(CONFIG_I2S_ESP32
     ../../components/esp_hal_i2s/i2s_hal.c

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -425,10 +425,18 @@ if(CONFIG_SOC_SERIES_ESP32C6)
     ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_pvt.c
     )
 
-  zephyr_sources_ifdef(CONFIG_I2C_ESP32
-    ../../components/esp_hal_i2c/i2c_hal_iram.c
-    ../../components/esp_hal_i2c/i2c_hal.c
-    )
+  if(CONFIG_I2C_ESP32)
+    zephyr_sources(
+      ../../components/esp_hal_i2c/i2c_hal_iram.c
+      ../../components/esp_hal_i2c/i2c_hal.c
+      )
+
+    if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_sources(
+        ../../components/esp_hal_i2c/${CONFIG_SOC_SERIES}/i2c_periph.c
+        )
+    endif()
+  endif()
 
   zephyr_sources_ifdef(CONFIG_I2S_ESP32
     ../../components/esp_hal_i2s/i2s_hal.c

--- a/zephyr/esp32h2/CMakeLists.txt
+++ b/zephyr/esp32h2/CMakeLists.txt
@@ -370,10 +370,18 @@ if(CONFIG_SOC_SERIES_ESP32H2)
       )
   endif()
 
-  zephyr_sources_ifdef(CONFIG_I2C_ESP32
-    ../../components/esp_hal_i2c/i2c_hal_iram.c
-    ../../components/esp_hal_i2c/i2c_hal.c
-    )
+  if(CONFIG_I2C_ESP32)
+    zephyr_sources(
+      ../../components/esp_hal_i2c/i2c_hal_iram.c
+      ../../components/esp_hal_i2c/i2c_hal.c
+      )
+
+    if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_sources(
+        ../../components/esp_hal_i2c/${CONFIG_SOC_SERIES}/i2c_periph.c
+        )
+    endif()
+  endif()
 
   zephyr_sources_ifdef(CONFIG_I2S_ESP32
     ../../components/esp_hal_i2s/i2s_hal.c

--- a/zephyr/esp32p4/CMakeLists.txt
+++ b/zephyr/esp32p4/CMakeLists.txt
@@ -458,10 +458,18 @@ if(CONFIG_SOC_SERIES_ESP32P4)
     ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_pvt.c
     )
 
-  zephyr_sources_ifdef(CONFIG_I2C_ESP32
-    ../../components/esp_hal_i2c/i2c_hal_iram.c
-    ../../components/esp_hal_i2c/i2c_hal.c
-    )
+  if(CONFIG_I2C_ESP32)
+    zephyr_sources(
+      ../../components/esp_hal_i2c/i2c_hal_iram.c
+      ../../components/esp_hal_i2c/i2c_hal.c
+      )
+
+    if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_sources(
+        ../../components/esp_hal_i2c/${CONFIG_SOC_SERIES}/i2c_periph.c
+        )
+    endif()
+  endif()
 
   zephyr_sources_ifdef(CONFIG_I2S_ESP32
     ../../components/esp_hal_i2s/i2s_hal.c


### PR DESCRIPTION
Link i2c_periph.c retention tables when I2C and TOP peripheral power-down in light sleep are enabled on supported SoCs.