### PR TITLE
esp_hal_ana_cmpr: fix ESP32-C5/P4 edge polarity and wire up HAL build for Zephyr's ana_cmpr driver

### DIFF
--- a/components/esp_hal_ana_cmpr/esp32c5/include/hal/ana_cmpr_ll.h
+++ b/components/esp_hal_ana_cmpr/esp32c5/include/hal/ana_cmpr_ll.h
@@ -37,8 +37,8 @@ extern "C" {
 
 #define ANALOG_CMPR_LL_GET_HW(unit)     (&ANALOG_CMPR[unit])
 
-#define ANALOG_CMPR_LL_NEG_CROSS_INTR_MASK(unit, src_chan)   0x01
-#define ANALOG_CMPR_LL_POS_CROSS_INTR_MASK(unit, src_chan)   0x02
+#define ANALOG_CMPR_LL_NEG_CROSS_INTR_MASK(unit, src_chan)   0x02
+#define ANALOG_CMPR_LL_POS_CROSS_INTR_MASK(unit, src_chan)   0x01
 #define ANALOG_CMPR_LL_ANY_CROSS_INTR_MASK(unit, src_chan)   (ANALOG_CMPR_LL_NEG_CROSS_INTR_MASK(unit, src_chan) | ANALOG_CMPR_LL_POS_CROSS_INTR_MASK(unit, src_chan))
 #define ANALOG_CMPR_LL_ALL_INTR_MASK(unit)                   0x07
 

--- a/components/esp_hal_ana_cmpr/esp32p4/include/hal/ana_cmpr_ll.h
+++ b/components/esp_hal_ana_cmpr/esp32p4/include/hal/ana_cmpr_ll.h
@@ -38,8 +38,8 @@ extern "C" {
 #define ANALOG_CMPR_LL_GET_HW(unit)     (&ANALOG_CMPR[unit])
 #define ANALOG_CMPR_LL_GET_UNIT(hw)     ((hw) == (&ANALOG_CMPR[0]) ? 0 : 1)
 
-#define ANALOG_CMPR_LL_NEG_CROSS_INTR_MASK(unit, src_chan)   (1UL << ((unit) * 3 + 0))
-#define ANALOG_CMPR_LL_POS_CROSS_INTR_MASK(unit, src_chan)   (1UL << ((unit) * 3 + 1))
+#define ANALOG_CMPR_LL_NEG_CROSS_INTR_MASK(unit, src_chan)   (1UL << ((unit) * 3 + 1))
+#define ANALOG_CMPR_LL_POS_CROSS_INTR_MASK(unit, src_chan)   (1UL << ((unit) * 3 + 0))
 #define ANALOG_CMPR_LL_ANY_CROSS_INTR_MASK(unit, src_chan)   (ANALOG_CMPR_LL_NEG_CROSS_INTR_MASK(unit, src_chan) | ANALOG_CMPR_LL_POS_CROSS_INTR_MASK(unit, src_chan))
 #define ANALOG_CMPR_LL_ALL_INTR_MASK(unit)                   (0x07 << ((unit) * 3))
 

--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -39,6 +39,8 @@ if(CONFIG_SOC_SERIES_ESP32C5)
     ../../components/esp_common/include
     ../../components/esp_driver_gpio/include
     ../../components/esp_event/include
+    ../../components/esp_hal_ana_cmpr/include
+    ../../components/esp_hal_ana_cmpr/${CONFIG_SOC_SERIES}/include
     ../../components/esp_hal_ana_conv/include
     ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/include
     ../../components/esp_hal_clock/include
@@ -498,6 +500,11 @@ if(CONFIG_SOC_SERIES_ESP32C5)
 
   zephyr_sources_ifdef(CONFIG_PCNT_ESP32
     ../../components/esp_hal_pcnt/pcnt_hal.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_COMPARATOR_ESP32_ANA_CMPR
+    ../../components/esp_hal_ana_cmpr/${CONFIG_SOC_SERIES}/ana_cmpr_periph.c
+    ../../components/esp_driver_gpio/src/gpio.c
     )
 
   zephyr_sources_ifdef(CONFIG_CAN_ESP32_TWAIFD

--- a/zephyr/esp32h2/CMakeLists.txt
+++ b/zephyr/esp32h2/CMakeLists.txt
@@ -39,6 +39,8 @@ if(CONFIG_SOC_SERIES_ESP32H2)
     ../../components/esp_common/include
     ../../components/esp_driver_gpio/include
     ../../components/esp_event/include
+    ../../components/esp_hal_ana_cmpr/include
+    ../../components/esp_hal_ana_cmpr/${CONFIG_SOC_SERIES}/include
     ../../components/esp_hal_ana_conv/include
     ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/include
     ../../components/esp_hal_clock/include
@@ -425,6 +427,11 @@ if(CONFIG_SOC_SERIES_ESP32H2)
 
   zephyr_sources_ifdef(CONFIG_PCNT_ESP32
     ../../components/esp_hal_pcnt/pcnt_hal.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_COMPARATOR_ESP32_ANA_CMPR
+    ../../components/esp_hal_ana_cmpr/${CONFIG_SOC_SERIES}/ana_cmpr_periph.c
+    ../../components/esp_driver_gpio/src/gpio.c
     )
 
   zephyr_sources_ifdef(CONFIG_ESPRESSIF_RMT

--- a/zephyr/esp32p4/CMakeLists.txt
+++ b/zephyr/esp32p4/CMakeLists.txt
@@ -51,6 +51,8 @@ if(CONFIG_SOC_SERIES_ESP32P4)
     ../../components/esp_common/include
     ../../components/esp_driver_gpio/include
     ../../components/esp_event/include
+    ../../components/esp_hal_ana_cmpr/include
+    ../../components/esp_hal_ana_cmpr/${CONFIG_SOC_SERIES}/include
     ../../components/esp_hal_ana_conv/include
     ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/include
     ../../components/esp_hal_clock/include
@@ -512,6 +514,11 @@ if(CONFIG_SOC_SERIES_ESP32P4)
 
   zephyr_sources_ifdef(CONFIG_PCNT_ESP32
     ../../components/esp_hal_pcnt/pcnt_hal.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_COMPARATOR_ESP32_ANA_CMPR
+    ../../components/esp_hal_ana_cmpr/${CONFIG_SOC_SERIES}/ana_cmpr_periph.c
+    ../../components/esp_driver_gpio/src/gpio.c
     )
 
   zephyr_sources_ifdef(CONFIG_SDHC_ESP32


### PR DESCRIPTION
Fix the ESP32-C5 and ESP32-P4 positive/negative edge-crossing interrupt
mask macros in `esp_hal_ana_cmpr`'s LL headers, and add the include
paths and `CMakeLists.txt` wiring needed to build `esp_hal_ana_cmpr`
sources for ESP32-C5/ESP32-H2/ESP32-P4 under Zephyr's new analog
comparator (`ana_cmpr`) driver.

`ANALOG_CMPR_LL_NEG_CROSS_INTR_MASK()`/`POS_CROSS_INTR_MASK()` were
defined from the vendored register header's field *names*
(`comp_neg_0_*`/`comp_pos_0_*` on C5, `compN_neg`/`compN_pos` on P4),
but each field's own inline comment documents the opposite polarity.
Verified against real hardware (ESP32-C5-DevKitC-1 GPIO loopback) and
cross-checked with an equivalent regression test added on the ESP-IDF
side that the comments — not the field names — match actual silicon
behavior, so the macros are corrected to match the comments/measured
behavior instead.