### PR TITLE
hal: pm: Fix sleep retention

### DIFF
--- a/components/esp_driver_dma/esp32c5/gdma_retention.c
+++ b/components/esp_driver_dma/esp32c5/gdma_retention.c
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gdma_priv.h"
+#include "soc/ahb_dma_reg.h"
+
+/* AHB_DMA Channel (Group0, Pair0) Registers Context
+   Include: AHB_DMA_MISC_CONF_REG
+            AHB_DMA_IN_INT_ENA_CH0_REG / AHB_DMA_OUT_INT_ENA_CH0_REG / AHB_DMA_IN_PERI_SEL_CH0_REG / AHB_DMA_OUT_PERI_SEL_CH0_REG
+            AHB_DMA_IN_CONF0_CH0_REG / AHB_DMA_IN_CONF1_CH0_REG / AHB_DMA_IN_LINK_CH0_REG / AHB_DMA_IN_PRI_CH0_REG
+            AHB_DMA_OUT_CONF0_CH0_REG / AHB_DMA_OUT_CONF1_CH0_REG / AHB_DMA_OUT_LINK_CH0_REG / AHB_DMA_OUT_PRI_CH0_REG
+
+            AHB_DMA_TX_CH_ARB_WEIGHT_CH0_REG / AHB_DMA_TX_ARB_WEIGHT_OPT_DIS_CH0_REG
+            AHB_DMA_RX_CH_ARB_WEIGHT_CH0_REG / AHB_DMA_RX_ARB_WEIGHT_OPT_DIS_CH0_REG
+            AHB_DMA_IN_LINK_ADDR_CH0_REG / AHB_DMA_OUT_LINK_ADDR_CH0_REG
+            AHB_DMA_INTR_MEM_START_ADDR_REG / AHB_DMA_INTR_MEM_END_ADDR_REG
+            AHB_DMA_ARB_TIMEOUT_REG / AHB_DMA_WEIGHT_EN_REG
+            AHB_DMA_MODULE_CLK_EN_REG
+*/
+#define G0P0_RETENTION_REGS_CNT_0 13
+#define G0P0_RETENTION_MAP_BASE_0 (DR_REG_AHB_DMA_BASE + 0x8)
+#define G0P0_RETENTION_REGS_CNT_1 11
+#define G0P0_RETENTION_MAP_BASE_1 (DR_REG_AHB_DMA_BASE + 0x2dc)
+static const uint32_t g0p0_regs_map0[4] = {0x4c801001, 0x604c0060, 0x0, 0x0};
+static const uint32_t g0p0_regs_map1[4] = {0xc0000003, 0x0c900000, 0x601, 0x0};
+static const regdma_entries_config_t gdma_g0p0_regs_retention[] = {
+    [0] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            G0P0_RETENTION_MAP_BASE_0, G0P0_RETENTION_MAP_BASE_0, \
+                                            G0P0_RETENTION_REGS_CNT_0, 0, 0, \
+                                            g0p0_regs_map0[0], g0p0_regs_map0[1], \
+                                            g0p0_regs_map0[2], g0p0_regs_map0[3]), \
+        .owner = GDMA_RETENTION_ENTRY
+    }, \
+    [1] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x01), \
+                                            G0P0_RETENTION_MAP_BASE_1, G0P0_RETENTION_MAP_BASE_1, \
+                                            G0P0_RETENTION_REGS_CNT_1, 0, 0, \
+                                            g0p0_regs_map1[0], g0p0_regs_map1[1],   \
+                                            g0p0_regs_map1[2], g0p0_regs_map1[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+/* AHB_DMA Channel (Group0, Pair1) Registers Context
+   Include: AHB_DMA_MISC_CONF_REG
+            AHB_DMA_IN_INT_ENA_CH1_REG / AHB_DMA_OUT_INT_ENA_CH1_REG / AHB_DMA_IN_PERI_SEL_CH1_REG / AHB_DMA_OUT_PERI_SEL_CH1_REG
+            AHB_DMA_IN_CONF0_CH1_REG / AHB_DMA_IN_CONF1_CH1_REG / AHB_DMA_IN_LINK_CH1_REG / AHB_DMA_IN_PRI_CH1_REG
+            AHB_DMA_OUT_CONF0_CH1_REG / AHB_DMA_OUT_CONF1_CH1_REG / AHB_DMA_OUT_LINK_CH1_REG / AHB_DMA_OUT_PRI_CH1_REG
+
+            AHB_DMA_TX_CH_ARB_WEIGHT_CH1_REG / AHB_DMA_TX_ARB_WEIGHT_OPT_DIS_CH1_REG
+            AHB_DMA_RX_CH_ARB_WEIGHT_CH1_REG / AHB_DMA_RX_ARB_WEIGHT_OPT_DIS_CH1_REG
+            AHB_DMA_IN_LINK_ADDR_CH1_REG / AHB_DMA_OUT_LINK_ADDR_CH1_REG
+            AHB_DMA_INTR_MEM_START_ADDR_REG / AHB_DMA_INTR_MEM_END_ADDR_REG
+            AHB_DMA_ARB_TIMEOUT_REG / AHB_DMA_WEIGHT_EN_REG
+            AHB_DMA_MODULE_CLK_EN_REG
+*/
+#define G0P1_RETENTION_REGS_CNT_0  13
+#define G0P1_RETENTION_MAP_BASE_0  (DR_REG_AHB_DMA_BASE + 0x18)
+#define G0P1_RETENTION_REGS_CNT_1  11
+#define G0P1_RETENTION_MAP_BASE_1  (DR_REG_AHB_DMA_BASE + 0x304)
+static const uint32_t g0p1_regs_map0[4] = {0x81001, 0x0, 0xc00604c0, 0x604};
+static const uint32_t g0p1_regs_map1[4] = {0xc0000003, 0x434800, 0x18, 0x0};
+static const regdma_entries_config_t gdma_g0p1_regs_retention[] = {
+    [0] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            G0P1_RETENTION_MAP_BASE_0, G0P1_RETENTION_MAP_BASE_0, \
+                                            G0P1_RETENTION_REGS_CNT_0, 0, 0, \
+                                            g0p1_regs_map0[0], g0p1_regs_map0[1],   \
+                                            g0p1_regs_map0[2], g0p1_regs_map0[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+    [1] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x01), \
+                                            G0P1_RETENTION_MAP_BASE_1, G0P1_RETENTION_MAP_BASE_1, \
+                                            G0P1_RETENTION_REGS_CNT_1, 0, 0, \
+                                            g0p1_regs_map1[0], g0p1_regs_map1[1],   \
+                                            g0p1_regs_map1[2], g0p1_regs_map1[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+/* AHB_DMA Channel (Group0, Pair2) Registers Context
+   Include: AHB_DMA_MISC_CONF_REG
+            AHB_DMA_IN_INT_ENA_CH2_REG / AHB_DMA_OUT_INT_ENA_CH2_REG
+            AHB_DMA_IN_PERI_SEL_CH2_REG
+            AHB_DMA_IN_CONF0_CH2_REG / AHB_DMA_IN_CONF1_CH2_REG / AHB_DMA_IN_LINK_CH2_REG / AHB_DMA_IN_PRI_CH2_REG
+
+            AHB_DMA_OUT_PERI_SEL_CH2_REG
+            AHB_DMA_OUT_CONF0_CH2_REG / AHB_DMA_OUT_CONF1_CH2_REG / AHB_DMA_OUT_LINK_CH2_REG / AHB_DMA_OUT_PRI_CH2_REG
+            AHB_DMA_TX_CH_ARB_WEIGHT_CH2_REG / AHB_DMA_TX_ARB_WEIGHT_OPT_DIS_CH2_REG
+            AHB_DMA_RX_CH_ARB_WEIGHT_CH2_REG / AHB_DMA_RX_ARB_WEIGHT_OPT_DIS_CH2_REG
+            AHB_DMA_IN_LINK_ADDR_CH2_REG / AHB_DMA_OUT_LINK_ADDR_CH2_REG
+            AHB_DMA_INTR_MEM_START_ADDR_REG / AHB_DMA_INTR_MEM_END_ADDR_REG
+            AHB_DMA_ARB_TIMEOUT_REG / AHB_DMA_WEIGHT_EN_REG
+            AHB_DMA_MODULE_CLK_EN_REG
+*/
+#define G0P2_RETENTION_REGS_CNT_0  8
+#define G0P2_RETENTION_MAP_BASE_0  (DR_REG_AHB_DMA_BASE + 0x28)
+#define G0P2_RETENTION_REGS_CNT_1  16
+#define G0P2_RETENTION_MAP_BASE_1  (DR_REG_AHB_DMA_BASE + 0x250)
+static const uint32_t g0p2_regs_map0[4] = {0x9001, 0x0, 0x0, 0x604c0000};
+static const uint32_t g0p2_regs_map1[4] =  {0x1813, 0x1800000, 0x72600000, 0x3008};
+static const regdma_entries_config_t gdma_g0p2_regs_retention[] = {
+    [0] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            G0P2_RETENTION_MAP_BASE_0, G0P2_RETENTION_MAP_BASE_0, \
+                                            G0P2_RETENTION_REGS_CNT_0, 0, 0, \
+                                            g0p2_regs_map0[0], g0p2_regs_map0[1],   \
+                                            g0p2_regs_map0[2], g0p2_regs_map0[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+    [1] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x01), \
+                                            G0P2_RETENTION_MAP_BASE_1, G0P2_RETENTION_MAP_BASE_1, \
+                                            G0P2_RETENTION_REGS_CNT_1, 0, 0, \
+                                            g0p2_regs_map1[0], g0p2_regs_map1[1],   \
+                                            g0p2_regs_map1[2], g0p2_regs_map1[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+const gdma_retention_desc_t gdma_retention_infos[1][3] = {
+    [0] = {
+        [0] = {
+            gdma_g0p0_regs_retention,
+            ARRAY_SIZE(gdma_g0p0_regs_retention),
+            SLEEP_RETENTION_MODULE_GDMA_CH0,
+        },
+        [1] = {
+            gdma_g0p1_regs_retention,
+            ARRAY_SIZE(gdma_g0p1_regs_retention),
+            SLEEP_RETENTION_MODULE_GDMA_CH1,
+        },
+        [2] = {
+            gdma_g0p2_regs_retention,
+            ARRAY_SIZE(gdma_g0p2_regs_retention),
+            SLEEP_RETENTION_MODULE_GDMA_CH2,
+        }
+    }
+};

--- a/components/esp_driver_dma/esp32c6/gdma_retention.c
+++ b/components/esp_driver_dma/esp32c6/gdma_retention.c
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gdma_priv.h"
+#include "soc/gdma_reg.h"
+
+/* GDMA Channel (Group0, Pair0) Registers Context
+   Include: GDMA_MISC_CONF_REG /
+            GDMA_IN_INT_ENA_CH0_REG / GDMA_OUT_INT_ENA_CH0_REG / GDMA_IN_PERI_SEL_CH0_REG / GDMA_OUT_PERI_SEL_CH0_REG
+            GDMA_IN_CONF0_CH0_REG / GDMA_IN_CONF1_CH0_REG / GDMA_IN_LINK_CH0_REG / GDMA_IN_PRI_CH0_REG
+            GDMA_OUT_CONF0_CH0_REG / GDMA_OUT_CONF1_CH0_REG / GDMA_OUT_LINK_CH0_REG /GDMA_OUT_PRI_CH0_REG
+*/
+#define G0P0_RETENTION_REGS_CNT  13
+#define G0P0_RETENTION_MAP_BASE  GDMA_IN_INT_ENA_CH0_REG
+static const uint32_t g0p0_regs_map[4] = {0x4C801001, 0x604C0060, 0, 0};
+static const regdma_entries_config_t gdma_g0p0_regs_retention[] = {
+    [0]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            G0P0_RETENTION_MAP_BASE, G0P0_RETENTION_MAP_BASE, \
+                                            G0P0_RETENTION_REGS_CNT, 0, 0, \
+                                            g0p0_regs_map[0], g0p0_regs_map[1],   \
+                                            g0p0_regs_map[2], g0p0_regs_map[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+/* GDMA Channel (Group0, Pair1) Registers Context
+   Include: GDMA_MISC_CONF_REG /
+            GDMA_IN_INT_ENA_CH1_REG / GDMA_OUT_INT_ENA_CH1_REG / GDMA_IN_PERI_SEL_CH1_REG / GDMA_OUT_PERI_SEL_CH1_REG
+            GDMA_IN_CONF0_CH1_REG / GDMA_IN_CONF1_CH1_REG / GDMA_IN_LINK_CH1_REG / GDMA_IN_PRI_CH1_REG
+            GDMA_OUT_CONF0_CH1_REG / GDMA_OUT_CONF1_CH1_REG / GDMA_OUT_LINK_CH1_REG /GDMA_OUT_PRI_CH1_REG
+*/
+#define G0P1_RETENTION_REGS_CNT  13
+#define G0P1_RETENTION_MAP_BASE  GDMA_IN_INT_ENA_CH1_REG
+static const uint32_t g0p1_regs_map[4] = {0x81001, 0, 0xC00604C0, 0x604};
+static const regdma_entries_config_t gdma_g0p1_regs_retention[] = {
+    [0]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            G0P1_RETENTION_MAP_BASE, G0P1_RETENTION_MAP_BASE, \
+                                            G0P1_RETENTION_REGS_CNT, 0, 0, \
+                                            g0p1_regs_map[0], g0p1_regs_map[1],   \
+                                            g0p1_regs_map[2], g0p1_regs_map[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+/* GDMA Channel (Group0, Pair2) Registers Context
+   Include: GDMA_MISC_CONF_REG /
+            GDMA_IN_INT_ENA_CH2_REG / GDMA_OUT_INT_ENA_CH2_REG / GDMA_IN_PERI_SEL_CH2_REG / GDMA_OUT_PERI_SEL_CH2_REG
+            GDMA_IN_CONF0_CH2_REG / GDMA_IN_CONF1_CH2_REG / GDMA_IN_LINK_CH2_REG / GDMA_IN_PRI_CH2_REG
+            GDMA_OUT_CONF0_CH2_REG / GDMA_OUT_CONF1_CH2_REG / GDMA_OUT_LINK_CH2_REG /GDMA_OUT_PRI_CH2_REG
+*/
+#define G0P2_RETENTION_REGS_CNT_0  6
+#define G0P2_RETENTION_MAP_BASE_0  GDMA_IN_INT_ENA_CH2_REG
+#define G0P2_RETENTION_REGS_CNT_1  7
+#define G0P2_RETENTION_MAP_BASE_1  GDMA_IN_PRI_CH2_REG
+static const uint32_t g0p2_regs_map0[4] = {0x9001, 0, 0, 0x4C0000};
+static const uint32_t g0p2_regs_map1[4] = {0x3026003, 0, 0, 0};
+static const regdma_entries_config_t gdma_g0p2_regs_retention[] = {
+    [0]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            G0P2_RETENTION_MAP_BASE_0, G0P2_RETENTION_MAP_BASE_0, \
+                                            G0P2_RETENTION_REGS_CNT_0, 0, 0, \
+                                            g0p2_regs_map0[0], g0p2_regs_map0[1],   \
+                                            g0p2_regs_map0[2], g0p2_regs_map0[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+    [1]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x01), \
+                                            G0P2_RETENTION_MAP_BASE_1, G0P2_RETENTION_MAP_BASE_1, \
+                                            G0P2_RETENTION_REGS_CNT_1, 0, 0, \
+                                            g0p2_regs_map1[0], g0p2_regs_map1[1],   \
+                                            g0p2_regs_map1[2], g0p2_regs_map1[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+const gdma_retention_desc_t gdma_retention_infos[1][3] = {
+    [0] = {
+        [0] = {
+            gdma_g0p0_regs_retention,
+            ARRAY_SIZE(gdma_g0p0_regs_retention),
+            SLEEP_RETENTION_MODULE_GDMA_CH0,
+        },
+        [1] = {
+            gdma_g0p1_regs_retention,
+            ARRAY_SIZE(gdma_g0p1_regs_retention),
+            SLEEP_RETENTION_MODULE_GDMA_CH1,
+        },
+        [2] = {
+            gdma_g0p2_regs_retention,
+            ARRAY_SIZE(gdma_g0p2_regs_retention),
+            SLEEP_RETENTION_MODULE_GDMA_CH2,
+        },
+    }
+};

--- a/components/esp_driver_dma/esp32h2/gdma_retention.c
+++ b/components/esp_driver_dma/esp32h2/gdma_retention.c
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gdma_priv.h"
+#include "soc/gdma_reg.h"
+
+/* GDMA Channel (Group0, Pair0) Registers Context
+   Include: GDMA_MISC_CONF_REG /
+            GDMA_IN_INT_ENA_CH0_REG / GDMA_OUT_INT_ENA_CH0_REG / GDMA_IN_PERI_SEL_CH0_REG / GDMA_OUT_PERI_SEL_CH0_REG
+            GDMA_IN_CONF0_CH0_REG / GDMA_IN_CONF1_CH0_REG / GDMA_IN_LINK_CH0_REG / GDMA_IN_PRI_CH0_REG
+            GDMA_OUT_CONF0_CH0_REG / GDMA_OUT_CONF1_CH0_REG / GDMA_OUT_LINK_CH0_REG /GDMA_OUT_PRI_CH0_REG
+*/
+#define G0P0_RETENTION_REGS_CNT  13
+#define G0P0_RETENTION_MAP_BASE  GDMA_IN_INT_ENA_CH0_REG
+static const uint32_t g0p0_regs_map[4] = {0x4C801001, 0x604C0060, 0, 0};
+static const regdma_entries_config_t gdma_g0p0_regs_retention[] = {
+    [0]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            G0P0_RETENTION_MAP_BASE, G0P0_RETENTION_MAP_BASE, \
+                                            G0P0_RETENTION_REGS_CNT, 0, 0, \
+                                            g0p0_regs_map[0], g0p0_regs_map[1],   \
+                                            g0p0_regs_map[2], g0p0_regs_map[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+/* GDMA Channel (Group0, Pair1) Registers Context
+   Include: GDMA_MISC_CONF_REG /
+            GDMA_IN_INT_ENA_CH1_REG / GDMA_OUT_INT_ENA_CH1_REG / GDMA_IN_PERI_SEL_CH1_REG / GDMA_OUT_PERI_SEL_CH1_REG
+            GDMA_IN_CONF0_CH1_REG / GDMA_IN_CONF1_CH1_REG / GDMA_IN_LINK_CH1_REG / GDMA_IN_PRI_CH1_REG
+            GDMA_OUT_CONF0_CH1_REG / GDMA_OUT_CONF1_CH1_REG / GDMA_OUT_LINK_CH1_REG /GDMA_OUT_PRI_CH1_REG
+*/
+#define G0P1_RETENTION_REGS_CNT  13
+#define G0P1_RETENTION_MAP_BASE  GDMA_IN_INT_ENA_CH1_REG
+static const uint32_t g0p1_regs_map[4] = {0x81001, 0, 0xC00604C0, 0x604};
+static const regdma_entries_config_t gdma_g0p1_regs_retention[] = {
+    [0]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            G0P1_RETENTION_MAP_BASE, G0P1_RETENTION_MAP_BASE, \
+                                            G0P1_RETENTION_REGS_CNT, 0, 0, \
+                                            g0p1_regs_map[0], g0p1_regs_map[1],   \
+                                            g0p1_regs_map[2], g0p1_regs_map[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+/* GDMA Channel (Group0, Pair2) Registers Context
+   Include: GDMA_MISC_CONF_REG /
+            GDMA_IN_INT_ENA_CH2_REG / GDMA_OUT_INT_ENA_CH2_REG / GDMA_IN_PERI_SEL_CH2_REG / GDMA_OUT_PERI_SEL_CH2_REG
+            GDMA_IN_CONF0_CH2_REG / GDMA_IN_CONF1_CH2_REG / GDMA_IN_LINK_CH2_REG / GDMA_IN_PRI_CH2_REG
+            GDMA_OUT_CONF0_CH2_REG / GDMA_OUT_CONF1_CH2_REG / GDMA_OUT_LINK_CH2_REG /GDMA_OUT_PRI_CH2_REG
+*/
+#define G0P2_RETENTION_REGS_CNT_0  6
+#define G0P2_RETENTION_MAP_BASE_0  GDMA_IN_INT_ENA_CH2_REG
+#define G0P2_RETENTION_REGS_CNT_1  7
+#define G0P2_RETENTION_MAP_BASE_1  GDMA_IN_PRI_CH2_REG
+static const uint32_t g0p2_regs_map0[4] = {0x9001, 0, 0, 0x4C0000};
+static const uint32_t g0p2_regs_map1[4] = {0x3026003, 0, 0, 0};
+static const regdma_entries_config_t gdma_g0p2_regs_retention[] = {
+    [0]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            G0P2_RETENTION_MAP_BASE_0, G0P2_RETENTION_MAP_BASE_0, \
+                                            G0P2_RETENTION_REGS_CNT_0, 0, 0, \
+                                            g0p2_regs_map0[0], g0p2_regs_map0[1],   \
+                                            g0p2_regs_map0[2], g0p2_regs_map0[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+    [1]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x01), \
+                                            G0P2_RETENTION_MAP_BASE_1, G0P2_RETENTION_MAP_BASE_1, \
+                                            G0P2_RETENTION_REGS_CNT_1, 0, 0, \
+                                            g0p2_regs_map1[0], g0p2_regs_map1[1],   \
+                                            g0p2_regs_map1[2], g0p2_regs_map1[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+const gdma_retention_desc_t gdma_retention_infos[1][3] = {
+    [0] = {
+        [0] = {
+            gdma_g0p0_regs_retention,
+            ARRAY_SIZE(gdma_g0p0_regs_retention),
+            SLEEP_RETENTION_MODULE_GDMA_CH0,
+        },
+        [1] = {
+            gdma_g0p1_regs_retention,
+            ARRAY_SIZE(gdma_g0p1_regs_retention),
+            SLEEP_RETENTION_MODULE_GDMA_CH1,
+        },
+        [2] = {
+            gdma_g0p2_regs_retention,
+            ARRAY_SIZE(gdma_g0p2_regs_retention),
+            SLEEP_RETENTION_MODULE_GDMA_CH2,
+        }
+    }
+};

--- a/components/esp_driver_dma/esp32p4/gdma_retention.c
+++ b/components/esp_driver_dma/esp32p4/gdma_retention.c
@@ -1,0 +1,265 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gdma_priv.h"
+#include "soc/ahb_dma_reg.h"
+#include "soc/axi_dma_reg.h"
+
+/* AHB_DMA Channel (Group0, Pair0) Registers Context
+   Include: AHB_DMA_INTR_MEM_START_ADDR_REG / AHB_DMA_INTR_MEM_END_ADDR_REG
+            AHB_DMA_ARB_TIMEOUT_TX_REG / AHB_DMA_ARB_TIMEOUT_RX_REG / AHB_DMA_WEIGHT_EN_TX_REG / AHB_DMA_WEIGHT_EN_RX_REG
+            AHB_DMA_MISC_CONF_REG /
+            AHB_DMA_IN_INT_ENA_CH0_REG / AHB_DMA_OUT_INT_ENA_CH0_REG / AHB_DMA_IN_PERI_SEL_CH0_REG / AHB_DMA_OUT_PERI_SEL_CH0_REG
+            AHB_DMA_IN_CONF0_CH0_REG / AHB_DMA_IN_CONF1_CH0_REG / AHB_DMA_IN_LINK_CH0_REG / AHB_DMA_IN_LINK_ADDR_CH0_REG / AHB_DMA_IN_PRI_CH0_REG
+            AHB_DMA_OUT_CONF0_CH0_REG / AHB_DMA_OUT_CONF1_CH0_REG / AHB_DMA_OUT_LINK_CH0_REG / AHB_DMA_OUT_LINK_ADDR_CH0_REG / AHB_DMA_OUT_PRI_CH0_REG
+            AHB_DMA_TX_CH_ARB_WEIGH_CH0_REG / AHB_DMA_TX_ARB_WEIGH_OPT_DIR_CH0_REG
+            AHB_DMA_RX_CH_ARB_WEIGH_CH0_REG / AHB_DMA_RX_ARB_WEIGH_OPT_DIR_CH0_REG
+
+   Note: CRC functionality is hard to do hardware retention, will consider to use software to do the backup and restore.
+*/
+#define AHB_DMA_G0P0_RETENTION_REGS_CNT_0  13
+#define AHB_DMA_G0P0_RETENTION_MAP_BASE_0  AHB_DMA_IN_INT_ENA_CH0_REG
+#define AHB_DMA_G0P0_RETENTION_REGS_CNT_1  12
+#define AHB_DMA_G0P0_RETENTION_MAP_BASE_1  AHB_DMA_TX_CH_ARB_WEIGH_CH0_REG
+static const uint32_t ahb_dma_g0p0_regs_map0[4] = {0x4c801001, 0x604c0060, 0x0, 0x0};
+static const uint32_t ahb_dma_g0p0_regs_map1[4] = {0xc0000003, 0xfc900000, 0x0, 0x0};
+static const regdma_entries_config_t ahb_dma_g0p0_regs_retention[] = {
+    [0]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            AHB_DMA_G0P0_RETENTION_MAP_BASE_0, AHB_DMA_G0P0_RETENTION_MAP_BASE_0, \
+                                            AHB_DMA_G0P0_RETENTION_REGS_CNT_0, 0, 0, \
+                                            ahb_dma_g0p0_regs_map0[0], ahb_dma_g0p0_regs_map0[1],   \
+                                            ahb_dma_g0p0_regs_map0[2], ahb_dma_g0p0_regs_map0[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+    [1]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x01), \
+                                            AHB_DMA_G0P0_RETENTION_MAP_BASE_1, AHB_DMA_G0P0_RETENTION_MAP_BASE_1, \
+                                            AHB_DMA_G0P0_RETENTION_REGS_CNT_1, 0, 0, \
+                                            ahb_dma_g0p0_regs_map1[0], ahb_dma_g0p0_regs_map1[1],   \
+                                            ahb_dma_g0p0_regs_map1[2], ahb_dma_g0p0_regs_map1[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+/* AHB_DMA Channel (Group0, Pair1) Registers Context
+   Include: AHB_DMA_INTR_MEM_START_ADDR_REG / AHB_DMA_INTR_MEM_END_ADDR_REG
+            AHB_DMA_ARB_TIMEOUT_TX_REG / AHB_DMA_ARB_TIMEOUT_RX_REG / AHB_DMA_WEIGHT_EN_TX_REG / AHB_DMA_WEIGHT_EN_RX_REG
+            AHB_DMA_MISC_CONF_REG /
+            AHB_DMA_IN_INT_ENA_CH1_REG / AHB_DMA_OUT_INT_ENA_CH1_REG / AHB_DMA_IN_PERI_SEL_CH1_REG / AHB_DMA_OUT_PERI_SEL_CH1_REG
+            AHB_DMA_IN_CONF0_CH1_REG / AHB_DMA_IN_CONF1_CH1_REG / AHB_DMA_IN_LINK_CH1_REG / AHB_DMA_IN_LINK_ADDR_CH1_REG / AHB_DMA_IN_PRI_CH1_REG
+            AHB_DMA_OUT_CONF0_CH1_REG / AHB_DMA_OUT_CONF1_CH1_REG / AHB_DMA_OUT_LINK_CH1_REG / AHB_DMA_OUT_LINK_ADDR_CH1_REG / AHB_DMA_OUT_PRI_CH1_REG
+            AHB_DMA_TX_CH_ARB_WEIGH_CH1_REG / AHB_DMA_TX_ARB_WEIGH_OPT_DIR_CH1_REG
+            AHB_DMA_RX_CH_ARB_WEIGH_CH1_REG / AHB_DMA_RX_ARB_WEIGH_OPT_DIR_CH1_REG
+
+   Note: CRC functionality is hard to do hardware retention, will consider to use software to do the backup and restore.
+*/
+#define AHB_DMA_G0P1_RETENTION_REGS_CNT_0  13
+#define AHB_DMA_G0P1_RETENTION_MAP_BASE_0  AHB_DMA_IN_INT_ENA_CH1_REG
+#define AHB_DMA_G0P1_RETENTION_REGS_CNT_1  12
+#define AHB_DMA_G0P1_RETENTION_MAP_BASE_1  AHB_DMA_TX_CH_ARB_WEIGH_CH1_REG
+static const uint32_t ahb_dma_g0p1_regs_map0[4] = {0x81001, 0, 0xC00604C0, 0x604};
+static const uint32_t ahb_dma_g0p1_regs_map1[4] = {0xc0000003, 0x3f4800, 0x0, 0x0};
+static const regdma_entries_config_t ahb_dma_g0p1_regs_retention[] = {
+    [0]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            AHB_DMA_G0P1_RETENTION_MAP_BASE_0, AHB_DMA_G0P1_RETENTION_MAP_BASE_0, \
+                                            AHB_DMA_G0P1_RETENTION_REGS_CNT_0, 0, 0, \
+                                            ahb_dma_g0p1_regs_map0[0], ahb_dma_g0p1_regs_map0[1],   \
+                                            ahb_dma_g0p1_regs_map0[2], ahb_dma_g0p1_regs_map0[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+    [1]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x01), \
+                                            AHB_DMA_G0P1_RETENTION_MAP_BASE_1, AHB_DMA_G0P1_RETENTION_MAP_BASE_1, \
+                                            AHB_DMA_G0P1_RETENTION_REGS_CNT_1, 0, 0, \
+                                            ahb_dma_g0p1_regs_map1[0], ahb_dma_g0p1_regs_map1[1],   \
+                                            ahb_dma_g0p1_regs_map1[2], ahb_dma_g0p1_regs_map1[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+/* AHB_DMA Channel (Group0, Pair2) Registers Context
+   Include: AHB_DMA_INTR_MEM_START_ADDR_REG / AHB_DMA_INTR_MEM_END_ADDR_REG
+            AHB_DMA_ARB_TIMEOUT_TX_REG / AHB_DMA_ARB_TIMEOUT_RX_REG / AHB_DMA_WEIGHT_EN_TX_REG / AHB_DMA_WEIGHT_EN_RX_REG
+            AHB_DMA_MISC_CONF_REG /
+            AHB_DMA_IN_INT_ENA_CH2_REG / AHB_DMA_OUT_INT_ENA_CH2_REG / AHB_DMA_IN_PERI_SEL_CH2_REG / AHB_DMA_OUT_PERI_SEL_CH2_REG
+            AHB_DMA_IN_CONF0_CH2_REG / AHB_DMA_IN_CONF1_CH2_REG / AHB_DMA_IN_LINK_CH2_REG / AHB_DMA_IN_LINK_ADDR_CH2_REG / AHB_DMA_IN_PRI_CH2_REG
+            AHB_DMA_OUT_CONF0_CH2_REG / AHB_DMA_OUT_CONF1_CH2_REG / AHB_DMA_OUT_LINK_CH2_REG / AHB_DMA_OUT_LINK_ADDR_CH2_REG / AHB_DMA_OUT_PRI_CH2_REG
+            AHB_DMA_TX_CH_ARB_WEIGH_CH2_REG / AHB_DMA_TX_ARB_WEIGH_OPT_DIR_CH2_REG
+            AHB_DMA_RX_CH_ARB_WEIGH_CH2_REG / AHB_DMA_RX_ARB_WEIGH_OPT_DIR_CH2_REG
+
+   Note: CRC functionality is hard to do hardware retention, will consider to use software to do the backup and restore.
+*/
+#define AHB_DMA_G0P2_RETENTION_REGS_CNT_0  6
+#define AHB_DMA_G0P2_RETENTION_MAP_BASE_0  AHB_DMA_IN_INT_ENA_CH2_REG
+#define AHB_DMA_G0P2_RETENTION_REGS_CNT_1  19
+#define AHB_DMA_G0P2_RETENTION_MAP_BASE_1  AHB_DMA_IN_PRI_CH2_REG
+static const uint32_t ahb_dma_g0p2_regs_map0[4] = {0x9001, 0, 0, 0x4C0000};
+static const uint32_t ahb_dma_g0p2_regs_map1[4] = {0x3026003, 0x0, 0x30, 0xfe4c};
+static const regdma_entries_config_t ahb_dma_g0p2_regs_retention[] = {
+    [0]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            AHB_DMA_G0P2_RETENTION_MAP_BASE_0, AHB_DMA_G0P2_RETENTION_MAP_BASE_0, \
+                                            AHB_DMA_G0P2_RETENTION_REGS_CNT_0, 0, 0, \
+                                            ahb_dma_g0p2_regs_map0[0], ahb_dma_g0p2_regs_map0[1],   \
+                                            ahb_dma_g0p2_regs_map0[2], ahb_dma_g0p2_regs_map0[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+    [1]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x01), \
+                                            AHB_DMA_G0P2_RETENTION_MAP_BASE_1, AHB_DMA_G0P2_RETENTION_MAP_BASE_1, \
+                                            AHB_DMA_G0P2_RETENTION_REGS_CNT_1, 0, 0, \
+                                            ahb_dma_g0p2_regs_map1[0], ahb_dma_g0p2_regs_map1[1],   \
+                                            ahb_dma_g0p2_regs_map1[2], ahb_dma_g0p2_regs_map1[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+/* AXI_DMA Channel (Group1, Pair0) Registers Context
+   Include: AXI_DMA_IN_INT_ENA_CH0_REG / AXI_DMA_IN_CONF0_CH0_REG / AXI_DMA_IN_CONF1_CH0_REG / AXI_DMA_IN_LINK1_CH0_REG / AXI_DMA_IN_LINK2_CH0_REG
+            AXI_DMA_IN_PRI_CH0_REG / AXI_DMA_IN_PERI_SEL_CH0_REG
+            AXI_DMA_OUT_INT_ENA_CH0_REG / AXI_DMA_OUT_CONF0_CH0_REG / AXI_DMA_OUT_CONF1_CH0_REG / AXI_DMA_OUT_LINK1_CH0_REG / AXI_DMA_OUT_LINK2_CH0_REG
+            AXI_DMA_OUT_PRI_CH0_REG / AXI_DMA_OUT_PERI_SEL_CH0_REG
+            AXI_DMA_ARB_TIMEOUT_REG / AXI_DMA_WEIGHT_EN_REG / AXI_DMA_IN_MEM_CONF_REG
+            AXI_DMA_INTR_MEM_START_ADDR_REG / AXI_DMA_INTR_MEM_END_ADDR_REG / AXI_DMA_EXTR_MEM_START_ADDR_REG / AXI_DMA_EXTR_MEM_END_ADDR_REG
+            AXI_DMA_MISC_CONF_REG
+
+   Note: CRC functionality is hard to do hardware retention, will consider to use software to do the backup and restore.
+*/
+#define AXI_DMA_G1P0_RETENTION_REGS_CNT_0  14
+#define AXI_DMA_G1P0_RETENTION_MAP_BASE_0  AXI_DMA_IN_INT_ENA_CH0_REG
+#define AXI_DMA_G1P0_RETENTION_REGS_CNT_1  8
+#define AXI_DMA_G1P0_RETENTION_MAP_BASE_1  AXI_DMA_ARB_TIMEOUT_REG
+static const uint32_t axi_dma_g1p0_regs_map0[4] = {0xc0cd, 0x0, 0x30334000, 0x0};
+static const uint32_t axi_dma_g1p0_regs_map1[4] = {0x407f, 0x0, 0x0, 0x0};
+static const regdma_entries_config_t axi_dma_g1p0_regs_retention[] = {
+    [0]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            AXI_DMA_G1P0_RETENTION_MAP_BASE_0, AXI_DMA_G1P0_RETENTION_MAP_BASE_0, \
+                                            AXI_DMA_G1P0_RETENTION_REGS_CNT_0, 0, 0, \
+                                            axi_dma_g1p0_regs_map0[0], axi_dma_g1p0_regs_map0[1],   \
+                                            axi_dma_g1p0_regs_map0[2], axi_dma_g1p0_regs_map0[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+    [1]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x01), \
+                                            AXI_DMA_G1P0_RETENTION_MAP_BASE_1, AXI_DMA_G1P0_RETENTION_MAP_BASE_1, \
+                                            AXI_DMA_G1P0_RETENTION_REGS_CNT_1, 0, 0, \
+                                            axi_dma_g1p0_regs_map1[0], axi_dma_g1p0_regs_map1[1],   \
+                                            axi_dma_g1p0_regs_map1[2], axi_dma_g1p0_regs_map1[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+/* AXI_DMA Channel (Group1, Pair1) Registers Context
+   Include: AXI_DMA_IN_INT_ENA_CH1_REG / AXI_DMA_IN_CONF0_CH1_REG / AXI_DMA_IN_CONF1_CH1_REG / AXI_DMA_IN_LINK1_CH1_REG / AXI_DMA_IN_LINK2_CH1_REG
+            AXI_DMA_IN_PRI_CH1_REG / AXI_DMA_IN_PERI_SEL_CH1_REG
+            AXI_DMA_OUT_INT_ENA_CH1_REG / AXI_DMA_OUT_CONF0_CH1_REG / AXI_DMA_OUT_CONF1_CH1_REG / AXI_DMA_OUT_LINK1_CH1_REG / AXI_DMA_OUT_LINK2_CH1_REG
+            AXI_DMA_OUT_PRI_CH1_REG / AXI_DMA_OUT_PERI_SEL_CH1_REG
+            AXI_DMA_ARB_TIMEOUT_REG / AXI_DMA_WEIGHT_EN_REG / AXI_DMA_IN_MEM_CONF_REG
+            AXI_DMA_INTR_MEM_START_ADDR_REG / AXI_DMA_INTR_MEM_END_ADDR_REG / AXI_DMA_EXTR_MEM_START_ADDR_REG / AXI_DMA_EXTR_MEM_END_ADDR_REG
+            AXI_DMA_MISC_CONF_REG
+
+   Note: CRC functionality is hard to do hardware retention, will consider to use software to do the backup and restore.
+*/
+#define AXI_DMA_G1P1_RETENTION_REGS_CNT_0  14
+#define AXI_DMA_G1P1_RETENTION_MAP_BASE_0  AXI_DMA_IN_INT_ENA_CH1_REG
+#define AXI_DMA_G1P1_RETENTION_REGS_CNT_1  8
+#define AXI_DMA_G1P1_RETENTION_MAP_BASE_1  AXI_DMA_ARB_TIMEOUT_REG
+static const uint32_t axi_dma_g1p1_regs_map0[4] = {0xc0cd, 0x0, 0x30334000, 0x0};
+static const uint32_t axi_dma_g1p1_regs_map1[4] = {0x407f, 0x0, 0x0, 0x0};
+static const regdma_entries_config_t axi_dma_g1p1_regs_retention[] = {
+    [0]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            AXI_DMA_G1P1_RETENTION_MAP_BASE_0, AXI_DMA_G1P1_RETENTION_MAP_BASE_0, \
+                                            AXI_DMA_G1P1_RETENTION_REGS_CNT_0, 0, 0, \
+                                            axi_dma_g1p1_regs_map0[0], axi_dma_g1p1_regs_map0[1],   \
+                                            axi_dma_g1p1_regs_map0[2], axi_dma_g1p1_regs_map0[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+    [1]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x01), \
+                                            AXI_DMA_G1P1_RETENTION_MAP_BASE_1, AXI_DMA_G1P1_RETENTION_MAP_BASE_1, \
+                                            AXI_DMA_G1P1_RETENTION_REGS_CNT_1, 0, 0, \
+                                            axi_dma_g1p1_regs_map1[0], axi_dma_g1p1_regs_map1[1],   \
+                                            axi_dma_g1p1_regs_map1[2], axi_dma_g1p1_regs_map1[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+/* AXI_DMA Channel (Group1, Pair2) Registers Context
+   Include: AXI_DMA_IN_INT_ENA_CH2_REG / AXI_DMA_IN_CONF0_CH2_REG / AXI_DMA_IN_CONF1_CH2_REG / AXI_DMA_IN_LINK1_CH2_REG / AXI_DMA_IN_LINK2_CH2_REG
+            AXI_DMA_IN_PRI_CH2_REG / AXI_DMA_IN_PERI_SEL_CH2_REG
+            AXI_DMA_OUT_INT_ENA_CH2_REG / AXI_DMA_OUT_CONF0_CH2_REG / AXI_DMA_OUT_CONF1_CH2_REG / AXI_DMA_OUT_LINK1_CH2_REG / AXI_DMA_OUT_LINK2_CH2_REG
+            AXI_DMA_OUT_PRI_CH2_REG / AXI_DMA_OUT_PERI_SEL_CH2_REG
+            AXI_DMA_ARB_TIMEOUT_REG / AXI_DMA_WEIGHT_EN_REG / AXI_DMA_IN_MEM_CONF_REG
+            AXI_DMA_INTR_MEM_START_ADDR_REG / AXI_DMA_INTR_MEM_END_ADDR_REG / AXI_DMA_EXTR_MEM_START_ADDR_REG / AXI_DMA_EXTR_MEM_END_ADDR_REG
+            AXI_DMA_MISC_CONF_REG
+
+   Note: CRC functionality is hard to do hardware retention, will consider to use software to do the backup and restore.
+*/
+#define AXI_DMA_G1P2_RETENTION_REGS_CNT_0  14
+#define AXI_DMA_G1P2_RETENTION_MAP_BASE_0  AXI_DMA_IN_INT_ENA_CH2_REG
+#define AXI_DMA_G1P2_RETENTION_REGS_CNT_1  8
+#define AXI_DMA_G1P2_RETENTION_MAP_BASE_1  AXI_DMA_ARB_TIMEOUT_REG
+static const uint32_t axi_dma_g1p2_regs_map0[4] = {0xc0cd, 0x0, 0x30334000, 0x0};
+static const uint32_t axi_dma_g1p2_regs_map1[4] = {0x407f, 0x0, 0x0, 0x0};
+static const regdma_entries_config_t axi_dma_g1p2_regs_retention[] = {
+    [0]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x00), \
+                                            AXI_DMA_G1P2_RETENTION_MAP_BASE_0, AXI_DMA_G1P2_RETENTION_MAP_BASE_0, \
+                                            AXI_DMA_G1P2_RETENTION_REGS_CNT_0, 0, 0, \
+                                            axi_dma_g1p2_regs_map0[0], axi_dma_g1p2_regs_map0[1],   \
+                                            axi_dma_g1p2_regs_map0[2], axi_dma_g1p2_regs_map0[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+    [1]  = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_GDMA_LINK(0x01), \
+                                            AXI_DMA_G1P2_RETENTION_MAP_BASE_1, AXI_DMA_G1P2_RETENTION_MAP_BASE_1, \
+                                            AXI_DMA_G1P2_RETENTION_REGS_CNT_1, 0, 0, \
+                                            axi_dma_g1p2_regs_map1[0], axi_dma_g1p2_regs_map1[1],   \
+                                            axi_dma_g1p2_regs_map1[2], axi_dma_g1p2_regs_map1[3]),  \
+        .owner = GDMA_RETENTION_ENTRY
+    },
+};
+
+const gdma_retention_desc_t gdma_retention_infos[2][3] = {
+    [0] = {
+        [0] = {
+            ahb_dma_g0p0_regs_retention,
+            ARRAY_SIZE(ahb_dma_g0p0_regs_retention),
+            SLEEP_RETENTION_MODULE_AHB_DMA_CH0,
+        },
+        [1] = {
+            ahb_dma_g0p1_regs_retention,
+            ARRAY_SIZE(ahb_dma_g0p1_regs_retention),
+            SLEEP_RETENTION_MODULE_AHB_DMA_CH1,
+        },
+        [2] = {
+            ahb_dma_g0p2_regs_retention,
+            ARRAY_SIZE(ahb_dma_g0p2_regs_retention),
+            SLEEP_RETENTION_MODULE_AHB_DMA_CH2,
+        },
+    },
+    [1] = {
+        [0] = {
+            axi_dma_g1p0_regs_retention,
+            ARRAY_SIZE(axi_dma_g1p0_regs_retention),
+            SLEEP_RETENTION_MODULE_AXI_DMA_CH0,
+        },
+        [1] = {
+            axi_dma_g1p1_regs_retention,
+            ARRAY_SIZE(axi_dma_g1p1_regs_retention),
+            SLEEP_RETENTION_MODULE_AXI_DMA_CH1,
+        },
+        [2] = {
+            axi_dma_g1p2_regs_retention,
+            ARRAY_SIZE(axi_dma_g1p2_regs_retention),
+            SLEEP_RETENTION_MODULE_AXI_DMA_CH2,
+        },
+    }
+};

--- a/components/esp_driver_dma/src/gdma_priv.h
+++ b/components/esp_driver_dma/src/gdma_priv.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+#include "hal/gdma_ll.h"
+#include "esp_private/sleep_retention.h"
+#include <zephyr/sys/util.h>
+
+#if SOC_PHY_SUPPORTED
+#define GDMA_RETENTION_ENTRY    (ENTRY(0) | ENTRY(2))
+#else
+#define GDMA_RETENTION_ENTRY    (ENTRY(0))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if SOC_GDMA_SUPPORT_SLEEP_RETENTION && SOC_PAU_SUPPORTED
+typedef struct {
+    const regdma_entries_config_t *link_list;
+    uint32_t link_num;
+    const periph_retention_module_t module_id;
+} gdma_retention_desc_t;
+
+extern const gdma_retention_desc_t gdma_retention_infos[GDMA_LL_GET(INST_NUM)][GDMA_LL_GET(PAIRS_PER_INST)];
+
+#endif // SOC_GDMA_SUPPORT_SLEEP_RETENTION && SOC_PAU_SUPPORTED
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/esp_driver_gptimer/esp32c5/timer_retention.c
+++ b/components/esp_driver_gptimer/esp32c5/timer_retention.c
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include "soc/timer_group_reg.h"
+#include "gptimer_priv.h"
+
+/*  Registers in retention context:
+ *      TIMG_T0CONFIG_REG
+ *      TIMG_T0ALARMLO_REG
+ *      TIMG_T0ALARMHI_REG
+ *      TIMG_T0LOADLO_REG
+ *      TIMG_T0LOADHI_REG
+ *      TIMG_INT_ENA_TIMERS_REG
+ *      TIMG_REGCLK_REG
+ */
+#define TG_TIMER_RETENTION_REGS_CNT 7
+static const uint32_t tg_timer_regs_map[4] = {0x100000f1, 0x80000000, 0x0, 0x0};
+
+const regdma_entries_config_t tg0_timer_regdma_entries[] = {
+    // backup stage: trigger a soft capture
+    [0] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG0_TIMER_LINK(0x00),
+                                         TIMG_T0UPDATE_REG(0), TIMG_T0_UPDATE, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: wait for the capture done
+    [1] = {
+        .config = REGDMA_LINK_WAIT_INIT(REGDMA_TG0_TIMER_LINK(0x01),
+                                        TIMG_T0UPDATE_REG(0), 0x0, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: save the captured counter value
+    // restore stage: store the captured counter value to the loader register
+    [2] = {
+        .config = REGDMA_LINK_CONTINUOUS_INIT(REGDMA_TG0_TIMER_LINK(0x02),
+                                              TIMG_T0LO_REG(0), TIMG_T0LOADLO_REG(0), 2, 0, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // restore stage: trigger a soft reload, so the timer can continue from where it was backed up
+    [3] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG0_TIMER_LINK(0x03),
+                                         TIMG_T0LOAD_REG(0), 0x1, TIMG_T0_LOAD_M, 1, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: save other configuration and status registers
+    // restore stage: restore the configuration and status registers
+    [4] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_TG0_TIMER_LINK(0x04),
+                                            TIMG_T0CONFIG_REG(0), TIMG_T0CONFIG_REG(0),
+                                            TG_TIMER_RETENTION_REGS_CNT, 0, 0,
+                                            tg_timer_regs_map[0], tg_timer_regs_map[1],
+                                            tg_timer_regs_map[2], tg_timer_regs_map[3]),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+};
+
+const regdma_entries_config_t tg1_timer_regdma_entries[] = {
+    // backup stage: trigger a soft capture
+    [0] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG1_TIMER_LINK(0x00),
+                                         TIMG_T0UPDATE_REG(1), TIMG_T0_UPDATE, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: wait for the capture done
+    [1] = {
+        .config = REGDMA_LINK_WAIT_INIT(REGDMA_TG1_TIMER_LINK(0x01),
+                                        TIMG_T0UPDATE_REG(1), 0x0, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: save the captured counter value
+    // restore stage: store the captured counter value to the loader register
+    [2] = {
+        .config = REGDMA_LINK_CONTINUOUS_INIT(REGDMA_TG1_TIMER_LINK(0x02),
+                                              TIMG_T0LO_REG(1), TIMG_T0LOADLO_REG(1), 2, 0, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // restore stage: trigger a soft reload, so the timer can continue from where it was backed up
+    [3] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG1_TIMER_LINK(0x03),
+                                         TIMG_T0LOAD_REG(1), 0x1, TIMG_T0_LOAD_M, 1, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: save other configuration and status registers
+    // restore stage: restore the configuration and status registers
+    [4] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_TG1_TIMER_LINK(0x04),
+                                            TIMG_T0CONFIG_REG(1), TIMG_T0CONFIG_REG(1),
+                                            TG_TIMER_RETENTION_REGS_CNT, 0, 0,
+                                            tg_timer_regs_map[0], tg_timer_regs_map[1],
+                                            tg_timer_regs_map[2], tg_timer_regs_map[3]),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+};
+
+const gptimer_retention_desc_t gptimer_retention_infos[2][1] = {
+    [0] = {
+        [0] = {
+            .module = SLEEP_RETENTION_MODULE_TG0_TIMER0,
+            .regdma_entry_array = tg0_timer_regdma_entries,
+            .array_size = ARRAY_SIZE(tg0_timer_regdma_entries)
+        }
+    },
+    [1] = {
+        [0] = {
+            .module = SLEEP_RETENTION_MODULE_TG1_TIMER0,
+            .regdma_entry_array = tg1_timer_regdma_entries,
+            .array_size = ARRAY_SIZE(tg1_timer_regdma_entries)
+        }
+    },
+};

--- a/components/esp_driver_gptimer/esp32c6/timer_retention.c
+++ b/components/esp_driver_gptimer/esp32c6/timer_retention.c
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include "soc/timer_group_reg.h"
+#include "gptimer_priv.h"
+
+/*  Registers in retention context:
+ *      TIMG_T0CONFIG_REG
+ *      TIMG_T0ALARMLO_REG
+ *      TIMG_T0ALARMHI_REG
+ *      TIMG_T0LOADLO_REG
+ *      TIMG_T0LOADHI_REG
+ *      TIMG_INT_ENA_TIMERS_REG
+ *      TIMG_REGCLK_REG
+ */
+#define TG_TIMER_RETENTION_REGS_CNT 7
+static const uint32_t tg_timer_regs_map[4] = {0x100000f1, 0x80000000, 0x0, 0x0};
+
+const regdma_entries_config_t tg0_timer_regdma_entries[] = {
+    // backup stage: trigger a soft capture
+    [0] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG0_TIMER_LINK(0x00),
+                                         TIMG_T0UPDATE_REG(0), TIMG_T0_UPDATE, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: wait for the capture done
+    [1] = {
+        .config = REGDMA_LINK_WAIT_INIT(REGDMA_TG0_TIMER_LINK(0x01),
+                                        TIMG_T0UPDATE_REG(0), 0x0, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: save the captured counter value
+    // restore stage: store the captured counter value to the loader register
+    [2] = {
+        .config = REGDMA_LINK_CONTINUOUS_INIT(REGDMA_TG0_TIMER_LINK(0x02),
+                                              TIMG_T0LO_REG(0), TIMG_T0LOADLO_REG(0), 2, 0, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // restore stage: trigger a soft reload, so the timer can continue from where it was backed up
+    [3] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG0_TIMER_LINK(0x03),
+                                         TIMG_T0LOAD_REG(0), 0x1, TIMG_T0_LOAD_M, 1, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: save other configuration and status registers
+    // restore stage: restore the configuration and status registers
+    [4] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_TG0_TIMER_LINK(0x04),
+                                            TIMG_T0CONFIG_REG(0), TIMG_T0CONFIG_REG(0),
+                                            TG_TIMER_RETENTION_REGS_CNT, 0, 0,
+                                            tg_timer_regs_map[0], tg_timer_regs_map[1],
+                                            tg_timer_regs_map[2], tg_timer_regs_map[3]),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+};
+
+const regdma_entries_config_t tg1_timer_regdma_entries[] = {
+    // backup stage: trigger a soft capture
+    [0] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG1_TIMER_LINK(0x00),
+                                         TIMG_T0UPDATE_REG(1), TIMG_T0_UPDATE, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: wait for the capture done
+    [1] = {
+        .config = REGDMA_LINK_WAIT_INIT(REGDMA_TG1_TIMER_LINK(0x01),
+                                        TIMG_T0UPDATE_REG(1), 0x0, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: save the captured counter value
+    // restore stage: store the captured counter value to the loader register
+    [2] = {
+        .config = REGDMA_LINK_CONTINUOUS_INIT(REGDMA_TG1_TIMER_LINK(0x02),
+                                              TIMG_T0LO_REG(1), TIMG_T0LOADLO_REG(1), 2, 0, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // restore stage: trigger a soft reload, so the timer can continue from where it was backed up
+    [3] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG1_TIMER_LINK(0x03),
+                                         TIMG_T0LOAD_REG(1), 0x1, TIMG_T0_LOAD_M, 1, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: save other configuration and status registers
+    // restore stage: restore the configuration and status registers
+    [4] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_TG1_TIMER_LINK(0x04),
+                                            TIMG_T0CONFIG_REG(1), TIMG_T0CONFIG_REG(1),
+                                            TG_TIMER_RETENTION_REGS_CNT, 0, 0,
+                                            tg_timer_regs_map[0], tg_timer_regs_map[1],
+                                            tg_timer_regs_map[2], tg_timer_regs_map[3]),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+};
+
+const gptimer_retention_desc_t gptimer_retention_infos[2][1] = {
+    [0] = {
+        [0] = {
+            .module = SLEEP_RETENTION_MODULE_TG0_TIMER0,
+            .regdma_entry_array = tg0_timer_regdma_entries,
+            .array_size = ARRAY_SIZE(tg0_timer_regdma_entries)
+        }
+    },
+    [1] = {
+        [0] = {
+            .module = SLEEP_RETENTION_MODULE_TG1_TIMER0,
+            .regdma_entry_array = tg1_timer_regdma_entries,
+            .array_size = ARRAY_SIZE(tg1_timer_regdma_entries)
+        }
+    },
+};

--- a/components/esp_driver_gptimer/esp32h2/timer_retention.c
+++ b/components/esp_driver_gptimer/esp32h2/timer_retention.c
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include "soc/timer_group_reg.h"
+#include "gptimer_priv.h"
+
+/*  Registers in retention context:
+ *      TIMG_T0CONFIG_REG
+ *      TIMG_T0ALARMLO_REG
+ *      TIMG_T0ALARMHI_REG
+ *      TIMG_T0LOADLO_REG
+ *      TIMG_T0LOADHI_REG
+ *      TIMG_INT_ENA_TIMERS_REG
+ *      TIMG_REGCLK_REG
+ */
+#define TG_TIMER_RETENTION_REGS_CNT 7
+static const uint32_t tg_timer_regs_map[4] = {0x100000f1, 0x80000000, 0x0, 0x0};
+
+const regdma_entries_config_t tg0_timer_regdma_entries[] = {
+    // backup stage: trigger a soft capture
+    [0] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG0_TIMER_LINK(0x00),
+                                         TIMG_T0UPDATE_REG(0), TIMG_T0_UPDATE, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: wait for the capture done
+    [1] = {
+        .config = REGDMA_LINK_WAIT_INIT(REGDMA_TG0_TIMER_LINK(0x01),
+                                        TIMG_T0UPDATE_REG(0), 0x0, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: save the captured counter value
+    // restore stage: store the captured counter value to the loader register
+    [2] = {
+        .config = REGDMA_LINK_CONTINUOUS_INIT(REGDMA_TG0_TIMER_LINK(0x02),
+                                              TIMG_T0LO_REG(0), TIMG_T0LOADLO_REG(0), 2, 0, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // restore stage: trigger a soft reload, so the timer can continue from where it was backed up
+    [3] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG0_TIMER_LINK(0x03),
+                                         TIMG_T0LOAD_REG(0), 0x1, TIMG_T0_LOAD_M, 1, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: save other configuration and status registers
+    // restore stage: restore the configuration and status registers
+    [4] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_TG0_TIMER_LINK(0x04),
+                                            TIMG_T0CONFIG_REG(0), TIMG_T0CONFIG_REG(0),
+                                            TG_TIMER_RETENTION_REGS_CNT, 0, 0,
+                                            tg_timer_regs_map[0], tg_timer_regs_map[1],
+                                            tg_timer_regs_map[2], tg_timer_regs_map[3]),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+};
+
+const regdma_entries_config_t tg1_timer_regdma_entries[] = {
+    // backup stage: trigger a soft capture
+    [0] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG1_TIMER_LINK(0x00),
+                                         TIMG_T0UPDATE_REG(1), TIMG_T0_UPDATE, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: wait for the capture done
+    [1] = {
+        .config = REGDMA_LINK_WAIT_INIT(REGDMA_TG1_TIMER_LINK(0x01),
+                                        TIMG_T0UPDATE_REG(1), 0x0, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: save the captured counter value
+    // restore stage: store the captured counter value to the loader register
+    [2] = {
+        .config = REGDMA_LINK_CONTINUOUS_INIT(REGDMA_TG1_TIMER_LINK(0x02),
+                                              TIMG_T0LO_REG(1), TIMG_T0LOADLO_REG(1), 2, 0, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // restore stage: trigger a soft reload, so the timer can continue from where it was backed up
+    [3] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG1_TIMER_LINK(0x03),
+                                         TIMG_T0LOAD_REG(1), 0x1, TIMG_T0_LOAD_M, 1, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // backup stage: save other configuration and status registers
+    // restore stage: restore the configuration and status registers
+    [4] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_TG1_TIMER_LINK(0x04),
+                                            TIMG_T0CONFIG_REG(1), TIMG_T0CONFIG_REG(1),
+                                            TG_TIMER_RETENTION_REGS_CNT, 0, 0,
+                                            tg_timer_regs_map[0], tg_timer_regs_map[1],
+                                            tg_timer_regs_map[2], tg_timer_regs_map[3]),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+};
+
+const gptimer_retention_desc_t gptimer_retention_infos[2][1] = {
+    [0] = {
+        [0] = {
+            .module = SLEEP_RETENTION_MODULE_TG0_TIMER0,
+            .regdma_entry_array = tg0_timer_regdma_entries,
+            .array_size = ARRAY_SIZE(tg0_timer_regdma_entries)
+        }
+    },
+    [1] = {
+        [0] = {
+            .module = SLEEP_RETENTION_MODULE_TG1_TIMER0,
+            .regdma_entry_array = tg1_timer_regdma_entries,
+            .array_size = ARRAY_SIZE(tg1_timer_regdma_entries)
+        }
+    },
+};

--- a/components/esp_driver_gptimer/esp32p4/timer_retention.c
+++ b/components/esp_driver_gptimer/esp32p4/timer_retention.c
@@ -1,0 +1,216 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include "soc/timer_group_reg.h"
+#include "gptimer_priv.h"
+
+/*  Registers in retention context:
+ *      TIMG_T0CONFIG_REG
+ *      TIMG_T0ALARMLO_REG
+ *      TIMG_T0ALARMHI_REG
+ *      TIMG_T0LOADLO_REG
+ *      TIMG_T0LOADHI_REG
+ *      TIMG_INT_ENA_TIMERS_REG
+ *      TIMG_REGCLK_REG
+ */
+#define TG0_TIMER0_RETENTION_REGS_BASE   (REG_TIMG_BASE(0))
+#define TG1_TIMER0_RETENTION_REGS_BASE   (REG_TIMG_BASE(1))
+#define TG_TIMER0_RETENTION_REGS_CNT 7
+static const uint32_t tg_timer0_regs_map[4] = {0x100000f1, 0x80000000, 0x0, 0x0};
+
+/*  Registers in retention context:
+ *      TIMG_T1CONFIG_REG
+ *      TIMG_T1ALARMLO_REG
+ *      TIMG_T1ALARMHI_REG
+ *      TIMG_T1LOADLO_REG
+ *      TIMG_T1LOADHI_REG
+ *      TIMG_INT_ENA_TIMERS_REG
+ *      TIMG_REGCLK_REG
+ */
+#define TG0_TIMER1_RETENTION_REGS_BASE   (REG_TIMG_BASE(0) + 0x24)
+#define TG1_TIMER1_RETENTION_REGS_BASE   (REG_TIMG_BASE(1) + 0x24)
+#define TG_TIMER1_RETENTION_REGS_CNT    7
+static const uint32_t tg_timer1_regs_map[4] = {0x800f1, 0x400000, 0x0, 0x0};
+
+const regdma_entries_config_t tg0_timer0_regdma_entries[] = {
+    // backup stage: trigger a soft capture
+    [0] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG0_TIMER_LINK(0x00),
+                                         TIMG_T0UPDATE_REG(0), TIMG_T0_UPDATE, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0)
+    },
+    // backup stage: wait for the capture done
+    [1] = {
+        .config = REGDMA_LINK_WAIT_INIT(REGDMA_TG0_TIMER_LINK(0x01),
+                                        TIMG_T0UPDATE_REG(0), 0x0, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0)
+    },
+    // backup stage: save the captured counter value
+    // restore stage: store the captured counter value to the loader register
+    [2] = {
+        .config = REGDMA_LINK_CONTINUOUS_INIT(REGDMA_TG0_TIMER_LINK(0x02),
+                                              TIMG_T0LO_REG(0), TIMG_T0LOADLO_REG(0), 2, 0, 0),
+        .owner = ENTRY(0)
+    },
+    // restore stage: trigger a soft reload, so the timer can continue from where it was backed up
+    [3] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG0_TIMER_LINK(0x03),
+                                         TIMG_T0LOAD_REG(0), 0x1, TIMG_T0_LOAD_M, 1, 0),
+        .owner = ENTRY(0)
+    },
+    // backup stage: save other configuration and status registers
+    // restore stage: restore the configuration and status registers
+    [4] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_TG0_TIMER_LINK(0x04),
+                                            TG0_TIMER0_RETENTION_REGS_BASE, TG0_TIMER0_RETENTION_REGS_BASE,
+                                            TG_TIMER0_RETENTION_REGS_CNT, 0, 0,
+                                            tg_timer0_regs_map[0], tg_timer0_regs_map[1],
+                                            tg_timer0_regs_map[2], tg_timer0_regs_map[3]),
+        .owner = ENTRY(0)
+    },
+};
+
+const regdma_entries_config_t tg0_timer1_regdma_entries[] = {
+    // backup stage: trigger a soft capture
+    [0] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG0_TIMER_LINK(0x05),
+                                         TIMG_T1UPDATE_REG(0), TIMG_T1_UPDATE, TIMG_T1_UPDATE_M, 0, 1),
+        .owner = ENTRY(0)
+    },
+    // backup stage: wait for the capture done
+    [1] = {
+        .config = REGDMA_LINK_WAIT_INIT(REGDMA_TG0_TIMER_LINK(0x06),
+                                        TIMG_T1UPDATE_REG(0), 0x0, TIMG_T1_UPDATE_M, 0, 1),
+        .owner = ENTRY(0)
+    },
+    // backup stage: save the captured counter value
+    // restore stage: store the captured counter value to the loader register
+    [2] = {
+        .config = REGDMA_LINK_CONTINUOUS_INIT(REGDMA_TG0_TIMER_LINK(0x07),
+                                              TIMG_T1LO_REG(0), TIMG_T1LOADLO_REG(0), 2, 0, 0),
+        .owner = ENTRY(0)
+    },
+    // restore stage: trigger a soft reload, so the timer can continue from where it was backed up
+    [3] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG0_TIMER_LINK(0x08),
+                                         TIMG_T1LOAD_REG(0), 0x1, TIMG_T1_LOAD_M, 1, 0),
+        .owner = ENTRY(0)
+    },
+    // backup stage: save other configuration and status registers
+    // restore stage: restore the configuration and status registers
+    [4] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_TG0_TIMER_LINK(0x09),
+                                            TG0_TIMER1_RETENTION_REGS_BASE, TG0_TIMER1_RETENTION_REGS_BASE,
+                                            TG_TIMER1_RETENTION_REGS_CNT, 0, 0,
+                                            tg_timer1_regs_map[0], tg_timer1_regs_map[1],
+                                            tg_timer1_regs_map[2], tg_timer1_regs_map[3]),
+        .owner = ENTRY(0)
+    },
+};
+
+const regdma_entries_config_t tg1_timer0_regdma_entries[] = {
+    // backup stage: trigger a soft capture
+    [0] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG1_TIMER_LINK(0x00),
+                                         TIMG_T0UPDATE_REG(1), TIMG_T0_UPDATE, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0)
+    },
+    // backup stage: wait for the capture done
+    [1] = {
+        .config = REGDMA_LINK_WAIT_INIT(REGDMA_TG1_TIMER_LINK(0x01),
+                                        TIMG_T0UPDATE_REG(1), 0x0, TIMG_T0_UPDATE_M, 0, 1),
+        .owner = ENTRY(0)
+    },
+    // backup stage: save the captured counter value
+    // restore stage: store the captured counter value to the loader register
+    [2] = {
+        .config = REGDMA_LINK_CONTINUOUS_INIT(REGDMA_TG1_TIMER_LINK(0x02),
+                                              TIMG_T0LO_REG(1), TIMG_T0LOADLO_REG(1), 2, 0, 0),
+        .owner = ENTRY(0)
+    },
+    // restore stage: trigger a soft reload, so the timer can continue from where it was backed up
+    [3] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG1_TIMER_LINK(0x03),
+                                         TIMG_T0LOAD_REG(1), 0x1, TIMG_T0_LOAD_M, 1, 0),
+        .owner = ENTRY(0)
+    },
+    // backup stage: save other configuration and status registers
+    // restore stage: restore the configuration and status registers
+    [4] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_TG1_TIMER_LINK(0x04),
+                                            TG1_TIMER0_RETENTION_REGS_BASE, TG1_TIMER0_RETENTION_REGS_BASE,
+                                            TG_TIMER0_RETENTION_REGS_CNT, 0, 0,
+                                            tg_timer0_regs_map[0], tg_timer0_regs_map[1],
+                                            tg_timer0_regs_map[2], tg_timer0_regs_map[3]),
+        .owner = ENTRY(0)
+    },
+};
+
+const regdma_entries_config_t tg1_timer1_regdma_entries[] = {
+    // backup stage: trigger a soft capture
+    [0] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG1_TIMER_LINK(0x05),
+                                         TIMG_T1UPDATE_REG(1), TIMG_T1_UPDATE, TIMG_T1_UPDATE_M, 0, 1),
+        .owner = ENTRY(0)
+    },
+    // backup stage: wait for the capture done
+    [1] = {
+        .config = REGDMA_LINK_WAIT_INIT(REGDMA_TG1_TIMER_LINK(0x06),
+                                        TIMG_T1UPDATE_REG(1), 0x0, TIMG_T1_UPDATE_M, 0, 1),
+        .owner = ENTRY(0)
+    },
+    // backup stage: save the captured counter value
+    // restore stage: store the captured counter value to the loader register
+    [2] = {
+        .config = REGDMA_LINK_CONTINUOUS_INIT(REGDMA_TG1_TIMER_LINK(0x07),
+                                              TIMG_T1LO_REG(1), TIMG_T1LOADLO_REG(1), 2, 0, 0),
+        .owner = ENTRY(0)
+    },
+    // restore stage: trigger a soft reload, so the timer can continue from where it was backed up
+    [3] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_TG1_TIMER_LINK(0x08),
+                                         TIMG_T1LOAD_REG(1), 0x1, TIMG_T1_LOAD_M, 1, 0),
+        .owner = ENTRY(0)
+    },
+    // backup stage: save other configuration and status registers
+    // restore stage: restore the configuration and status registers
+    [4] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_TG1_TIMER_LINK(0x09),
+                                            TG1_TIMER1_RETENTION_REGS_BASE, TG1_TIMER1_RETENTION_REGS_BASE,
+                                            TG_TIMER1_RETENTION_REGS_CNT, 0, 0,
+                                            tg_timer1_regs_map[0], tg_timer1_regs_map[1],
+                                            tg_timer1_regs_map[2], tg_timer1_regs_map[3]),
+        .owner = ENTRY(0)
+    },
+};
+
+const gptimer_retention_desc_t gptimer_retention_infos[2][2] = {
+    [0] = {
+        [0] = {
+            .module = SLEEP_RETENTION_MODULE_TG0_TIMER0,
+            .regdma_entry_array = tg0_timer0_regdma_entries,
+            .array_size = ARRAY_SIZE(tg0_timer0_regdma_entries)
+        },
+        [1] = {
+            .module = SLEEP_RETENTION_MODULE_TG0_TIMER1,
+            .regdma_entry_array = tg0_timer1_regdma_entries,
+            .array_size = ARRAY_SIZE(tg0_timer1_regdma_entries)
+        },
+    },
+    [1] = {
+        [0] = {
+            .module = SLEEP_RETENTION_MODULE_TG1_TIMER0,
+            .regdma_entry_array = tg1_timer0_regdma_entries,
+            .array_size = ARRAY_SIZE(tg1_timer0_regdma_entries)
+        },
+        [1] = {
+            .module = SLEEP_RETENTION_MODULE_TG1_TIMER1,
+            .regdma_entry_array = tg1_timer1_regdma_entries,
+            .array_size = ARRAY_SIZE(tg1_timer1_regdma_entries)
+        },
+    },
+};

--- a/components/esp_driver_gptimer/src/gptimer_priv.h
+++ b/components/esp_driver_gptimer/src/gptimer_priv.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include "soc/soc_caps.h"
+#include "hal/timer_ll.h"
+#include "esp_private/sleep_retention.h"
+#include <zephyr/sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if SOC_PAU_SUPPORTED && SOC_TIMER_SUPPORT_SLEEP_RETENTION
+#include "soc/retention_periph_defs.h"
+
+typedef struct {
+    const periph_retention_module_t module;
+    const regdma_entries_config_t *regdma_entry_array;
+    const size_t array_size;
+} gptimer_retention_desc_t;
+
+extern const gptimer_retention_desc_t gptimer_retention_infos[TIMG_LL_GET(INST_NUM)][TIMG_LL_GET(GPTIMERS_PER_INST)];
+#endif /* SOC_PAU_SUPPORTED && SOC_TIMER_SUPPORT_SLEEP_RETENTION */
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/esp_driver_mcpwm/esp32c5/mcpwm_retention.c
+++ b/components/esp_driver_mcpwm/esp32c5/mcpwm_retention.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc.h"
+#include "soc/mcpwm_reg.h"
+#include "mcpwm_private.h"
+
+/**
+ * MCPWM Registers to be saved during sleep retention
+ * - Timer Configuration registers, e.g.: MCPWM_TIMER_SYNCI_CFG_REG, MCPWM_TIMER0_CFG0_REG, MCPWM_TIMER0_CFG1_REG
+ * - Operator Configuration registers, e.g.: MCPWM_OPERATOR_TIMERSEL_REG
+ *   |- Generator Configuration registers, e.g.: MCPWM_GEN0_STMP_CFG_REG, MCPWM_GEN0_TSTMP_A_REG, MCPWM_GEN0_TSTMP_B_REG, MCPWM_GEN0_CFG0_REG, MCPWM_GEN0_FORCE_REG, MCPWM_GEN0_A_REG, MCPWM_GEN0_B_REG
+ *   |- Dead Time Configuration registers, e.g.: MCPWM_DT0_CFG_REG, MCPWM_DT0_FED_CFG_REG, MCPWM_DT0_RED_CFG_REG
+ *   |- Carrier Configuration registers, e.g.: MCPWM_CARRIER0_CFG_REG
+ *   └- Fault Handle Configuration registers, e.g.: MCPWM_FAULT_DETECT_REG, MCPWM_FH0_CFG0_REG, MCPWM_FH0_CFG1_REG
+ * - Capture Timer Configuration registers, e.g.: MCPWM_CAP_TIMER_CFG_REG, MCPWM_CAP_TIMER_PHASE_REG, MCPWM_CAP_CH0_CFG_REG, MCPWM_CAP_CH1_CFG_REG, MCPWM_CAP_CH2_CFG_REG
+ * - Interrupt enable registers, e.g.: MCPWM_INT_ENA_REG
+ * - ETM Configurations, e.g.: MCPWM_EVT_EN_REG, MCPWM_EVT_EN2_REG, MCPWM_TASK_EN_REG, MCPWM_OP0_TSTMP_E1_REG, MCPWM_OP0_TSTMP_E2_REG, MCPWM_OP1_TSTMP_E1_REG, MCPWM_OP1_TSTMP_E2_REG, MCPWM_OP2_TSTMP_E1_REG, MCPWM_OP2_TSTMP_E2_REG
+ * - Misc Configurations, e.g.: MCPWM_UPDATE_CFG_REG
+ */
+#define MCPWM_RETENTION_REGS_CNT 67
+#define MCPWM_RETENTION_REGS_BASE (DR_REG_MCPWM_BASE + 0x4)
+static const uint32_t mcpwm_regs_map[4] = {0xf7fff777, 0x3f7ffdff, 0xff8c, 0x0};
+static const regdma_entries_config_t mcpwm_regs_retention[] = {
+    // backup stage: save configuration registers
+    // restore stage: restore the configuration registers
+    [0] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_MCPWM_LINK(0x00),
+                                            MCPWM_RETENTION_REGS_BASE, MCPWM_RETENTION_REGS_BASE,
+                                            MCPWM_RETENTION_REGS_CNT, 0, 0,
+                                            mcpwm_regs_map[0], mcpwm_regs_map[1],
+                                            mcpwm_regs_map[2], mcpwm_regs_map[3]),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // restore stage: trigger a forced update of all active registers
+    [1] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_MCPWM_LINK(0x01),
+                                         MCPWM_UPDATE_CFG_REG(0), MCPWM_GLOBAL_FORCE_UP, MCPWM_GLOBAL_FORCE_UP_M, 1, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    [2] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_MCPWM_LINK(0x02),
+                                         MCPWM_UPDATE_CFG_REG(0), 0, MCPWM_GLOBAL_FORCE_UP_M, 1, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+};
+
+const mcpwm_retention_desc_t mcpwm_retention_infos[1] = {
+    [0] = {
+        .regdma_entry_array = mcpwm_regs_retention,
+        .array_size = ARRAY_SIZE(mcpwm_regs_retention),
+        .retention_module = SLEEP_RETENTION_MODULE_MCPWM0
+    },
+};

--- a/components/esp_driver_mcpwm/esp32c6/mcpwm_retention.c
+++ b/components/esp_driver_mcpwm/esp32c6/mcpwm_retention.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc.h"
+#include "soc/mcpwm_reg.h"
+#include "mcpwm_private.h"
+
+/**
+ * MCPWM Registers to be saved during sleep retention
+ * - Timer Configuration registers, e.g.: MCPWM_TIMER_SYNCI_CFG_REG, MCPWM_TIMER0_CFG0_REG, MCPWM_TIMER0_CFG1_REG
+ * - Operator Configuration registers, e.g.: MCPWM_OPERATOR_TIMERSEL_REG
+ *   |- Generator Configuration registers, e.g.: MCPWM_GEN0_STMP_CFG_REG, MCPWM_GEN0_TSTMP_A_REG, MCPWM_GEN0_TSTMP_B_REG, MCPWM_GEN0_CFG0_REG, MCPWM_GEN0_FORCE_REG, MCPWM_GEN0_A_REG, MCPWM_GEN0_B_REG
+ *   |- Dead Time Configuration registers, e.g.: MCPWM_DT0_CFG_REG, MCPWM_DT0_FED_CFG_REG, MCPWM_DT0_RED_CFG_REG
+ *   |- Carrier Configuration registers, e.g.: MCPWM_CARRIER0_CFG_REG
+ *   └- Fault Handle Configuration registers, e.g.: MCPWM_FAULT_DETECT_REG, MCPWM_FH0_CFG0_REG, MCPWM_FH0_CFG1_REG
+ * - Capture Timer Configuration registers, e.g.: MCPWM_CAP_TIMER_CFG_REG, MCPWM_CAP_TIMER_PHASE_REG, MCPWM_CAP_CH0_CFG_REG, MCPWM_CAP_CH1_CFG_REG, MCPWM_CAP_CH2_CFG_REG
+ * - Interrupt enable registers, e.g.: MCPWM_INT_ENA_REG
+ * - ETM Configurations, e.g.: MCPWM_EVT_EN_REG, MCPWM_TASK_EN_REG
+ * - Misc Configurations, e.g.: MCPWM_UPDATE_CFG_REG
+ */
+#define MCPWM_RETENTION_REGS_CNT 60
+#define MCPWM_RETENTION_REGS_BASE (DR_REG_MCPWM_BASE + 0x4)
+static const uint32_t mcpwm_regs_map[4] = {0xf7fff777, 0x3f7ffdff, 0x18c, 0x0};
+static const regdma_entries_config_t mcpwm_regs_retention[] = {
+    // backup stage: save configuration registers
+    // restore stage: restore the configuration registers
+    [0] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_MCPWM_LINK(0x00),
+                                            MCPWM_RETENTION_REGS_BASE, MCPWM_RETENTION_REGS_BASE,
+                                            MCPWM_RETENTION_REGS_CNT, 0, 0,
+                                            mcpwm_regs_map[0], mcpwm_regs_map[1],
+                                            mcpwm_regs_map[2], mcpwm_regs_map[3]),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // restore stage: trigger a forced update of all active registers
+    [1] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_MCPWM_LINK(0x01),
+                                         MCPWM_UPDATE_CFG_REG(0), MCPWM_GLOBAL_FORCE_UP, MCPWM_GLOBAL_FORCE_UP_M, 1, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    [2] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_MCPWM_LINK(0x02),
+                                         MCPWM_UPDATE_CFG_REG(0), 0, MCPWM_GLOBAL_FORCE_UP_M, 1, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+};
+
+const mcpwm_retention_desc_t mcpwm_retention_infos[1] = {
+    [0] = {
+        .regdma_entry_array = mcpwm_regs_retention,
+        .array_size = ARRAY_SIZE(mcpwm_regs_retention),
+        .retention_module = SLEEP_RETENTION_MODULE_MCPWM0
+    },
+};

--- a/components/esp_driver_mcpwm/esp32h2/mcpwm_retention.c
+++ b/components/esp_driver_mcpwm/esp32h2/mcpwm_retention.c
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/mcpwm_reg.h"
+#include "mcpwm_private.h"
+
+/**
+ * MCPWM Registers to be saved during sleep retention
+ * - Timer Configuration registers, e.g.: MCPWM_TIMER_SYNCI_CFG_REG, MCPWM_TIMER0_CFG0_REG, MCPWM_TIMER0_CFG1_REG
+ * - Operator Configuration registers, e.g.: MCPWM_OPERATOR_TIMERSEL_REG
+ *   |- Generator Configuration registers, e.g.: MCPWM_GEN0_STMP_CFG_REG, MCPWM_GEN0_TSTMP_A_REG, MCPWM_GEN0_TSTMP_B_REG, MCPWM_GEN0_CFG0_REG, MCPWM_GEN0_FORCE_REG, MCPWM_GEN0_A_REG, MCPWM_GEN0_B_REG
+ *   |- Dead Time Configuration registers, e.g.: MCPWM_DT0_CFG_REG, MCPWM_DT0_FED_CFG_REG, MCPWM_DT0_RED_CFG_REG
+ *   |- Carrier Configuration registers, e.g.: MCPWM_CARRIER0_CFG_REG
+ *   └- Fault Handle Configuration registers, e.g.: MCPWM_FAULT_DETECT_REG, MCPWM_FH0_CFG0_REG, MCPWM_FH0_CFG1_REG
+ * - Capture Timer Configuration registers, e.g.: MCPWM_CAP_TIMER_CFG_REG, MCPWM_CAP_TIMER_PHASE_REG, MCPWM_CAP_CH0_CFG_REG, MCPWM_CAP_CH1_CFG_REG, MCPWM_CAP_CH2_CFG_REG
+ * - Interrupt enable registers, e.g.: MCPWM_INT_ENA_REG
+ * - ETM Configurations, e.g.: MCPWM_EVT_EN_REG, MCPWM_TASK_EN_REG
+ * - Misc Configurations, e.g.: MCPWM_UPDATE_CFG_REG
+ */
+#define MCPWM_RETENTION_REGS_CNT 60
+#define MCPWM_RETENTION_REGS_BASE (DR_REG_MCPWM_BASE + 0x4)
+static const uint32_t mcpwm_regs_map[4] = {0xf7fff777, 0x3f7ffdff, 0x18c, 0x0};
+static const regdma_entries_config_t mcpwm_regs_retention[] = {
+    // backup stage: save configuration registers
+    // restore stage: restore the configuration registers
+    [0] = {
+        .config = REGDMA_LINK_ADDR_MAP_INIT(REGDMA_MCPWM_LINK(0x00),
+                                            MCPWM_RETENTION_REGS_BASE, MCPWM_RETENTION_REGS_BASE,
+                                            MCPWM_RETENTION_REGS_CNT, 0, 0,
+                                            mcpwm_regs_map[0], mcpwm_regs_map[1],
+                                            mcpwm_regs_map[2], mcpwm_regs_map[3]),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    // restore stage: trigger a forced update of all active registers
+    [1] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_MCPWM_LINK(0x01),
+                                         MCPWM_UPDATE_CFG_REG, MCPWM_GLOBAL_FORCE_UP, MCPWM_GLOBAL_FORCE_UP_M, 1, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+    [2] = {
+        .config = REGDMA_LINK_WRITE_INIT(REGDMA_MCPWM_LINK(0x02),
+                                         MCPWM_UPDATE_CFG_REG, 0, MCPWM_GLOBAL_FORCE_UP_M, 1, 0),
+        .owner = ENTRY(0) | ENTRY(2)
+    },
+};
+
+const mcpwm_retention_desc_t mcpwm_retention_infos[1] = {
+    [0] = {
+        .regdma_entry_array = mcpwm_regs_retention,
+        .array_size = ARRAY_SIZE(mcpwm_regs_retention),
+        .retention_module = SLEEP_RETENTION_MODULE_MCPWM0
+    },
+};

--- a/components/esp_driver_mcpwm/esp32p4/mcpwm_retention.c
+++ b/components/esp_driver_mcpwm/esp32p4/mcpwm_retention.c
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc/soc.h"
+#include "soc/mcpwm_reg.h"
+#include "mcpwm_private.h"
+
+/**
+ * MCPWM Registers to be saved during sleep retention
+ * - Timer Configuration registers, e.g.: MCPWM_TIMER_SYNCI_CFG_REG, MCPWM_TIMER0_CFG0_REG, MCPWM_TIMER0_CFG1_REG
+ * - Operator Configuration registers, e.g.: MCPWM_OPERATOR_TIMERSEL_REG
+ *   |- Generator Configuration registers, e.g.: MCPWM_GEN0_STMP_CFG_REG, MCPWM_GEN0_TSTMP_A_REG, MCPWM_GEN0_TSTMP_B_REG, MCPWM_GEN0_CFG0_REG, MCPWM_GEN0_FORCE_REG, MCPWM_GEN0_A_REG, MCPWM_GEN0_B_REG
+ *   |- Dead Time Configuration registers, e.g.: MCPWM_DT0_CFG_REG, MCPWM_DT0_FED_CFG_REG, MCPWM_DT0_RED_CFG_REG
+ *   |- Carrier Configuration registers, e.g.: MCPWM_CARRIER0_CFG_REG
+ *   └- Fault Handle Configuration registers, e.g.: MCPWM_FAULT_DETECT_REG, MCPWM_FH0_CFG0_REG, MCPWM_FH0_CFG1_REG
+ * - Capture Timer Configuration registers, e.g.: MCPWM_CAP_TIMER_CFG_REG, MCPWM_CAP_TIMER_PHASE_REG, MCPWM_CAP_CH0_CFG_REG, MCPWM_CAP_CH1_CFG_REG, MCPWM_CAP_CH2_CFG_REG
+ * - Interrupt enable registers, e.g.: MCPWM_INT_ENA_REG
+ * - ETM Configurations, e.g.: MCPWM_EVT_EN_REG, MCPWM_TASK_EN_REG
+ * - Misc Configurations, e.g.: MCPWM_UPDATE_CFG_REG
+ */
+#define MCPWM_RETENTION_REGS_CNT 67
+#define MCPWM_RETENTION_REGS_BASE(i) (REG_MCPWM_BASE(i) + 0x4)
+static const uint32_t mcpwm_regs_map[4] = {0xf7fff777, 0x3f7ffdff, 0xff8c, 0x0};
+#define MCPWM_SLEEP_RETENTION_ENTRIES(mcpwm_port) {  \
+    /* backup stage: save configuration registers \
+       restore stage: restore the configuration registers */ \
+    [0] = { .config = REGDMA_LINK_ADDR_MAP_INIT(  \
+                REGDMA_MCPWM_LINK(0x00), \
+                MCPWM_RETENTION_REGS_BASE(mcpwm_port),  \
+                MCPWM_RETENTION_REGS_BASE(mcpwm_port), \
+                MCPWM_RETENTION_REGS_CNT, 0, 0, \
+                mcpwm_regs_map[0], mcpwm_regs_map[1], \
+                mcpwm_regs_map[2], mcpwm_regs_map[3]), \
+                .owner = ENTRY(0)}, \
+    /* restore stage: trigger a forced update of all active registers*/ \
+    [1] = { .config = REGDMA_LINK_WRITE_INIT(REGDMA_MCPWM_LINK(0x01),  \
+                                                MCPWM_UPDATE_CFG_REG(mcpwm_port), MCPWM_GLOBAL_FORCE_UP, MCPWM_GLOBAL_FORCE_UP_M, 1, 0),  \
+                                                .owner = ENTRY(0) }, \
+    [2] = { .config = REGDMA_LINK_WRITE_INIT(REGDMA_MCPWM_LINK(0x02),  \
+                                                MCPWM_UPDATE_CFG_REG(mcpwm_port), 0, MCPWM_GLOBAL_FORCE_UP_M, 1, 0),  \
+                                                .owner = ENTRY(0) },  \
+};
+
+static const regdma_entries_config_t mcpwm0_regs_retention[] = MCPWM_SLEEP_RETENTION_ENTRIES(0);
+static const regdma_entries_config_t mcpwm1_regs_retention[] = MCPWM_SLEEP_RETENTION_ENTRIES(1);
+
+const mcpwm_retention_desc_t mcpwm_retention_infos[2] = {
+    [0] = {
+        .regdma_entry_array = mcpwm0_regs_retention,
+        .array_size = ARRAY_SIZE(mcpwm0_regs_retention),
+        .retention_module = SLEEP_RETENTION_MODULE_MCPWM0
+    },
+    [1] = {
+        .regdma_entry_array = mcpwm1_regs_retention,
+        .array_size = ARRAY_SIZE(mcpwm1_regs_retention),
+        .retention_module = SLEEP_RETENTION_MODULE_MCPWM1
+    },
+};

--- a/components/esp_driver_mcpwm/src/mcpwm_private.h
+++ b/components/esp_driver_mcpwm/src/mcpwm_private.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include "soc/soc_caps.h"
+#include "hal/mcpwm_ll.h"
+#include "esp_private/sleep_retention.h"
+#include <zephyr/sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if SOC_MCPWM_SUPPORT_SLEEP_RETENTION
+typedef struct {
+    const regdma_entries_config_t *regdma_entry_array;
+    const size_t array_size;
+    const periph_retention_module_t retention_module;
+} mcpwm_retention_desc_t;
+
+extern const mcpwm_retention_desc_t mcpwm_retention_infos[MCPWM_LL_GET(GROUP_NUM)];
+#endif /* SOC_MCPWM_SUPPORT_SLEEP_RETENTION */
+
+#ifdef __cplusplus
+}
+#endif

--- a/tools/sync/hal-config.yml
+++ b/tools/sync/hal-config.yml
@@ -17,7 +17,10 @@ components:
   - esp_coex
   - esp_common
   - esp_driver_dac
+  - esp_driver_dma
   - esp_driver_gpio
+  - esp_driver_gptimer
+  - esp_driver_mcpwm
   - esp_driver_touch_sens
   - esp_driver_tsens
   - esp_event
@@ -110,7 +113,10 @@ exclude:
   - esp_coex/test_apps
   - esp_common/test_apps
   - esp_driver_dac/test_apps
+  - esp_driver_dma/test_apps
   - esp_driver_gpio/test_apps
+  - esp_driver_gptimer/test_apps
+  - esp_driver_mcpwm/test_apps
   - esp_driver_touch_sens/test_apps
   - esp_driver_tsens/test_apps
   - esp_event/host_test

--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -314,8 +314,11 @@ if(CONFIG_SOC_SERIES_ESP32C5)
       )
 
     if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_include_directories(
+        ../../components/esp_driver_dma/src
+        )
       zephyr_sources(
-        ../../components/esp_hal_dma/${CONFIG_SOC_SERIES}/gdma_periph.c
+        ../../components/esp_driver_dma/${CONFIG_SOC_SERIES}/gdma_retention.c
         )
     endif()
   endif()
@@ -467,8 +470,11 @@ if(CONFIG_SOC_SERIES_ESP32C5)
       ../../components/esp_hal_timg/timer_hal.c
       )
     if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_include_directories(
+        ../../components/esp_driver_gptimer/src
+        )
       zephyr_sources(
-        ../../components/esp_hal_timg/${CONFIG_SOC_SERIES}/timer_periph.c
+        ../../components/esp_driver_gptimer/${CONFIG_SOC_SERIES}/timer_retention.c
         )
     endif()
   endif()
@@ -490,8 +496,11 @@ if(CONFIG_SOC_SERIES_ESP32C5)
       ../../components/esp_hal_mcpwm/mcpwm_hal.c
       )
     if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_include_directories(
+        ../../components/esp_driver_mcpwm/src
+        )
       zephyr_sources(
-        ../../components/esp_hal_mcpwm/${CONFIG_SOC_SERIES}/mcpwm_periph.c
+        ../../components/esp_driver_mcpwm/${CONFIG_SOC_SERIES}/mcpwm_retention.c
         )
     endif()
   endif()

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -309,8 +309,11 @@ if(CONFIG_SOC_SERIES_ESP32C6)
       )
 
     if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_include_directories(
+        ../../components/esp_driver_dma/src
+        )
       zephyr_sources(
-        ../../components/esp_hal_dma/${CONFIG_SOC_SERIES}/gdma_periph.c
+        ../../components/esp_driver_dma/${CONFIG_SOC_SERIES}/gdma_retention.c
         )
     endif()
   endif()
@@ -448,8 +451,11 @@ if(CONFIG_SOC_SERIES_ESP32C6)
       ../../components/esp_hal_timg/timer_hal.c
       )
     if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_include_directories(
+        ../../components/esp_driver_gptimer/src
+        )
       zephyr_sources(
-        ../../components/esp_hal_timg/${CONFIG_SOC_SERIES}/timer_periph.c
+        ../../components/esp_driver_gptimer/${CONFIG_SOC_SERIES}/timer_retention.c
         )
     endif()
   endif()
@@ -471,8 +477,11 @@ if(CONFIG_SOC_SERIES_ESP32C6)
       ../../components/esp_hal_mcpwm/mcpwm_hal.c
       )
     if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_include_directories(
+        ../../components/esp_driver_mcpwm/src
+        )
       zephyr_sources(
-        ../../components/esp_hal_mcpwm/${CONFIG_SOC_SERIES}/mcpwm_periph.c
+        ../../components/esp_driver_mcpwm/${CONFIG_SOC_SERIES}/mcpwm_retention.c
         )
     endif()
   endif()

--- a/zephyr/esp32h2/CMakeLists.txt
+++ b/zephyr/esp32h2/CMakeLists.txt
@@ -309,8 +309,11 @@ if(CONFIG_SOC_SERIES_ESP32H2)
       ../../components/esp_hal_timg/timer_hal.c
       )
     if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_include_directories(
+        ../../components/esp_driver_gptimer/src
+        )
       zephyr_sources(
-        ../../components/esp_hal_timg/${CONFIG_SOC_SERIES}/timer_periph.c
+        ../../components/esp_driver_gptimer/${CONFIG_SOC_SERIES}/timer_retention.c
         )
     endif()
   endif()
@@ -358,8 +361,11 @@ if(CONFIG_SOC_SERIES_ESP32H2)
       )
 
     if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_include_directories(
+        ../../components/esp_driver_dma/src
+        )
       zephyr_sources(
-        ../../components/esp_hal_dma/${CONFIG_SOC_SERIES}/gdma_periph.c
+        ../../components/esp_driver_dma/${CONFIG_SOC_SERIES}/gdma_retention.c
         )
     endif()
   endif()
@@ -417,8 +423,11 @@ if(CONFIG_SOC_SERIES_ESP32H2)
       ../../components/esp_hal_mcpwm/mcpwm_hal.c
       )
     if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_include_directories(
+        ../../components/esp_driver_mcpwm/src
+        )
       zephyr_sources(
-        ../../components/esp_hal_mcpwm/${CONFIG_SOC_SERIES}/mcpwm_periph.c
+        ../../components/esp_driver_mcpwm/${CONFIG_SOC_SERIES}/mcpwm_retention.c
         )
     endif()
   endif()

--- a/zephyr/esp32p4/CMakeLists.txt
+++ b/zephyr/esp32p4/CMakeLists.txt
@@ -325,8 +325,11 @@ if(CONFIG_SOC_SERIES_ESP32P4)
       )
 
     if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_include_directories(
+        ../../components/esp_driver_dma/src
+        )
       zephyr_sources(
-        ../../components/esp_hal_dma/${CONFIG_SOC_SERIES}/gdma_periph.c
+        ../../components/esp_driver_dma/${CONFIG_SOC_SERIES}/gdma_retention.c
         )
     endif()
   endif()
@@ -481,8 +484,11 @@ if(CONFIG_SOC_SERIES_ESP32P4)
       ../../components/esp_hal_timg/timer_hal.c
       )
     if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_include_directories(
+        ../../components/esp_driver_gptimer/src
+        )
       zephyr_sources(
-        ../../components/esp_hal_timg/${CONFIG_SOC_SERIES}/timer_periph.c
+        ../../components/esp_driver_gptimer/${CONFIG_SOC_SERIES}/timer_retention.c
         )
     endif()
   endif()
@@ -504,8 +510,11 @@ if(CONFIG_SOC_SERIES_ESP32P4)
       ../../components/esp_hal_mcpwm/mcpwm_hal.c
       )
     if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_include_directories(
+        ../../components/esp_driver_mcpwm/src
+        )
       zephyr_sources(
-        ../../components/esp_hal_mcpwm/${CONFIG_SOC_SERIES}/mcpwm_periph.c
+        ../../components/esp_driver_mcpwm/${CONFIG_SOC_SERIES}/mcpwm_retention.c
         )
     endif()
   endif()


### PR DESCRIPTION
Fix sleep retention for several peripherals after a recent HAL sync, which requires some file imports (as is), and refactored xxxx_priv.h header files to keep Zephyr driver usage simple, while stripping OS specific code present in original HAL code.