### PR TITLE
zephyr: route hal os calls through the esp_os glue

### DIFF
--- a/components/bt/controller/esp32/bt.c
+++ b/components/bt/controller/esp32/bt.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/random/random.h>
+#include <esp_os.h>
 
 #include <stddef.h>
 #include <stdlib.h>
@@ -107,8 +108,7 @@ typedef struct {
 
 /* bt queue */
 struct bt_queue_t {
-    struct k_msgq queue;
-    void *pool;
+    esp_os_queue_t handle;
 };
 
 /* OSI function */
@@ -340,7 +340,7 @@ static const struct osi_funcs_t osi_funcs_ro = {
 #endif /* CONFIG_BTDM_CTRL_HLI */
     ._task_create = task_create_wrapper,
     ._task_delete = task_delete_wrapper,
-    ._is_in_isr = k_is_in_isr,
+    ._is_in_isr = esp_os_is_in_isr,
     ._cause_sw_intr_to_core = cause_sw_intr_to_core_wrapper,
     ._malloc = malloc_internal_wrapper,
     ._malloc_internal = malloc_internal_wrapper,
@@ -415,8 +415,6 @@ static DRAM_ATTR esp_bt_controller_status_t btdm_controller_status = ESP_BT_CONT
 static esp_os_spinlock_t global_int_lock = ESP_OS_SPINLOCK_INIT;
 
 // BT library uses a single task
-K_THREAD_STACK_DEFINE(bt_stack, CONFIG_ESP32_BT_CONTROLLER_STACK_SIZE);
-static struct k_thread bt_task_handle;
 
 // measured average low power clock period in micro seconds
 static DRAM_ATTR uint32_t btdm_lpcycle_us = 0;
@@ -431,7 +429,7 @@ static DRAM_ATTR uint8_t btdm_lpclk_sel = ESP_BT_SLEEP_CLOCK_MAIN_XTAL;
 #endif /* CONFIG_BTDM_CTRL_LPCLK_SEL_EXT_32K_XTAL */
 #endif /* #ifdef CONFIG_BTDM_CTRL_MODEM_SLEEP_MODE_ORIG */
 
-static DRAM_ATTR struct k_sem *s_wakeup_req_sem = NULL;
+static DRAM_ATTR esp_os_sem_t s_wakeup_req_sem = NULL;
 #ifdef CONFIG_PM
 static DRAM_ATTR esp_timer_handle_t s_btdm_slp_tmr;
 static DRAM_ATTR esp_pm_lock_handle_t s_pm_lock;
@@ -519,8 +517,8 @@ static void IRAM_ATTR interrupt_l3_restore(void)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-    irq_disable(n);
-    irq_connect_dynamic(n, Xthal_intlevel[n], f, arg, 0);
+    esp_os_irq_disable(n);
+    esp_os_irq_connect(n, Xthal_intlevel[n], f, arg, 0);
 }
 
 static void intr_on(unsigned int mask)
@@ -532,51 +530,46 @@ static void intr_on(unsigned int mask)
         ++pos;
     }
 
-    irq_enable(pos);
+    esp_os_irq_enable(pos);
 }
 
 static void IRAM_ATTR task_yield_from_isr(void)
 {
-    k_yield();
+    esp_os_thread_yield();
 }
 
 static void *semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    struct k_sem *sem = (struct k_sem *)esp_bt_malloc_func(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
 
     if (sem == NULL) {
         LOG_ERR("semaphore malloc failed");
         return NULL;
     }
 
-    k_sem_init(sem, init, max);
     return sem;
 }
 
 static void semphr_delete_wrapper(void *semphr)
 {
-    esp_bt_free(semphr);
+    esp_os_sem_delete(semphr);
 }
 
 static int32_t IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
-    int ret = k_sem_take((struct k_sem *)semphr, K_NO_WAIT);
+    int ret = esp_os_sem_take(semphr, ESP_OS_NO_WAIT);
 
     *hpt = 0;
 
-    if (ret == 0) {
-        return 1;
-    }
-
-    return 0;
+    return ret == 0 ? 1 : 0;
 }
 
 static int32_t IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
 
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
 
     *hpt = 0;
     return 1;
@@ -584,59 +577,43 @@ static int32_t IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr, void *hptw)
 
 static int32_t semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
 {
-    int ret = 0;
+    uint32_t timeout = (block_time_ms == OSI_FUNCS_TIME_BLOCKING) ? ESP_OS_FOREVER : block_time_ms;
 
-    if (block_time_ms == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_sem_take((struct k_sem *)semphr, K_FOREVER);
-    } else {
-        ret = k_sem_take((struct k_sem *)semphr, K_MSEC(block_time_ms));
-    }
-
-    if (ret == 0) {
-        return 1;
-    }
-
-    return 0;
+    return esp_os_sem_take(semphr, timeout) == 0 ? 1 : 0;
 }
 
 static int32_t semphr_give_wrapper(void *semphr)
 {
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
     return 1;
 }
 
 static void *mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)esp_bt_malloc_func(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("mutex malloc failed");
         return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return my_mutex;
+    return mutex;
 }
 
 static void mutex_delete_wrapper(void *mutex)
 {
-    esp_bt_free(mutex);
+    esp_os_mutex_delete(mutex);
 }
 
 static int32_t mutex_lock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-    k_mutex_lock(my_mutex, K_FOREVER);
+    esp_os_mutex_lock(mutex, ESP_OS_FOREVER);
     return 0;
 }
 
 static int32_t mutex_unlock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-    k_mutex_unlock(my_mutex);
+    esp_os_mutex_unlock(mutex);
     return 0;
 }
 
@@ -649,15 +626,14 @@ static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
         return NULL;
     }
 
-    queue->pool = (uint8_t *)esp_bt_malloc_func(queue_len * item_size * sizeof(uint8_t));
+    queue->handle = esp_os_queue_create(queue_len, item_size);
 
-    if (queue->pool == NULL) {
+    if (queue->handle == NULL) {
         LOG_ERR("queue pool malloc failed");
         esp_bt_free(queue);
         return NULL;
     }
 
-    k_msgq_init(&queue->queue, queue->pool, item_size, queue_len);
     return queue;
 }
 
@@ -666,7 +642,7 @@ static void queue_delete_wrapper(void *queue)
     struct bt_queue_t *q = (struct bt_queue_t *)queue;
 
     if (q != NULL) {
-        esp_bt_free(q->pool);
+        esp_os_queue_delete(q->handle);
         esp_bt_free(q);
     }
 }
@@ -766,78 +742,47 @@ static int32_t IRAM_ATTR queue_recv_from_isr_hlevel_wrapper(void *queue, void *i
 static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_ms)
 {
     struct bt_queue_t *q = (struct bt_queue_t *)queue;
-    int res = 0;
+    uint32_t timeout = (block_time_ms == OSI_FUNCS_TIME_BLOCKING) ? ESP_OS_FOREVER : block_time_ms;
 
-    if (block_time_ms == OSI_FUNCS_TIME_BLOCKING) {
-        res = k_msgq_put(&q->queue, item, K_FOREVER);
-    } else {
-        res = k_msgq_put(&q->queue, item, K_MSEC(block_time_ms));
-    }
-
-    if (res == 0) {
-        return 1;
-    }
-
-    return 0;
+    return esp_os_queue_send(q->handle, item, timeout) == 0 ? 1 : 0;
 }
 
 static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
 {
     struct bt_queue_t *q = (struct bt_queue_t *)queue;
     int *hpt = (int *)hptw;
-    int ret = k_msgq_put(&q->queue, item, K_NO_WAIT);
+    int ret = esp_os_queue_send(q->handle, item, ESP_OS_NO_WAIT);
 
     *hpt = 0;
 
-    if (ret == 0) {
-        return 1;
-    }
-
-    return 0;
+    return ret == 0 ? 1 : 0;
 }
 
 static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_ms)
 {
     struct bt_queue_t *q = (struct bt_queue_t *)queue;
-    int ret = 0;
+    uint32_t timeout = (block_time_ms == OSI_FUNCS_TIME_BLOCKING) ? ESP_OS_FOREVER : block_time_ms;
 
-    if (block_time_ms == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_get(&q->queue, item, K_FOREVER);
-    } else {
-        ret = k_msgq_get(&q->queue, item, K_MSEC(block_time_ms));
-    }
-
-    if (ret == 0) {
-        return 1;
-    }
-
-    return 0;
+    return esp_os_queue_recv(q->handle, item, timeout) == 0 ? 1 : 0;
 }
 
 static int32_t IRAM_ATTR queue_recv_from_isr_wrapper(void *queue, void *item, void *hptw)
 {
     struct bt_queue_t *q = (struct bt_queue_t *)queue;
     int *hpt = (int *)hptw;
-    int ret = k_msgq_get(&q->queue, item, K_NO_WAIT);
+    int ret = esp_os_queue_recv(q->handle, item, ESP_OS_NO_WAIT);
 
     *hpt = 0;
 
-    if (ret == 0) {
-        return 1;
-    }
-
-    return 0;
+    return ret == 0 ? 1 : 0;
 }
 #endif /* CONFIG_BTDM_CTRL_HLI */
 
 
 static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t stack_depth, void *param, uint32_t prio, void *task_handle, uint32_t core_id)
 {
-    k_tid_t tid = k_thread_create(&bt_task_handle, bt_stack, stack_depth,
-                      (k_thread_entry_t)task_func, param, NULL, NULL,
-                      K_PRIO_COOP(prio), K_INHERIT_PERMS, K_NO_WAIT);
-
-    k_thread_name_set(tid, name);
+    esp_os_thread_t tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+                      stack_depth, K_PRIO_COOP(prio), name);
 
     *(int32_t *)task_handle = (int32_t)tid;
 
@@ -847,10 +792,8 @@ static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t s
 static void task_delete_wrapper(void *task_handle)
 {
     if (task_handle != NULL) {
-        k_thread_abort((k_tid_t)task_handle);
+        esp_os_thread_delete((esp_os_thread_t)task_handle);
     }
-
-    k_object_release(&bt_task_handle);
 }
 
 static int IRAM_ATTR cause_sw_intr_to_core_wrapper(int core_id, int intr_no)

--- a/components/bt/controller/esp32c2/bt.c
+++ b/components/bt/controller/esp32c2/bt.c
@@ -55,6 +55,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/irq.h>
+#include <esp_os.h>
 
 #include "soc/dport_access.h"
 
@@ -607,8 +608,6 @@ static uint32_t IRAM_ATTR osi_random_wrapper(void)
     return esp_random();
 }
 
-static K_KERNEL_STACK_DEFINE(bt_task_stack, CONFIG_ESP32_BT_LE_CONTROLLER_TASK_STACK_SIZE);
-static struct k_thread bt_task_thread;
 
 static void coex_schm_status_bit_set_wrapper(uint32_t type, uint32_t status)
 {
@@ -627,23 +626,20 @@ static void coex_schm_status_bit_clear_wrapper(uint32_t type, uint32_t status)
 static int task_create_wrapper(void *task_func, const char *name, uint32_t stack_depth,
                                 void *param, uint32_t prio, void *task_handle, uint32_t core_id)
 {
-    k_tid_t tid;
+    esp_os_thread_t tid;
 
-    tid = k_thread_create(&bt_task_thread, bt_task_stack,
-                          K_KERNEL_STACK_SIZEOF(bt_task_stack),
-                          (k_thread_entry_t)task_func, param, NULL, NULL,
-                          K_PRIO_COOP(prio), 0, K_NO_WAIT);
+    tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+                               stack_depth, K_PRIO_COOP(prio), name);
     if (tid == NULL) {
         return 0;
     }
-    k_thread_name_set(tid, name);
-    *(k_tid_t *)task_handle = tid;
+    *(void **)task_handle = tid;
     return 1;
 }
 
 static void task_delete_wrapper(void *task_handle)
 {
-    k_thread_abort((k_tid_t)task_handle);
+    esp_os_thread_delete((esp_os_thread_t)task_handle);
 }
 
 static int esp_ecc_gen_key_pair(uint8_t *pub, uint8_t *priv)

--- a/components/bt/controller/esp32c3/bt.c
+++ b/components/bt/controller/esp32c3/bt.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/random/random.h>
+#include <esp_os.h>
 
 #include <stddef.h>
 #include <stdlib.h>
@@ -148,8 +149,7 @@ typedef struct vhci_host_callback {
 
 /* Zephyr queue structure for BT adapter */
 struct bt_queue_t {
-    struct k_msgq queue;
-    void *pool;
+    esp_os_queue_t handle;
 };
 
 typedef void (* osi_intr_handler)(void);
@@ -495,14 +495,12 @@ static DRAM_ATTR uint32_t btdm_lpcycle_us = 0;
 // number of fractional bit for btdm_lpcycle_us
 static DRAM_ATTR uint8_t btdm_lpcycle_us_frac = 0;
 /* semaphore used for blocking VHCI API to wait for controller to wake up */
-static DRAM_ATTR struct k_sem *s_wakeup_req_sem = NULL;
+static DRAM_ATTR esp_os_sem_t s_wakeup_req_sem = NULL;
 
-/* Zephyr thread handle and stack for BT task */
-static struct k_thread bt_task_handle;
+/* BT task stack size */
 #ifndef CONFIG_ESP32_BT_LE_CONTROLLER_TASK_STACK_SIZE
 #define CONFIG_ESP32_BT_LE_CONTROLLER_TASK_STACK_SIZE 4096
 #endif
-static K_THREAD_STACK_DEFINE(bt_stack, CONFIG_ESP32_BT_LE_CONTROLLER_TASK_STACK_SIZE);
 // wakeup timer
 static DRAM_ATTR esp_timer_handle_t s_btdm_slp_tmr = NULL;
 
@@ -561,7 +559,7 @@ static void esp_bt_controller_log_interface(uint32_t len, const uint8_t *addr, u
         esp_bt_controller_log_storage(len, addr, end);
 #endif //CONFIG_BT_CTRL_LE_LOG_STORAGE_EN
     } else {
-        unsigned int key = irq_lock();
+        unsigned int key = esp_os_irq_lock();
         esp_panic_handler_feed_wdts();
 
         if (len && addr) {
@@ -572,7 +570,7 @@ static void esp_bt_controller_log_interface(uint32_t len, const uint8_t *addr, u
         }
         if (end) { esp_rom_printf("\n"); }
 
-        irq_unlock(key);
+        esp_os_irq_unlock(key);
     }
 }
 
@@ -583,12 +581,12 @@ void esp_ble_controller_log_dump_all(bool output)
         esp_bt_read_ctrl_log_from_flash(output);
 #endif // CONFIG_BT_CTRL_LE_LOG_STORAGE_EN
     } else {
-        unsigned int key = irq_lock();
+        unsigned int key = esp_os_irq_lock();
         esp_panic_handler_feed_wdts();
         esp_rom_printf("\r\n[DUMP_START:");
         r_ble_log_async_output_dump_all(output);
         esp_rom_printf(":DUMP_END]\r\n");
-        irq_unlock(key);
+        esp_os_irq_unlock(key);
     }
 }
 #endif /* CONFIG_BT_CTRL_LE_LOG_MODE_BLE_LOG_V2 */
@@ -758,7 +756,7 @@ void esp_bt_read_ctrl_log_from_flash(bool output)
         return;
     }
 
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     esp_panic_handler_feed_wdts();
     r_ble_log_async_output_dump_all(true);
     esp_bt_controller_log_deinit();
@@ -786,7 +784,7 @@ void esp_bt_read_ctrl_log_from_flash(bool output)
     }
 
     esp_rom_printf(":DUMP_END]\r\n");
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
     esp_partition_munmap(mmap_handle);
     err = esp_bt_controller_log_init(log_output_mode);
     assert(err == ESP_OK);
@@ -903,22 +901,21 @@ static void IRAM_ATTR global_interrupt_restore(void)
 
 static void IRAM_ATTR task_yield_wrapper(void)
 {
-    k_yield();
+    esp_os_thread_yield();
 }
 
 static void IRAM_ATTR task_yield_from_isr(void)
 {
-    k_yield();
+    esp_os_thread_yield();
 }
 
 static void *semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    struct k_sem *sem = (struct k_sem *)esp_bt_malloc_func(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
     if (sem == NULL) {
         LOG_ERR("semaphore malloc failed");
         return NULL;
     }
-    k_sem_init(sem, init, max);
     return (void *)sem;
 }
 
@@ -927,7 +924,7 @@ static void semphr_delete_wrapper(void *semphr)
     if (semphr == NULL) {
         return;
     }
-    esp_bt_free(semphr);
+    esp_os_sem_delete(semphr);
 }
 
 static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
@@ -936,7 +933,7 @@ static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
     if (semphr == NULL) {
         return 0;
     }
-    int ret = k_sem_take((struct k_sem *)semphr, K_NO_WAIT);
+    int ret = esp_os_sem_take(semphr, ESP_OS_NO_WAIT);
     return (ret == 0) ? 1 : 0;
 }
 
@@ -946,7 +943,7 @@ static int IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr, void *hptw)
     if (semphr == NULL) {
         return 0;
     }
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
     return 1;
 }
 
@@ -955,12 +952,8 @@ static int semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
     if (semphr == NULL) {
         return 0;
     }
-    int ret;
-    if (block_time_ms == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_sem_take((struct k_sem *)semphr, K_FOREVER);
-    } else {
-        ret = k_sem_take((struct k_sem *)semphr, K_MSEC(block_time_ms));
-    }
+    uint32_t timeout = (block_time_ms == OSI_FUNCS_TIME_BLOCKING) ? ESP_OS_FOREVER : block_time_ms;
+    int ret = esp_os_sem_take(semphr, timeout);
     return (ret == 0) ? 1 : 0;
 }
 
@@ -969,18 +962,17 @@ static int semphr_give_wrapper(void *semphr)
     if (semphr == NULL) {
         return 0;
     }
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
     return 1;
 }
 
 static void *mutex_create_wrapper(void)
 {
-    struct k_mutex *mutex = (struct k_mutex *)esp_bt_malloc_func(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
     if (mutex == NULL) {
         LOG_ERR("mutex malloc failed");
         return NULL;
     }
-    k_mutex_init(mutex);
     return (void *)mutex;
 }
 
@@ -989,7 +981,7 @@ static void mutex_delete_wrapper(void *mutex)
     if (mutex == NULL) {
         return;
     }
-    esp_bt_free(mutex);
+    esp_os_mutex_delete(mutex);
 }
 
 static int mutex_lock_wrapper(void *mutex)
@@ -997,7 +989,7 @@ static int mutex_lock_wrapper(void *mutex)
     if (mutex == NULL) {
         return 0;
     }
-    int ret = k_mutex_lock((struct k_mutex *)mutex, K_FOREVER);
+    int ret = esp_os_mutex_lock(mutex, ESP_OS_FOREVER);
     return (ret == 0) ? 1 : 0;
 }
 
@@ -1006,7 +998,7 @@ static int mutex_unlock_wrapper(void *mutex)
     if (mutex == NULL) {
         return 0;
     }
-    int ret = k_mutex_unlock((struct k_mutex *)mutex);
+    int ret = esp_os_mutex_unlock(mutex);
     return (ret == 0) ? 1 : 0;
 }
 
@@ -1017,13 +1009,12 @@ static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
         LOG_ERR("queue malloc failed");
         return NULL;
     }
-    queue->pool = (uint8_t *)esp_bt_malloc_func(queue_len * item_size * sizeof(uint8_t));
-    if (queue->pool == NULL) {
+    queue->handle = esp_os_queue_create(queue_len, item_size);
+    if (queue->handle == NULL) {
         LOG_ERR("queue pool malloc failed");
         esp_bt_free(queue);
         return NULL;
     }
-    k_msgq_init(&queue->queue, queue->pool, item_size, queue_len);
     return (void *)queue;
 }
 
@@ -1033,8 +1024,8 @@ static void queue_delete_wrapper(void *queue)
         return;
     }
     struct bt_queue_t *q = (struct bt_queue_t *)queue;
-    if (q->pool) {
-        esp_bt_free(q->pool);
+    if (q->handle) {
+        esp_os_queue_delete(q->handle);
     }
     esp_bt_free(queue);
 }
@@ -1044,12 +1035,8 @@ static int queue_send_wrapper(void *queue, void *item, uint32_t block_time_ms)
     if (queue == NULL) {
         return 0;
     }
-    int ret;
-    if (block_time_ms == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_put(&((struct bt_queue_t *)queue)->queue, item, K_FOREVER);
-    } else {
-        ret = k_msgq_put(&((struct bt_queue_t *)queue)->queue, item, K_MSEC(block_time_ms));
-    }
+    uint32_t timeout = (block_time_ms == OSI_FUNCS_TIME_BLOCKING) ? ESP_OS_FOREVER : block_time_ms;
+    int ret = esp_os_queue_send(((struct bt_queue_t *)queue)->handle, item, timeout);
     return (ret == 0) ? 1 : 0;
 }
 
@@ -1059,7 +1046,7 @@ static int IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *
     if (queue == NULL) {
         return 0;
     }
-    int ret = k_msgq_put(&((struct bt_queue_t *)queue)->queue, item, K_NO_WAIT);
+    int ret = esp_os_queue_send(((struct bt_queue_t *)queue)->handle, item, ESP_OS_NO_WAIT);
     return (ret == 0) ? 1 : 0;
 }
 
@@ -1068,12 +1055,8 @@ static int queue_recv_wrapper(void *queue, void *item, uint32_t block_time_ms)
     if (queue == NULL) {
         return 0;
     }
-    int ret;
-    if (block_time_ms == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_get(&((struct bt_queue_t *)queue)->queue, item, K_FOREVER);
-    } else {
-        ret = k_msgq_get(&((struct bt_queue_t *)queue)->queue, item, K_MSEC(block_time_ms));
-    }
+    uint32_t timeout = (block_time_ms == OSI_FUNCS_TIME_BLOCKING) ? ESP_OS_FOREVER : block_time_ms;
+    int ret = esp_os_queue_recv(((struct bt_queue_t *)queue)->handle, item, timeout);
     return (ret == 0) ? 1 : 0;
 }
 
@@ -1083,7 +1066,7 @@ static int IRAM_ATTR queue_recv_from_isr_wrapper(void *queue, void *item, void *
     if (queue == NULL) {
         return 0;
     }
-    int ret = k_msgq_get(&((struct bt_queue_t *)queue)->queue, item, K_NO_WAIT);
+    int ret = esp_os_queue_recv(((struct bt_queue_t *)queue)->handle, item, ESP_OS_NO_WAIT);
     return (ret == 0) ? 1 : 0;
 }
 
@@ -1091,28 +1074,25 @@ static int task_create_wrapper(void *task_func, const char *name, uint32_t stack
 {
     ARG_UNUSED(stack_depth);
     ARG_UNUSED(core_id);
-    k_tid_t tid = k_thread_create(&bt_task_handle, bt_stack,
-                                  K_THREAD_STACK_SIZEOF(bt_stack),
-                                  (k_thread_entry_t)task_func,
-                                  param, NULL, NULL,
-                                  K_PRIO_COOP(prio), 0, K_NO_WAIT);
+    esp_os_thread_t tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+                                  CONFIG_ESP32_BT_LE_CONTROLLER_TASK_STACK_SIZE,
+                                  K_PRIO_COOP(prio), name);
     if (task_handle) {
-        *((k_tid_t *)task_handle) = tid;
+        *((esp_os_thread_t *)task_handle) = tid;
     }
-    k_thread_name_set(tid, name);
     return (tid != NULL) ? 1 : 0;
 }
 
 static void task_delete_wrapper(void *task_handle)
 {
     if (task_handle) {
-        k_thread_abort((k_tid_t)task_handle);
+        esp_os_thread_delete((esp_os_thread_t)task_handle);
     }
 }
 
 static bool IRAM_ATTR is_in_isr_wrapper(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 static void *malloc_internal_wrapper(size_t size)

--- a/components/bt/controller/esp32c5/bt.c
+++ b/components/bt/controller/esp32c5/bt.c
@@ -52,6 +52,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/irq.h>
+#include <esp_os.h>
 
 #include "hal/efuse_hal.h"
 #include "soc/rtc.h"
@@ -427,7 +428,7 @@ void esp_bt_read_ctrl_log_from_flash(bool output)
         return;
     }
 
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     esp_panic_handler_feed_wdts();
     r_ble_log_async_output_dump_all(true);
     esp_bt_controller_log_deinit();
@@ -455,7 +456,7 @@ void esp_bt_read_ctrl_log_from_flash(bool output)
     }
 
     esp_rom_printf(":DUMP_END]\r\n");
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
     esp_partition_munmap(mmap_handle);
     err = esp_bt_controller_log_init();
     assert(err == ESP_OK);
@@ -555,29 +556,24 @@ static void coex_schm_status_bit_clear_wrapper(uint32_t type, uint32_t status)
 #endif // CONFIG_SW_COEXIST_ENABLE
 }
 
-static K_KERNEL_STACK_DEFINE(bt_task_stack, CONFIG_ESP32_BT_LE_CONTROLLER_TASK_STACK_SIZE);
-static struct k_thread bt_task_thread;
 
 static int task_create_wrapper(void *task_func, const char *name, uint32_t stack_depth,
                                 void *param, uint32_t prio, void *task_handle, uint32_t core_id)
 {
-    k_tid_t tid;
+    esp_os_thread_t tid;
 
-    tid = k_thread_create(&bt_task_thread, bt_task_stack,
-                          K_KERNEL_STACK_SIZEOF(bt_task_stack),
-                          (k_thread_entry_t)task_func, param, NULL, NULL,
-                          K_PRIO_COOP(prio), 0, K_NO_WAIT);
+    tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+                               stack_depth, K_PRIO_COOP(prio), name);
     if (tid == NULL) {
         return 0;
     }
-    k_thread_name_set(tid, name);
-    *(k_tid_t *)task_handle = tid;
+    *(void **)task_handle = tid;
     return 1;
 }
 
 static void task_delete_wrapper(void *task_handle)
 {
-    k_thread_abort((k_tid_t)task_handle);
+    esp_os_thread_delete((esp_os_thread_t)task_handle);
 }
 
 static int esp_ecc_gen_key_pair(uint8_t *pub, uint8_t *priv)
@@ -1524,7 +1520,7 @@ static void esp_bt_controller_log_interface(uint32_t len, const uint8_t *addr, u
 #if CONFIG_BT_LE_CONTROLLER_LOG_STORAGE_ENABLE
     esp_bt_controller_log_storage(len, addr, end);
 #else // !CONFIG_BT_LE_CONTROLLER_LOG_STORAGE_ENABLE
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     esp_panic_handler_feed_wdts();
 
     if (len && addr) {
@@ -1535,7 +1531,7 @@ static void esp_bt_controller_log_interface(uint32_t len, const uint8_t *addr, u
     }
     if (end) { esp_rom_printf("\n"); }
 
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
 #endif // CONFIG_BT_LE_CONTROLLER_LOG_STORAGE_ENABLE
 }
 #endif // !CONFIG_BT_LE_CONTROLLER_LOG_SPI_OUT_ENABLED
@@ -1549,12 +1545,12 @@ void esp_ble_controller_log_dump_all(bool output)
 #if CONFIG_BT_LE_CONTROLLER_LOG_STORAGE_ENABLE
     esp_bt_read_ctrl_log_from_flash(output);
 #elif !CONFIG_BT_LE_CONTROLLER_LOG_SPI_OUT_ENABLED
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     esp_panic_handler_feed_wdts();
     BT_ASSERT_PRINT("\r\n[DUMP_START:");
     r_ble_log_async_output_dump_all(output);
     BT_ASSERT_PRINT(":DUMP_END]\r\n");
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
 #endif
 }
 #endif /* CONFIG_BT_LE_CONTROLLER_LOG_MODE_BLE_LOG_V2 */

--- a/components/bt/controller/esp32c6/bt.c
+++ b/components/bt/controller/esp32c6/bt.c
@@ -52,6 +52,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/irq.h>
+#include <esp_os.h>
 
 #include "hal/efuse_hal.h"
 #include "soc/rtc.h"
@@ -438,7 +439,7 @@ void esp_bt_read_ctrl_log_from_flash(bool output)
         return;
     }
 
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     esp_panic_handler_feed_wdts();
     r_ble_log_async_output_dump_all(true);
     esp_bt_controller_log_deinit();
@@ -466,7 +467,7 @@ void esp_bt_read_ctrl_log_from_flash(bool output)
     }
 
     esp_rom_printf(":DUMP_END]\r\n");
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
     esp_partition_munmap(mmap_handle);
     err = esp_bt_controller_log_init(log_output_mode);
     assert(err == ESP_OK);
@@ -592,29 +593,24 @@ static void coex_schm_status_bit_clear_wrapper(uint32_t type, uint32_t status)
 #endif // CONFIG_SW_COEXIST_ENABLE
 }
 
-static K_KERNEL_STACK_DEFINE(bt_task_stack, CONFIG_ESP32_BT_LE_CONTROLLER_TASK_STACK_SIZE);
-static struct k_thread bt_task_thread;
 
 static int task_create_wrapper(void *task_func, const char *name, uint32_t stack_depth,
                                 void *param, uint32_t prio, void *task_handle, uint32_t core_id)
 {
-    k_tid_t tid;
+    esp_os_thread_t tid;
 
-    tid = k_thread_create(&bt_task_thread, bt_task_stack,
-                          K_KERNEL_STACK_SIZEOF(bt_task_stack),
-                          (k_thread_entry_t)task_func, param, NULL, NULL,
-                          K_PRIO_COOP(prio), 0, K_NO_WAIT);
+    tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+                               stack_depth, K_PRIO_COOP(prio), name);
     if (tid == NULL) {
         return 0;
     }
-    k_thread_name_set(tid, name);
-    *(k_tid_t *)task_handle = tid;
+    *(void **)task_handle = tid;
     return 1;
 }
 
 static void task_delete_wrapper(void *task_handle)
 {
-    k_thread_abort((k_tid_t)task_handle);
+    esp_os_thread_delete((esp_os_thread_t)task_handle);
 }
 
 static int esp_ecc_gen_key_pair(uint8_t *pub, uint8_t *priv)
@@ -1601,7 +1597,7 @@ static void esp_bt_controller_log_interface(uint32_t len, const uint8_t *addr, u
 #if CONFIG_BT_LE_CONTROLLER_LOG_STORAGE_ENABLE
     esp_bt_controller_log_storage(len, addr, end);
 #else // !CONFIG_BT_LE_CONTROLLER_LOG_STORAGE_ENABLE
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     esp_panic_handler_feed_wdts();
 
     if (len && addr) {
@@ -1612,7 +1608,7 @@ static void esp_bt_controller_log_interface(uint32_t len, const uint8_t *addr, u
     }
     if (end) { esp_rom_printf("\n"); }
 
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
 #endif // CONFIG_BT_LE_CONTROLLER_LOG_STORAGE_ENABLE
 }
 #endif // !CONFIG_BT_LE_CONTROLLER_LOG_SPI_OUT_ENABLED
@@ -1626,12 +1622,12 @@ void esp_ble_controller_log_dump_all(bool output)
 #if CONFIG_BT_LE_CONTROLLER_LOG_STORAGE_ENABLE
     esp_bt_read_ctrl_log_from_flash(output);
 #elif !CONFIG_BT_LE_CONTROLLER_LOG_SPI_OUT_ENABLED
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     esp_panic_handler_feed_wdts();
     BT_ASSERT_PRINT("\r\n[DUMP_START:");
     r_ble_log_async_output_dump_all(output);
     BT_ASSERT_PRINT(":DUMP_END]\r\n");
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
 #endif
 }
 #endif /* CONFIG_BT_LE_CONTROLLER_LOG_MODE_BLE_LOG_V2 */

--- a/components/bt/controller/esp32h2/bt.c
+++ b/components/bt/controller/esp32h2/bt.c
@@ -49,6 +49,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/irq.h>
+#include <esp_os.h>
 
 #include "esp_private/esp_clk_tree_common.h"
 #include "soc/rtc.h"
@@ -437,7 +438,7 @@ void esp_bt_read_ctrl_log_from_flash(bool output)
         return;
     }
 
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     esp_panic_handler_feed_wdts();
     r_ble_log_async_output_dump_all(true);
     esp_bt_controller_log_deinit();
@@ -465,7 +466,7 @@ void esp_bt_read_ctrl_log_from_flash(bool output)
     }
 
     esp_rom_printf(":DUMP_END]\r\n");
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
     esp_partition_munmap(mmap_handle);
     err = esp_bt_controller_log_init();
     assert(err == ESP_OK);
@@ -607,29 +608,24 @@ static void coex_schm_status_bit_clear_wrapper(uint32_t type, uint32_t status)
 #endif // CONFIG_ESP32_SW_COEXIST_ENABLE
 }
 
-static K_KERNEL_STACK_DEFINE(bt_task_stack, CONFIG_ESP32_BT_LE_CONTROLLER_TASK_STACK_SIZE);
-static struct k_thread bt_task_thread;
 
 static int task_create_wrapper(void *task_func, const char *name, uint32_t stack_depth,
                                 void *param, uint32_t prio, void *task_handle, uint32_t core_id)
 {
-    k_tid_t tid;
+    esp_os_thread_t tid;
 
-    tid = k_thread_create(&bt_task_thread, bt_task_stack,
-                          K_KERNEL_STACK_SIZEOF(bt_task_stack),
-                          (k_thread_entry_t)task_func, param, NULL, NULL,
-                          K_PRIO_COOP(prio), 0, K_NO_WAIT);
+    tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+                               stack_depth, K_PRIO_COOP(prio), name);
     if (tid == NULL) {
         return 0;
     }
-    k_thread_name_set(tid, name);
-    *(k_tid_t *)task_handle = tid;
+    *(void **)task_handle = tid;
     return 1;
 }
 
 static void task_delete_wrapper(void *task_handle)
 {
-    k_thread_abort((k_tid_t)task_handle);
+    esp_os_thread_delete((esp_os_thread_t)task_handle);
 }
 
 static int esp_ecc_gen_key_pair(uint8_t *pub, uint8_t *priv)
@@ -1582,7 +1578,7 @@ static void esp_bt_controller_log_interface(uint32_t len, const uint8_t *addr, u
 #if CONFIG_BT_LE_CONTROLLER_LOG_STORAGE_ENABLE
     esp_bt_controller_log_storage(len, addr, end);
 #else // !CONFIG_BT_LE_CONTROLLER_LOG_STORAGE_ENABLE
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     esp_panic_handler_feed_wdts();
 
     if (len && addr) {
@@ -1593,7 +1589,7 @@ static void esp_bt_controller_log_interface(uint32_t len, const uint8_t *addr, u
     }
     if (end) { esp_rom_printf("\n"); }
 
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
 #endif // CONFIG_BT_LE_CONTROLLER_LOG_STORAGE_ENABLE
 }
 #endif // !CONFIG_BT_LE_CONTROLLER_LOG_SPI_OUT_ENABLED
@@ -1607,12 +1603,12 @@ void esp_ble_controller_log_dump_all(bool output)
 #if CONFIG_BT_LE_CONTROLLER_LOG_STORAGE_ENABLE
     esp_bt_read_ctrl_log_from_flash(output);
 #elif !CONFIG_BT_LE_CONTROLLER_LOG_SPI_OUT_ENABLED
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     esp_panic_handler_feed_wdts();
     BT_ASSERT_PRINT("\r\n[DUMP_START:");
     r_ble_log_async_output_dump_all(output);
     BT_ASSERT_PRINT(":DUMP_END]\r\n");
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
 #endif
 }
 #endif /* CONFIG_BT_LE_CONTROLLER_LOG_MODE_BLE_LOG_V2 */

--- a/components/bt/porting/npl/zephyr/include/nimble/npl_zephyr.h
+++ b/components/bt/porting/npl/zephyr/include/nimble/npl_zephyr.h
@@ -12,8 +12,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include <zephyr/kernel.h>
 #include <esp_timer.h>
+#include <esp_os.h>
 #include "sdkconfig.h"
 
 #define BLE_NPL_USE_ESP_TIMER (1)
@@ -29,7 +29,7 @@ typedef struct {
 typedef void ble_npl_event_fn(struct ble_npl_event *ev);
 
 struct ble_npl_event_zephyr {
-    void *_node;  /* Reserved for k_fifo linking - must be first */
+    void *_node;  /* Reserved for FIFO linking - must be first */
     struct ble_npl_event *parent;  /* Back-pointer to parent ble_npl_event */
     bool queued;
     ble_npl_event_fn *fn;
@@ -37,7 +37,7 @@ struct ble_npl_event_zephyr {
 };
 
 struct ble_npl_eventq_zephyr {
-    struct k_fifo q;
+    esp_os_fifo_t q;
 };
 
 struct ble_npl_callout_zephyr {
@@ -47,11 +47,11 @@ struct ble_npl_callout_zephyr {
 };
 
 struct ble_npl_mutex_zephyr {
-    struct k_mutex handle;
+    esp_os_mutex_t handle;
 };
 
 struct ble_npl_sem_zephyr {
-    struct k_sem handle;
+    esp_os_sem_t handle;
 };
 
 typedef void ble_npl_event_fn_zephyr(struct ble_npl_event_zephyr *ev);

--- a/components/bt/porting/npl/zephyr/src/npl_os_zephyr.c
+++ b/components/bt/porting/npl/zephyr/src/npl_os_zephyr.c
@@ -9,7 +9,7 @@
 #include <string.h>
 
 #include "nimble/nimble_npl.h"
-#include <zephyr/kernel.h>
+#include <esp_os.h>
 #include "nimble/npl_zephyr.h"
 
 /* Zephyr: soc_caps.h must be included before os_mempool.h to define SOC_ESP_NIMBLE_CONTROLLER */
@@ -56,12 +56,12 @@ static ble_npl_count_info_t g_ctrl_npl_info = {
 
 bool IRAM_ATTR npl_zephyr_os_started(void)
 {
-    return (k_is_pre_kernel() == false);
+    return (esp_os_is_pre_kernel() == false);
 }
 
 void *IRAM_ATTR npl_zephyr_get_current_task_id(void)
 {
-    return k_current_get();
+    return esp_os_thread_current();
 }
 
 void IRAM_ATTR npl_zephyr_event_init(struct ble_npl_event *ev, ble_npl_event_fn *fn, void *arg)
@@ -101,11 +101,11 @@ void npl_zephyr_eventq_init(struct ble_npl_eventq *evq)
         eventq = (struct ble_npl_eventq_zephyr *)evq->eventq;
         BLE_LL_ASSERT(eventq);
         memset(eventq, 0, sizeof(*eventq));
-        k_fifo_init(&eventq->q);
+        eventq->q = esp_os_fifo_create();
     } else {
         eventq = (struct ble_npl_eventq_zephyr *)evq->eventq;
         /* Drain any remaining events */
-        while (k_fifo_get(&eventq->q, K_NO_WAIT) != NULL) {
+        while (esp_os_fifo_get(eventq->q, ESP_OS_NO_WAIT) != NULL) {
             ;
         }
     }
@@ -118,6 +118,7 @@ void npl_zephyr_eventq_deinit(struct ble_npl_eventq *evq)
     if (!eventq) {
         return;
     }
+    esp_os_fifo_delete(eventq->q);
     bt_osi_mem_free(eventq);
     evq->eventq = NULL;
 }
@@ -134,7 +135,7 @@ void IRAM_ATTR npl_zephyr_callout_mem_reset(struct ble_npl_callout *co)
 
 static inline bool IRAM_ATTR in_isr(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 struct ble_npl_event *IRAM_ATTR npl_zephyr_eventq_get(struct ble_npl_eventq *evq,
@@ -146,9 +147,9 @@ struct ble_npl_event *IRAM_ATTR npl_zephyr_eventq_get(struct ble_npl_eventq *evq
 
     if (in_isr()) {
         BLE_LL_ASSERT(tmo == 0);
-        event = k_fifo_get(&eventq->q, K_NO_WAIT);
+        event = esp_os_fifo_get(eventq->q, ESP_OS_NO_WAIT);
     } else {
-        event = k_fifo_get(&eventq->q, K_MSEC(tmo));
+        event = esp_os_fifo_get(eventq->q, tmo);
     }
 
     if (event) {
@@ -169,7 +170,7 @@ void IRAM_ATTR npl_zephyr_eventq_put(struct ble_npl_eventq *evq, struct ble_npl_
     }
 
     event->queued = true;
-    k_fifo_put(&eventq->q, event);
+    esp_os_fifo_put(eventq->q, event);
 }
 
 void IRAM_ATTR npl_zephyr_eventq_put_to_front(struct ble_npl_eventq *evq, struct ble_npl_event *ev)
@@ -182,7 +183,7 @@ void IRAM_ATTR npl_zephyr_eventq_put_to_front(struct ble_npl_eventq *evq, struct
     }
 
     event->queued = true;
-    k_queue_prepend(&eventq->q._queue, event);
+    esp_os_fifo_put_to_front(eventq->q, event);
 }
 
 void IRAM_ATTR npl_zephyr_eventq_remove(struct ble_npl_eventq *evq, struct ble_npl_event *ev)
@@ -194,7 +195,7 @@ void IRAM_ATTR npl_zephyr_eventq_remove(struct ble_npl_eventq *evq, struct ble_n
         return;
     }
 
-    if (k_queue_remove(&eventq->q._queue, event)) {
+    if (esp_os_fifo_remove(eventq->q, event)) {
         event->queued = false;
     }
 }
@@ -207,7 +208,7 @@ ble_npl_error_t npl_zephyr_mutex_init(struct ble_npl_mutex *mu)
         mu->mutex = bt_osi_mem_malloc_internal(sizeof(struct ble_npl_mutex_zephyr));
         mutex = mu->mutex;
         BLE_LL_ASSERT(mutex);
-        k_mutex_init(&mutex->handle);
+        mutex->handle = esp_os_mutex_create();
     }
 
     return BLE_NPL_OK;
@@ -221,6 +222,7 @@ ble_npl_error_t npl_zephyr_mutex_deinit(struct ble_npl_mutex *mu)
         return BLE_NPL_INVALID_PARAM;
     }
 
+    esp_os_mutex_delete(mutex->handle);
     bt_osi_mem_free((void *)mutex);
     mu->mutex = NULL;
 
@@ -236,7 +238,7 @@ void IRAM_ATTR npl_zephyr_event_run(struct ble_npl_event *ev)
 bool IRAM_ATTR npl_zephyr_eventq_is_empty(struct ble_npl_eventq *evq)
 {
     struct ble_npl_eventq_zephyr *eventq = (struct ble_npl_eventq_zephyr *)evq->eventq;
-    return k_fifo_is_empty(&eventq->q);
+    return esp_os_fifo_is_empty(eventq->q);
 }
 
 bool IRAM_ATTR npl_zephyr_event_is_queued(struct ble_npl_event *ev)
@@ -270,7 +272,7 @@ ble_npl_error_t IRAM_ATTR npl_zephyr_mutex_pend(struct ble_npl_mutex *mu, ble_np
         BLE_LL_ASSERT(0);
     }
 
-    rc = k_mutex_lock(&mutex->handle, K_MSEC(timeout));
+    rc = esp_os_mutex_lock(mutex->handle, timeout);
 
     return rc == 0 ? BLE_NPL_OK : BLE_NPL_TIMEOUT;
 }
@@ -287,7 +289,7 @@ ble_npl_error_t IRAM_ATTR npl_zephyr_mutex_release(struct ble_npl_mutex *mu)
         BLE_LL_ASSERT(0);
     }
 
-    k_mutex_unlock(&mutex->handle);
+    esp_os_mutex_unlock(mutex->handle);
 
     return BLE_NPL_OK;
 }
@@ -300,7 +302,7 @@ ble_npl_error_t npl_zephyr_sem_init(struct ble_npl_sem *sem, uint16_t tokens)
         sem->sem = bt_osi_mem_malloc_internal(sizeof(struct ble_npl_sem_zephyr));
         semaphore = sem->sem;
         BLE_LL_ASSERT(semaphore);
-        k_sem_init(&semaphore->handle, tokens, 128);
+        semaphore->handle = esp_os_sem_create(tokens, 128);
     }
 
     return BLE_NPL_OK;
@@ -314,6 +316,7 @@ ble_npl_error_t npl_zephyr_sem_deinit(struct ble_npl_sem *sem)
         return BLE_NPL_INVALID_PARAM;
     }
 
+    esp_os_sem_delete(semaphore->handle);
     bt_osi_mem_free((void *)semaphore);
 
     sem->sem = NULL;
@@ -332,9 +335,9 @@ ble_npl_error_t IRAM_ATTR npl_zephyr_sem_pend(struct ble_npl_sem *sem, ble_npl_t
 
     if (in_isr()) {
         BLE_LL_ASSERT(timeout == 0);
-        rc = k_sem_take(&semaphore->handle, K_NO_WAIT);
+        rc = esp_os_sem_take(semaphore->handle, ESP_OS_NO_WAIT);
     } else {
-        rc = k_sem_take(&semaphore->handle, K_MSEC(timeout));
+        rc = esp_os_sem_take(semaphore->handle, timeout);
     }
 
     return rc == 0 ? BLE_NPL_OK : BLE_NPL_TIMEOUT;
@@ -348,7 +351,7 @@ ble_npl_error_t IRAM_ATTR npl_zephyr_sem_release(struct ble_npl_sem *sem)
         return BLE_NPL_INVALID_PARAM;
     }
 
-    k_sem_give(&semaphore->handle);
+    esp_os_sem_give(semaphore->handle);
 
     return BLE_NPL_OK;
 }
@@ -456,7 +459,7 @@ void npl_zephyr_callout_deinit(struct ble_npl_callout *co)
 uint16_t IRAM_ATTR npl_zephyr_sem_get_count(struct ble_npl_sem *sem)
 {
     struct ble_npl_sem_zephyr *semaphore = sem->sem;
-    return k_sem_count_get(&semaphore->handle);
+    return esp_os_sem_count(semaphore->handle);
 }
 
 ble_npl_error_t IRAM_ATTR npl_zephyr_callout_reset(struct ble_npl_callout *co, ble_npl_time_t ticks)
@@ -582,7 +585,7 @@ uint32_t IRAM_ATTR npl_zephyr_time_ticks_to_ms32(ble_npl_time_t ticks)
 
 void IRAM_ATTR npl_zephyr_time_delay(ble_npl_time_t ticks)
 {
-    k_sleep(K_TICKS(ticks));
+    esp_os_sleep_ticks(ticks);
 }
 
 uint32_t IRAM_ATTR npl_zephyr_hw_enter_critical(void)

--- a/components/bt/porting/transport/driver/vhci/hci_driver_standard.c
+++ b/components/bt/porting/transport/driver/vhci/hci_driver_standard.c
@@ -13,6 +13,7 @@
 #include "esp_hci_driver.h"
 #include "esp_bt.h"
 #include <zephyr/kernel.h>
+#include <esp_os.h>
 
 typedef struct {
     hci_driver_forward_fn *forward_cb;
@@ -40,7 +41,7 @@ hci_driver_vhci_controller_tx(hci_driver_data_type_t data_type, uint8_t *data, u
     if (data_type == HCI_DRIVER_TYPE_ACL) {
         om = (struct os_mbuf *)data;
         buf_len = length + 1;
-        buf = k_malloc(buf_len);
+        buf = esp_os_malloc(buf_len);
         /* TODO: If there is no memory, should handle it in the controller. */
         assert(buf);
         buf[0] = HCI_DRIVER_TYPE_ACL;
@@ -48,7 +49,7 @@ hci_driver_vhci_controller_tx(hci_driver_data_type_t data_type, uint8_t *data, u
         os_mbuf_free_chain(om);
     } else if (data_type == HCI_DRIVER_TYPE_EVT) {
         buf_len = length + 1;
-        buf = k_malloc(buf_len);
+        buf = esp_os_malloc(buf_len);
         /* TODO: If there is no memory, should handle it in the controller. */
         assert(buf != NULL);
         buf[0] = HCI_DRIVER_TYPE_EVT;
@@ -56,16 +57,16 @@ hci_driver_vhci_controller_tx(hci_driver_data_type_t data_type, uint8_t *data, u
         r_ble_hci_trans_buf_free(data);
     } else if (data_type == HCI_DRIVER_TYPE_ISO) {
         buf_len = length + 1;
-        buf = k_malloc(buf_len);
+        buf = esp_os_malloc(buf_len);
         /* TODO: If there is no memory, should handle it in the controller. */
         assert(buf);
         buf[0] = HCI_DRIVER_TYPE_ISO;
         memcpy(&buf[1], data, length);
-        k_free(data);
+        esp_os_free(data);
     }
 
     rc = s_hci_driver_vhci_env.forward_cb(data_type, buf, buf_len, HCI_DRIVER_DIR_C2H);
-    k_free(buf);
+    esp_os_free(buf);
 
     return rc;
 }

--- a/components/efuse/src/esp_efuse_api.c
+++ b/components/efuse/src/esp_efuse_api.c
@@ -5,6 +5,7 @@
  */
 
 #include "esp_efuse.h"
+#include <esp_os.h>
 #include "esp_efuse_utility.h"
 #include "soc/efuse_periph.h"
 #include "assert.h"
@@ -20,9 +21,9 @@ ESP_LOG_ATTR_TAG(TAG, "efuse");
 #else
 #include <string.h>
 #include <zephyr/kernel.h>
-K_MUTEX_DEFINE(s_efuse_lock);
-#define EFUSE_LOCK_ACQUIRE_RECURSIVE() k_mutex_lock(&s_efuse_lock, K_FOREVER)
-#define EFUSE_LOCK_RELEASE_RECURSIVE() k_mutex_unlock(&s_efuse_lock)
+ESP_OS_MUTEX_DEFINE(s_efuse_lock);
+#define EFUSE_LOCK_ACQUIRE_RECURSIVE() esp_os_mutex_lock(s_efuse_lock, ESP_OS_FOREVER)
+#define EFUSE_LOCK_RELEASE_RECURSIVE() esp_os_mutex_unlock(s_efuse_lock)
 #endif
 
 static int s_batch_writing_mode = 0;

--- a/components/esp_coex/esp32/esp_coex_adapter.c
+++ b/components/esp_coex/esp32/esp_coex_adapter.c
@@ -14,6 +14,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 LOG_MODULE_REGISTER(esp32_coex_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include "esp_attr.h"
@@ -30,19 +31,9 @@ static void esp_wifi_free(void *mem)
     esp_wifi_free_func(mem);
 }
 
-static void wifi_free(void *mem)
-{
-    esp_wifi_free_func(mem);
-}
-
 static void *wifi_malloc(size_t size)
 {
     return esp_wifi_malloc_func(size);
-}
-
-static void *wifi_calloc(size_t nmemb, size_t size)
-{
-    return esp_wifi_calloc_func(nmemb, size);
 }
 
 #define TAG "esp_coex_adapter"
@@ -50,9 +41,18 @@ static void *wifi_calloc(size_t nmemb, size_t size)
 #define OSI_FUNCS_TIME_BLOCKING  0xffffffff
 
 typedef struct {
-    void *handle;   /* k_sem pointer */
+    void *handle;   /* semaphore handle */
     void *storage;  /* unused in Zephyr */
 } modem_static_queue_t;
+
+static uint32_t coex_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
+    }
+
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
+}
 
 bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
 {
@@ -79,7 +79,7 @@ uint32_t IRAM_ATTR esp_coex_common_int_disable_wrapper(void *wifi_int_mux)
 {
     unsigned int *int_mux = (unsigned int *)wifi_int_mux;
 
-    *int_mux = irq_lock();
+    *int_mux = esp_os_irq_lock();
     return 0;
 }
 
@@ -87,52 +87,39 @@ void IRAM_ATTR esp_coex_common_int_restore_wrapper(void *wifi_int_mux, uint32_t 
 {
     unsigned int *key = (unsigned int *)wifi_int_mux;
 
-    irq_unlock(*key);
+    esp_os_irq_unlock(*key);
 }
 
 void IRAM_ATTR esp_coex_common_task_yield_from_isr_wrapper(void)
 {
-    k_yield();
+    esp_os_thread_yield();
 }
 
 void *esp_coex_common_semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    struct k_sem *sem = (struct k_sem *)wifi_malloc(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
 
     if (sem == NULL) {
         LOG_ERR("semphr_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_sem_init(sem, init, max);
-
     return (void *)sem;
 }
 
 void esp_coex_common_semphr_delete_wrapper(void *semphr)
 {
-    esp_wifi_free(semphr);
+    esp_os_sem_delete(semphr);
 }
 
 int32_t esp_coex_common_semphr_take_wrapper(void *semphr, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        int ret = k_sem_take((struct k_sem *)semphr, K_FOREVER);
-        if (ret == 0) {
-            return 1;
-        }
-    } else {
-        int ret = k_sem_take((struct k_sem *)semphr, K_TICKS(block_time_tick));
-        if (ret == 0) {
-            return 1;
-        }
-    }
-    return 0;
+    return esp_os_sem_take(semphr, coex_block_time_ms(block_time_tick)) == 0 ? 1 : 0;
 }
 
 int32_t esp_coex_common_semphr_give_wrapper(void *semphr)
 {
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
     return 1;
 }
 
@@ -158,30 +145,29 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-    return k_malloc(size);
+    return esp_os_malloc(size);
 }
 
 /* static wrapper */
 
 static int IRAM_ATTR esp_coex_is_in_isr_wrapper(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 static void *esp_coex_internal_semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    modem_static_queue_t *semphr = wifi_calloc(1, sizeof(modem_static_queue_t));
+    modem_static_queue_t *semphr = esp_os_calloc(1, sizeof(modem_static_queue_t));
     if (!semphr) {
         return NULL;
     }
 
-    struct k_sem *sem = wifi_malloc(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
     if (!sem) {
-        wifi_free(semphr);
+        esp_os_free(semphr);
         return NULL;
     }
 
-    k_sem_init(sem, init, max);
     semphr->handle = sem;
 
     return (void *)semphr;
@@ -192,35 +178,28 @@ static void esp_coex_internal_semphr_delete_wrapper(void *semphr)
     modem_static_queue_t *semphr_item = (modem_static_queue_t *)semphr;
     if (semphr_item) {
         if (semphr_item->handle) {
-            wifi_free(semphr_item->handle);
+            esp_os_sem_delete(semphr_item->handle);
         }
-        wifi_free(semphr_item);
+        esp_os_free(semphr_item);
     }
 }
 
 static int32_t IRAM_ATTR esp_coex_internal_semphr_take_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
-    int ret = k_sem_take((struct k_sem *)((modem_static_queue_t *)semphr)->handle, K_NO_WAIT);
-
-    if (ret == 0) {
-        if (hpt) {
-            *hpt = 0;
-        }
-        return 1;
-    }
+    int ret = esp_os_sem_take(((modem_static_queue_t *)semphr)->handle, ESP_OS_NO_WAIT);
 
     if (hpt) {
         *hpt = 0;
     }
-    return 0;
+    return ret == 0 ? 1 : 0;
 }
 
 static int32_t IRAM_ATTR esp_coex_internal_semphr_give_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
 
-    k_sem_give((struct k_sem *)((modem_static_queue_t *)semphr)->handle);
+    esp_os_sem_give(((modem_static_queue_t *)semphr)->handle);
 
     if (hpt) {
         *hpt = 0;
@@ -230,23 +209,13 @@ static int32_t IRAM_ATTR esp_coex_internal_semphr_give_from_isr_wrapper(void *se
 
 static int32_t esp_coex_internal_semphr_take_wrapper(void *semphr, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        int ret = k_sem_take((struct k_sem *)((modem_static_queue_t *)semphr)->handle, K_FOREVER);
-        if (ret == 0) {
-            return 1;
-        }
-    } else {
-        int ret = k_sem_take((struct k_sem *)((modem_static_queue_t *)semphr)->handle, K_TICKS(block_time_tick));
-        if (ret == 0) {
-            return 1;
-        }
-    }
-    return 0;
+    return esp_os_sem_take(((modem_static_queue_t *)semphr)->handle,
+                           coex_block_time_ms(block_time_tick)) == 0 ? 1 : 0;
 }
 
 static int32_t esp_coex_internal_semphr_give_wrapper(void *semphr)
 {
-    k_sem_give((struct k_sem *)((modem_static_queue_t *)semphr)->handle);
+    esp_os_sem_give(((modem_static_queue_t *)semphr)->handle);
     return 1;
 }
 

--- a/components/esp_coex/esp32c2/esp_coex_adapter.c
+++ b/components/esp_coex/esp32c2/esp_coex_adapter.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 LOG_MODULE_REGISTER(esp32c2_coex_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include "esp_attr.h"
@@ -29,6 +30,15 @@ LOG_MODULE_REGISTER(esp32c2_coex_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #define OSI_FUNCS_TIME_BLOCKING  0xffffffff
 
+static uint32_t coex_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
+    }
+
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
+}
+
 bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
 {
 #ifdef CONFIG_IDF_ENV_FPGA
@@ -40,7 +50,7 @@ bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
 
 void *esp_coex_common_spin_lock_create_wrapper(void)
 {
-    unsigned int *wifi_spin_lock = (unsigned int *)k_malloc(sizeof(unsigned int));
+    unsigned int *wifi_spin_lock = (unsigned int *)esp_os_malloc(sizeof(unsigned int));
     if (wifi_spin_lock == NULL) {
         LOG_ERR("spin_lock_create_wrapper allocation failed");
         return NULL;
@@ -54,7 +64,7 @@ uint32_t IRAM_ATTR esp_coex_common_int_disable_wrapper(void *wifi_int_mux)
 {
     unsigned int *int_mux = (unsigned int *)wifi_int_mux;
 
-    *int_mux = irq_lock();
+    *int_mux = esp_os_irq_lock();
     return 0;
 }
 
@@ -62,53 +72,39 @@ void IRAM_ATTR esp_coex_common_int_restore_wrapper(void *wifi_int_mux, uint32_t 
 {
     unsigned int *key = (unsigned int *)wifi_int_mux;
 
-    irq_unlock(*key);
+    esp_os_irq_unlock(*key);
 }
 
 void IRAM_ATTR esp_coex_common_task_yield_from_isr_wrapper(void)
 {
-    k_yield();
+    esp_os_thread_yield();
 }
 
 void *esp_coex_common_semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    struct k_sem *sem = (struct k_sem *)k_malloc(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
 
     if (sem == NULL) {
         LOG_ERR("semphr_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_sem_init(sem, init, max);
-
     return (void *)sem;
 }
 
 void esp_coex_common_semphr_delete_wrapper(void *semphr)
 {
-    k_free(semphr);
+    esp_os_sem_delete(semphr);
 }
 
 int32_t esp_coex_common_semphr_take_wrapper(void *semphr, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        int ret = k_sem_take((struct k_sem *)semphr, K_FOREVER);
-        if (ret == 0) {
-            return 1;
-        }
-    } else {
-        int ret = k_sem_take((struct k_sem *)semphr, K_TICKS(block_time_tick));
-
-        if (ret == 0) {
-            return 1;
-        }
-    }
-    return 0;
+    return esp_os_sem_take(semphr, coex_block_time_ms(block_time_tick)) == 0 ? 1 : 0;
 }
 
 int32_t esp_coex_common_semphr_give_wrapper(void *semphr)
 {
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
     return 1;
 }
 
@@ -134,7 +130,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-    return k_malloc(size);
+    return esp_os_malloc(size);
 }
 
 uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
@@ -150,26 +146,19 @@ uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
 static int32_t IRAM_ATTR esp_coex_semphr_take_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
-    int ret = k_sem_take((struct k_sem *)semphr, K_NO_WAIT);
-
-    if (ret == 0) {
-        if (hpt) {
-            *hpt = 0;
-        }
-        return 1;
-    }
+    int ret = esp_os_sem_take(semphr, ESP_OS_NO_WAIT);
 
     if (hpt) {
         *hpt = 0;
     }
-    return 0;
+    return ret == 0 ? 1 : 0;
 }
 
 static int32_t IRAM_ATTR esp_coex_semphr_give_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
 
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
 
     if (hpt) {
         *hpt = 0;
@@ -193,7 +182,7 @@ static IRAM_ATTR int esp_coex_common_xtal_freq_get_wrapper(void)
 
 int32_t IRAM_ATTR coex_is_in_isr_wrapper(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 coex_adapter_funcs_t g_coex_adapter_funcs = {
@@ -207,7 +196,7 @@ coex_adapter_funcs_t g_coex_adapter_funcs = {
     ._semphr_give = esp_coex_common_semphr_give_wrapper,
     ._is_in_isr = coex_is_in_isr_wrapper,
     ._malloc_internal = esp_coex_common_malloc_internal_wrapper,
-    ._free = k_free,
+    ._free = esp_os_free,
     ._esp_timer_get_time = esp_timer_get_time,
     ._env_is_chip = esp_coex_common_env_is_chip_wrapper,
     ._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,

--- a/components/esp_coex/esp32c3/esp_coex_adapter.c
+++ b/components/esp_coex/esp32c3/esp_coex_adapter.c
@@ -13,6 +13,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 LOG_MODULE_REGISTER(esp32c3_coex_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include "esp_attr.h"
@@ -33,6 +34,15 @@ LOG_MODULE_REGISTER(esp32c3_coex_adapter, CONFIG_WIFI_LOG_LEVEL);
 static void esp_wifi_free(void *mem)
 {
     esp_wifi_free_func(mem);
+}
+
+static uint32_t coex_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
+    }
+
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
 }
 
 bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
@@ -60,7 +70,7 @@ uint32_t IRAM_ATTR esp_coex_common_int_disable_wrapper(void *wifi_int_mux)
 {
     unsigned int *int_mux = (unsigned int *)wifi_int_mux;
 
-    *int_mux = irq_lock();
+    *int_mux = esp_os_irq_lock();
     return 0;
 }
 
@@ -68,53 +78,39 @@ void IRAM_ATTR esp_coex_common_int_restore_wrapper(void *wifi_int_mux, uint32_t 
 {
     unsigned int *key = (unsigned int *)wifi_int_mux;
 
-    irq_unlock(*key);
+    esp_os_irq_unlock(*key);
 }
 
 void IRAM_ATTR esp_coex_common_task_yield_from_isr_wrapper(void)
 {
-    k_yield();
+    esp_os_thread_yield();
 }
 
 void *esp_coex_common_semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    struct k_sem *sem = (struct k_sem *)esp_wifi_malloc_func(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
 
     if (sem == NULL) {
         LOG_ERR("semphr_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_sem_init(sem, init, max);
-
     return (void *)sem;
 }
 
 void esp_coex_common_semphr_delete_wrapper(void *semphr)
 {
-    esp_wifi_free_func(semphr);
+    esp_os_sem_delete(semphr);
 }
 
 int32_t esp_coex_common_semphr_take_wrapper(void *semphr, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        int ret = k_sem_take((struct k_sem *)semphr, K_FOREVER);
-        if (ret == 0) {
-            return 1;
-        }
-    } else {
-        int ret = k_sem_take((struct k_sem *)semphr, K_TICKS(block_time_tick));
-
-        if (ret == 0) {
-            return 1;
-        }
-    }
-    return 0;
+    return esp_os_sem_take(semphr, coex_block_time_ms(block_time_tick)) == 0 ? 1 : 0;
 }
 
 int32_t esp_coex_common_semphr_give_wrapper(void *semphr)
 {
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
     return 1;
 }
 
@@ -140,7 +136,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-    return k_malloc(size);
+    return esp_os_malloc(size);
 }
 
 uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
@@ -161,26 +157,19 @@ uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
 static int32_t IRAM_ATTR esp_coex_semphr_take_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
-    int ret = k_sem_take((struct k_sem *)semphr, K_NO_WAIT);
-
-    if (ret == 0) {
-        if (hpt) {
-            *hpt = 0;
-        }
-        return 1;
-    }
+    int ret = esp_os_sem_take(semphr, ESP_OS_NO_WAIT);
 
     if (hpt) {
         *hpt = 0;
     }
-    return 0;
+    return ret == 0 ? 1 : 0;
 }
 
 static int32_t IRAM_ATTR esp_coex_semphr_give_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
 
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
 
     if (hpt) {
         *hpt = 0;
@@ -199,7 +188,7 @@ static int esp_coexist_debug_matrix_init_wrapper(int evt, int sig, bool rev)
 
 int32_t IRAM_ATTR coex_is_in_isr_wrapper(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 static int esp_coex_xtal_freq_get_wrapper(void)

--- a/components/esp_coex/esp32c5/esp_coex_adapter.c
+++ b/components/esp_coex/esp32c5/esp_coex_adapter.c
@@ -14,6 +14,7 @@
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 
 #if CONFIG_WIFI_ESP32
 LOG_MODULE_REGISTER(esp32_coex_adapter, CONFIG_WIFI_LOG_LEVEL);
@@ -37,6 +38,15 @@ LOG_MODULE_REGISTER(esp32_coex_adapter);
 
 #define OSI_FUNCS_TIME_BLOCKING  0xffffffff
 
+static uint32_t coex_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
+    }
+
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
+}
+
 bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
 {
 #ifdef CONFIG_IDF_ENV_FPGA
@@ -48,7 +58,7 @@ bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
 
 void *esp_coex_common_spin_lock_create_wrapper(void)
 {
-    unsigned int *spin_lock = (unsigned int *)k_malloc(sizeof(unsigned int));
+    unsigned int *spin_lock = (unsigned int *)esp_os_malloc(sizeof(unsigned int));
     if (spin_lock == NULL) {
         LOG_ERR("spin_lock_create_wrapper allocation failed");
         return NULL;
@@ -62,7 +72,7 @@ uint32_t IRAM_ATTR esp_coex_common_int_disable_wrapper(void *wifi_int_mux)
 {
     unsigned int *int_mux = (unsigned int *)wifi_int_mux;
 
-    *int_mux = irq_lock();
+    *int_mux = esp_os_irq_lock();
     return 0;
 }
 
@@ -70,53 +80,39 @@ void IRAM_ATTR esp_coex_common_int_restore_wrapper(void *wifi_int_mux, uint32_t 
 {
     unsigned int *key = (unsigned int *)wifi_int_mux;
 
-    irq_unlock(*key);
+    esp_os_irq_unlock(*key);
 }
 
 void IRAM_ATTR esp_coex_common_task_yield_from_isr_wrapper(void)
 {
-    k_yield();
+    esp_os_thread_yield();
 }
 
 void *esp_coex_common_semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    struct k_sem *sem = (struct k_sem *)k_malloc(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
 
     if (sem == NULL) {
         LOG_ERR("semphr_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_sem_init(sem, init, max);
-
     return (void *)sem;
 }
 
 void esp_coex_common_semphr_delete_wrapper(void *semphr)
 {
-    k_free(semphr);
+    esp_os_sem_delete(semphr);
 }
 
 int32_t esp_coex_common_semphr_take_wrapper(void *semphr, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        int ret = k_sem_take((struct k_sem *)semphr, K_FOREVER);
-        if (ret == 0) {
-            return 1;
-        }
-    } else {
-        int ret = k_sem_take((struct k_sem *)semphr, K_TICKS(block_time_tick));
-
-        if (ret == 0) {
-            return 1;
-        }
-    }
-    return 0;
+    return esp_os_sem_take(semphr, coex_block_time_ms(block_time_tick)) == 0 ? 1 : 0;
 }
 
 int32_t esp_coex_common_semphr_give_wrapper(void *semphr)
 {
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
     return 1;
 }
 
@@ -142,7 +138,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-    return k_malloc(size);
+    return esp_os_malloc(size);
 }
 
 uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
@@ -158,26 +154,19 @@ uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
 static int32_t IRAM_ATTR esp_coex_semphr_take_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
-    int ret = k_sem_take((struct k_sem *)semphr, K_NO_WAIT);
-
-    if (ret == 0) {
-        if (hpt) {
-            *hpt = 0;
-        }
-        return 1;
-    }
+    int ret = esp_os_sem_take(semphr, ESP_OS_NO_WAIT);
 
     if (hpt) {
         *hpt = 0;
     }
-    return 0;
+    return ret == 0 ? 1 : 0;
 }
 
 static int32_t IRAM_ATTR esp_coex_semphr_give_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
 
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
 
     if (hpt) {
         *hpt = 0;
@@ -201,7 +190,7 @@ static IRAM_ATTR int esp_coex_common_xtal_freq_get_wrapper(void)
 
 int32_t IRAM_ATTR coex_is_in_isr_wrapper(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 coex_adapter_funcs_t g_coex_adapter_funcs = {
@@ -215,7 +204,7 @@ coex_adapter_funcs_t g_coex_adapter_funcs = {
     ._semphr_give = esp_coex_common_semphr_give_wrapper,
     ._is_in_isr = coex_is_in_isr_wrapper,
     ._malloc_internal = esp_coex_common_malloc_internal_wrapper,
-    ._free = k_free,
+    ._free = esp_os_free,
     ._esp_timer_get_time = esp_timer_get_time,
     ._env_is_chip = esp_coex_common_env_is_chip_wrapper,
     ._timer_disarm = esp_coex_common_timer_disarm_wrapper,

--- a/components/esp_coex/esp32c6/esp_coex_adapter.c
+++ b/components/esp_coex/esp32c6/esp_coex_adapter.c
@@ -14,6 +14,7 @@
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 
 #if CONFIG_WIFI_ESP32
 LOG_MODULE_REGISTER(esp32_coex_adapter, CONFIG_WIFI_LOG_LEVEL);
@@ -37,6 +38,15 @@ LOG_MODULE_REGISTER(esp32_coex_adapter);
 
 #define OSI_FUNCS_TIME_BLOCKING  0xffffffff
 
+static uint32_t coex_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
+    }
+
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
+}
+
 bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
 {
 #ifdef CONFIG_IDF_ENV_FPGA
@@ -48,7 +58,7 @@ bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
 
 void *esp_coex_common_spin_lock_create_wrapper(void)
 {
-    unsigned int *spin_lock = (unsigned int *)k_malloc(sizeof(unsigned int));
+    unsigned int *spin_lock = (unsigned int *)esp_os_malloc(sizeof(unsigned int));
     if (spin_lock == NULL) {
         LOG_ERR("spin_lock_create_wrapper allocation failed");
         return NULL;
@@ -62,7 +72,7 @@ uint32_t IRAM_ATTR esp_coex_common_int_disable_wrapper(void *wifi_int_mux)
 {
     unsigned int *int_mux = (unsigned int *)wifi_int_mux;
 
-    *int_mux = irq_lock();
+    *int_mux = esp_os_irq_lock();
     return 0;
 }
 
@@ -70,53 +80,39 @@ void IRAM_ATTR esp_coex_common_int_restore_wrapper(void *wifi_int_mux, uint32_t 
 {
     unsigned int *key = (unsigned int *)wifi_int_mux;
 
-    irq_unlock(*key);
+    esp_os_irq_unlock(*key);
 }
 
 void IRAM_ATTR esp_coex_common_task_yield_from_isr_wrapper(void)
 {
-    k_yield();
+    esp_os_thread_yield();
 }
 
 void *esp_coex_common_semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    struct k_sem *sem = (struct k_sem *)k_malloc(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
 
     if (sem == NULL) {
         LOG_ERR("semphr_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_sem_init(sem, init, max);
-
     return (void *)sem;
 }
 
 void esp_coex_common_semphr_delete_wrapper(void *semphr)
 {
-    k_free(semphr);
+    esp_os_sem_delete(semphr);
 }
 
 int32_t esp_coex_common_semphr_take_wrapper(void *semphr, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        int ret = k_sem_take((struct k_sem *)semphr, K_FOREVER);
-        if (ret == 0) {
-            return 1;
-        }
-    } else {
-        int ret = k_sem_take((struct k_sem *)semphr, K_TICKS(block_time_tick));
-
-        if (ret == 0) {
-            return 1;
-        }
-    }
-    return 0;
+    return esp_os_sem_take(semphr, coex_block_time_ms(block_time_tick)) == 0 ? 1 : 0;
 }
 
 int32_t esp_coex_common_semphr_give_wrapper(void *semphr)
 {
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
     return 1;
 }
 
@@ -142,7 +138,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-    return k_malloc(size);
+    return esp_os_malloc(size);
 }
 
 uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
@@ -158,26 +154,19 @@ uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
 static int32_t IRAM_ATTR esp_coex_semphr_take_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
-    int ret = k_sem_take((struct k_sem *)semphr, K_NO_WAIT);
-
-    if (ret == 0) {
-        if (hpt) {
-            *hpt = 0;
-        }
-        return 1;
-    }
+    int ret = esp_os_sem_take(semphr, ESP_OS_NO_WAIT);
 
     if (hpt) {
         *hpt = 0;
     }
-    return 0;
+    return ret == 0 ? 1 : 0;
 }
 
 static int32_t IRAM_ATTR esp_coex_semphr_give_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
 
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
 
     if (hpt) {
         *hpt = 0;
@@ -201,7 +190,7 @@ static IRAM_ATTR int esp_coex_common_xtal_freq_get_wrapper(void)
 
 int32_t IRAM_ATTR coex_is_in_isr_wrapper(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 coex_adapter_funcs_t g_coex_adapter_funcs = {
@@ -215,7 +204,7 @@ coex_adapter_funcs_t g_coex_adapter_funcs = {
     ._semphr_give = esp_coex_common_semphr_give_wrapper,
     ._is_in_isr = coex_is_in_isr_wrapper,
     ._malloc_internal = esp_coex_common_malloc_internal_wrapper,
-    ._free = k_free,
+    ._free = esp_os_free,
     ._esp_timer_get_time = esp_timer_get_time,
     ._env_is_chip = esp_coex_common_env_is_chip_wrapper,
     ._timer_disarm = esp_coex_common_timer_disarm_wrapper,

--- a/components/esp_coex/esp32h2/esp_coex_adapter.c
+++ b/components/esp_coex/esp32h2/esp_coex_adapter.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(esp32h2_coex_adapter, CONFIG_BT_LOG_LEVEL);
 LOG_MODULE_REGISTER(esp32h2_coex_adapter);
 #endif
 
+#include <esp_os.h>
 #include "esp_heap_adapter.h"
 #include "esp_attr.h"
 #include "esp_timer.h"
@@ -33,6 +34,15 @@ LOG_MODULE_REGISTER(esp32h2_coex_adapter);
 #define TAG "esp_coex_adapter"
 
 #define OSI_FUNCS_TIME_BLOCKING  0xffffffff
+
+static uint32_t coex_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
+    }
+
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
+}
 
 bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
 {
@@ -59,7 +69,7 @@ uint32_t IRAM_ATTR esp_coex_common_int_disable_wrapper(void *wifi_int_mux)
 {
     unsigned int *int_mux = (unsigned int *)wifi_int_mux;
 
-    *int_mux = irq_lock();
+    *int_mux = esp_os_irq_lock();
     return 0;
 }
 
@@ -67,53 +77,39 @@ void IRAM_ATTR esp_coex_common_int_restore_wrapper(void *wifi_int_mux, uint32_t 
 {
     unsigned int *key = (unsigned int *)wifi_int_mux;
 
-    irq_unlock(*key);
+    esp_os_irq_unlock(*key);
 }
 
 void IRAM_ATTR esp_coex_common_task_yield_from_isr_wrapper(void)
 {
-    k_yield();
+    esp_os_thread_yield();
 }
 
 void *esp_coex_common_semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    struct k_sem *sem = (struct k_sem *)esp_wifi_malloc_func(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
 
     if (sem == NULL) {
         LOG_ERR("semphr_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_sem_init(sem, init, max);
-
     return (void *)sem;
 }
 
 void esp_coex_common_semphr_delete_wrapper(void *semphr)
 {
-    esp_wifi_free_func(semphr);
+    esp_os_sem_delete(semphr);
 }
 
 int32_t esp_coex_common_semphr_take_wrapper(void *semphr, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        int ret = k_sem_take((struct k_sem *)semphr, K_FOREVER);
-        if (ret == 0) {
-            return 1;
-        }
-    } else {
-        int ret = k_sem_take((struct k_sem *)semphr, K_TICKS(block_time_tick));
-
-        if (ret == 0) {
-            return 1;
-        }
-    }
-    return 0;
+    return esp_os_sem_take(semphr, coex_block_time_ms(block_time_tick)) == 0 ? 1 : 0;
 }
 
 int32_t esp_coex_common_semphr_give_wrapper(void *semphr)
 {
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
     return 1;
 }
 
@@ -139,7 +135,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-    return k_malloc(size);
+    return esp_os_malloc(size);
 }
 
 /* static wrapper */
@@ -147,26 +143,19 @@ void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 static int32_t IRAM_ATTR esp_coex_semphr_take_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
-    int ret = k_sem_take((struct k_sem *)semphr, K_NO_WAIT);
-
-    if (ret == 0) {
-        if (hpt) {
-            *hpt = 0;
-        }
-        return 1;
-    }
+    int ret = esp_os_sem_take(semphr, ESP_OS_NO_WAIT);
 
     if (hpt) {
         *hpt = 0;
     }
-    return 0;
+    return ret == 0 ? 1 : 0;
 }
 
 static int32_t IRAM_ATTR esp_coex_semphr_give_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
 
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
 
     if (hpt) {
         *hpt = 0;
@@ -190,7 +179,7 @@ static IRAM_ATTR int esp_coex_common_xtal_freq_get_wrapper(void)
 
 int32_t IRAM_ATTR coex_is_in_isr_wrapper(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 coex_adapter_funcs_t g_coex_adapter_funcs = {
@@ -204,7 +193,7 @@ coex_adapter_funcs_t g_coex_adapter_funcs = {
     ._semphr_give = esp_coex_common_semphr_give_wrapper,
     ._is_in_isr = coex_is_in_isr_wrapper,
     ._malloc_internal = esp_coex_common_malloc_internal_wrapper,
-    ._free = k_free,
+    ._free = esp_os_free,
     ._esp_timer_get_time = esp_timer_get_time,
     ._env_is_chip = esp_coex_common_env_is_chip_wrapper,
     ._timer_disarm = esp_coex_common_timer_disarm_wrapper,

--- a/components/esp_coex/esp32s2/esp_coex_adapter.c
+++ b/components/esp_coex/esp32s2/esp_coex_adapter.c
@@ -13,6 +13,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 LOG_MODULE_REGISTER(esp32s2_coex_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include "esp_attr.h"
@@ -29,6 +30,15 @@ LOG_MODULE_REGISTER(esp32s2_coex_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #define OSI_FUNCS_TIME_BLOCKING  0xffffffff
 
+static uint32_t coex_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
+    }
+
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
+}
+
 bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
 {
 #ifdef CONFIG_IDF_ENV_FPGA
@@ -40,7 +50,7 @@ bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
 
 void *esp_coex_common_spin_lock_create_wrapper(void)
 {
-    unsigned int *wifi_spin_lock = (unsigned int *)k_malloc(sizeof(unsigned int));
+    unsigned int *wifi_spin_lock = (unsigned int *)esp_os_malloc(sizeof(unsigned int));
     if (wifi_spin_lock == NULL) {
         LOG_ERR("spin_lock_create_wrapper allocation failed");
         return NULL;
@@ -54,7 +64,7 @@ uint32_t IRAM_ATTR esp_coex_common_int_disable_wrapper(void *wifi_int_mux)
 {
     unsigned int *int_mux = (unsigned int *)wifi_int_mux;
 
-    *int_mux = irq_lock();
+    *int_mux = esp_os_irq_lock();
     return 0;
 }
 
@@ -62,53 +72,39 @@ void IRAM_ATTR esp_coex_common_int_restore_wrapper(void *wifi_int_mux, uint32_t 
 {
     unsigned int *key = (unsigned int *)wifi_int_mux;
 
-    irq_unlock(*key);
+    esp_os_irq_unlock(*key);
 }
 
 void IRAM_ATTR esp_coex_common_task_yield_from_isr_wrapper(void)
 {
-    k_yield();
+    esp_os_thread_yield();
 }
 
 void *esp_coex_common_semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    struct k_sem *sem = (struct k_sem *)k_malloc(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
 
     if (sem == NULL) {
         LOG_ERR("semphr_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_sem_init(sem, init, max);
-
     return (void *)sem;
 }
 
 void esp_coex_common_semphr_delete_wrapper(void *semphr)
 {
-    k_free(semphr);
+    esp_os_sem_delete(semphr);
 }
 
 int32_t esp_coex_common_semphr_take_wrapper(void *semphr, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        int ret = k_sem_take((struct k_sem *)semphr, K_FOREVER);
-        if (ret == 0) {
-            return 1;
-        }
-    } else {
-        int ret = k_sem_take((struct k_sem *)semphr, K_TICKS(block_time_tick));
-
-        if (ret == 0) {
-            return 1;
-        }
-    }
-    return 0;
+    return esp_os_sem_take(semphr, coex_block_time_ms(block_time_tick)) == 0 ? 1 : 0;
 }
 
 int32_t esp_coex_common_semphr_give_wrapper(void *semphr)
 {
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
     return 1;
 }
 
@@ -134,7 +130,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-    return k_malloc(size);
+    return esp_os_malloc(size);
 }
 
 uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
@@ -149,51 +145,42 @@ uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
 
 static int IRAM_ATTR esp_coex_is_in_isr_wrapper(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 static void *esp_coex_internal_semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    struct k_sem *sem = (struct k_sem *)k_malloc(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
 
     if (sem == NULL) {
         LOG_ERR("internal_semphr_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_sem_init(sem, init, max);
-
     return (void *)sem;
 }
 
 static void esp_coex_internal_semphr_delete_wrapper(void *semphr)
 {
-    k_free(semphr);
+    esp_os_sem_delete(semphr);
 }
 
 static int32_t IRAM_ATTR esp_coex_internal_semphr_take_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
-    int ret = k_sem_take((struct k_sem *)semphr, K_NO_WAIT);
-
-    if (ret == 0) {
-        if (hpt) {
-            *hpt = 0;
-        }
-        return 1;
-    }
+    int ret = esp_os_sem_take(semphr, ESP_OS_NO_WAIT);
 
     if (hpt) {
         *hpt = 0;
     }
-    return 0;
+    return ret == 0 ? 1 : 0;
 }
 
 static int32_t IRAM_ATTR esp_coex_internal_semphr_give_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
 
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
 
     if (hpt) {
         *hpt = 0;
@@ -204,24 +191,12 @@ static int32_t IRAM_ATTR esp_coex_internal_semphr_give_from_isr_wrapper(void *se
 
 static int32_t esp_coex_internal_semphr_take_wrapper(void *semphr, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        int ret = k_sem_take((struct k_sem *)semphr, K_FOREVER);
-        if (ret == 0) {
-            return 1;
-        }
-    } else {
-        int ret = k_sem_take((struct k_sem *)semphr, K_TICKS(block_time_tick));
-
-        if (ret == 0) {
-            return 1;
-        }
-    }
-    return 0;
+    return esp_os_sem_take(semphr, coex_block_time_ms(block_time_tick)) == 0 ? 1 : 0;
 }
 
 static int32_t esp_coex_internal_semphr_give_wrapper(void *semphr)
 {
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
     return 1;
 }
 
@@ -245,7 +220,7 @@ coex_adapter_funcs_t g_coex_adapter_funcs = {
     ._semphr_give = esp_coex_internal_semphr_give_wrapper,
     ._is_in_isr = esp_coex_is_in_isr_wrapper,
     ._malloc_internal =  esp_coex_common_malloc_internal_wrapper,
-    ._free = k_free,
+    ._free = esp_os_free,
     ._esp_timer_get_time = esp_timer_get_time,
     ._timer_disarm = esp_coex_common_timer_disarm_wrapper,
     ._timer_done = esp_coex_common_timer_done_wrapper,

--- a/components/esp_coex/esp32s3/esp_coex_adapter.c
+++ b/components/esp_coex/esp32s3/esp_coex_adapter.c
@@ -14,6 +14,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 
 #include "esp_attr.h"
 #include "esp_timer.h"
@@ -34,7 +35,7 @@ LOG_MODULE_REGISTER(esp32_coex_adapter, CONFIG_WIFI_LOG_LEVEL);
 #define OSI_FUNCS_TIME_BLOCKING  0xffffffff
 
 typedef struct {
-    void *handle;   /* k_sem pointer */
+    void *handle;   /* semaphore handle */
     void *storage;  /* unused in Zephyr */
 } modem_static_queue_t;
 
@@ -52,9 +53,18 @@ bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
 #endif
 }
 
+static uint32_t coex_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
+    }
+
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
+}
+
 void * esp_coex_common_spin_lock_create_wrapper(void)
 {
-    unsigned int *wifi_spin_lock = (unsigned int *)k_malloc(sizeof(unsigned int));
+    unsigned int *wifi_spin_lock = (unsigned int *)esp_os_malloc(sizeof(unsigned int));
 
     if (wifi_spin_lock == NULL) {
         LOG_ERR("spin_lock_create_wrapper allocation failed");
@@ -67,7 +77,7 @@ uint32_t IRAM_ATTR esp_coex_common_int_disable_wrapper(void *wifi_int_mux)
 {
     unsigned int *int_mux = (unsigned int *)wifi_int_mux;
 
-    *int_mux = irq_lock();
+    *int_mux = esp_os_irq_lock();
     return 0;
 }
 
@@ -75,52 +85,39 @@ void IRAM_ATTR esp_coex_common_int_restore_wrapper(void *wifi_int_mux, uint32_t 
 {
     unsigned int *key = (unsigned int *)wifi_int_mux;
 
-    irq_unlock(*key);
+    esp_os_irq_unlock(*key);
 }
 
 void IRAM_ATTR esp_coex_common_task_yield_from_isr_wrapper(void)
 {
-    k_yield();
+    esp_os_thread_yield();
 }
 
 void * esp_coex_common_semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    struct k_sem *sem = (struct k_sem *)k_malloc(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
 
     if (sem == NULL) {
         LOG_ERR("semphr_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_sem_init(sem, init, max);
-
     return (void *)sem;
 }
 
 void esp_coex_common_semphr_delete_wrapper(void *semphr)
 {
-    esp_wifi_free(semphr);
+    esp_os_sem_delete(semphr);
 }
 
 int32_t esp_coex_common_semphr_take_wrapper(void *semphr, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        int ret = k_sem_take((struct k_sem *)semphr, K_FOREVER);
-        if (ret == 0) {
-            return 1;
-        }
-    } else {
-        int ret = k_sem_take((struct k_sem *)semphr, K_TICKS(block_time_tick));
-        if (ret == 0) {
-            return 1;
-        }
-    }
-    return 0;
+    return esp_os_sem_take(semphr, coex_block_time_ms(block_time_tick)) == 0 ? 1 : 0;
 }
 
 int32_t esp_coex_common_semphr_give_wrapper(void *semphr)
 {
-    k_sem_give((struct k_sem *)semphr);
+    esp_os_sem_give(semphr);
     return 1;
 }
 
@@ -146,7 +143,7 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
 
 void * IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-    return k_malloc(size);
+    return esp_os_malloc(size);
 }
 
 uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
@@ -166,23 +163,22 @@ uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
 
 static int IRAM_ATTR esp_coex_is_in_isr_wrapper(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 static void *esp_coex_internal_semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    modem_static_queue_t *semphr = k_calloc(1, sizeof(modem_static_queue_t));
+    modem_static_queue_t *semphr = esp_os_calloc(1, sizeof(modem_static_queue_t));
     if (!semphr) {
         return NULL;
     }
 
-    struct k_sem *sem = k_malloc(sizeof(struct k_sem));
+    esp_os_sem_t sem = esp_os_sem_create(init, max);
     if (!sem) {
-        k_free(semphr);
+        esp_os_free(semphr);
         return NULL;
     }
 
-    k_sem_init(sem, init, max);
     semphr->handle = sem;
 
     return (void *)semphr;
@@ -193,35 +189,28 @@ static void esp_coex_internal_semphr_delete_wrapper(void *semphr)
     modem_static_queue_t *semphr_item = (modem_static_queue_t *)semphr;
     if (semphr_item) {
         if (semphr_item->handle) {
-            k_free(semphr_item->handle);
+            esp_os_sem_delete(semphr_item->handle);
         }
-        k_free(semphr_item);
+        esp_os_free(semphr_item);
     }
 }
 
 static int32_t IRAM_ATTR esp_coex_internal_semphr_take_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
-    int ret = k_sem_take((struct k_sem *)((modem_static_queue_t *)semphr)->handle, K_NO_WAIT);
-
-    if (ret == 0) {
-        if (hpt) {
-            *hpt = 0;
-        }
-        return 1;
-    }
+    int ret = esp_os_sem_take(((modem_static_queue_t *)semphr)->handle, ESP_OS_NO_WAIT);
 
     if (hpt) {
         *hpt = 0;
     }
-    return 0;
+    return ret == 0 ? 1 : 0;
 }
 
 static int32_t IRAM_ATTR esp_coex_internal_semphr_give_from_isr_wrapper(void *semphr, void *hptw)
 {
     int *hpt = (int *)hptw;
 
-    k_sem_give((struct k_sem *)((modem_static_queue_t *)semphr)->handle);
+    esp_os_sem_give(((modem_static_queue_t *)semphr)->handle);
 
     if (hpt) {
         *hpt = 0;
@@ -231,23 +220,13 @@ static int32_t IRAM_ATTR esp_coex_internal_semphr_give_from_isr_wrapper(void *se
 
 static int32_t esp_coex_internal_semphr_take_wrapper(void *semphr, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        int ret = k_sem_take((struct k_sem *)((modem_static_queue_t *)semphr)->handle, K_FOREVER);
-        if (ret == 0) {
-            return 1;
-        }
-    } else {
-        int ret = k_sem_take((struct k_sem *)((modem_static_queue_t *)semphr)->handle, K_TICKS(block_time_tick));
-        if (ret == 0) {
-            return 1;
-        }
-    }
-    return 0;
+    return esp_os_sem_take(((modem_static_queue_t *)semphr)->handle,
+                           coex_block_time_ms(block_time_tick)) == 0 ? 1 : 0;
 }
 
 static int32_t esp_coex_internal_semphr_give_wrapper(void *semphr)
 {
-    k_sem_give((struct k_sem *)((modem_static_queue_t *)semphr)->handle);
+    esp_os_sem_give(((modem_static_queue_t *)semphr)->handle);
     return 1;
 }
 

--- a/components/esp_driver_gpio/src/gpio.c
+++ b/components/esp_driver_gpio/src/gpio.c
@@ -5,6 +5,7 @@
  */
 
 #include <esp_types.h>
+#include <esp_os.h>
 #include "esp_err.h"
 #include <zephyr/kernel.h>
 #include <soc.h>
@@ -38,7 +39,7 @@ extern uint32_t esp_core_id(void);
 
 #define MALLOC_CAP_INTERNAL 0
 #define MALLOC_CAP_DEFAULT 0
-#define heap_caps_calloc(n, size, caps) k_calloc(n, size)
+#define heap_caps_calloc(n, size, caps) esp_os_calloc(n, size)
 
 static inline uint64_t esp_gpio_reserve(uint64_t mask) { (void)mask; return 0; }
 static inline void esp_gpio_revoke(uint64_t mask) { (void)mask; }
@@ -593,7 +594,7 @@ esp_err_t gpio_install_isr_service(int intr_alloc_flags)
             // isr service already installed, free allocated resource
             GPIO_EXIT_CRITICAL();
             ret = ESP_ERR_INVALID_STATE;
-            k_free(isr_func);
+            esp_os_free(isr_func);
         }
     }
 
@@ -645,7 +646,7 @@ esp_err_t gpio_uninstall_isr_service(void)
     gpio_context.isr_core_id = GPIO_ISR_CORE_ID_UNINIT;
     GPIO_EXIT_CRITICAL();
     esp_intr_free(gpio_isr_handle_free);
-    k_free(gpio_isr_func_free);
+    esp_os_free(gpio_isr_func_free);
     return ESP_OK;
 }
 

--- a/components/esp_hw_support/adc_share_hw_ctrl.c
+++ b/components/esp_hw_support/adc_share_hw_ctrl.c
@@ -18,6 +18,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <esp_os.h>
 
 #include <esp_types.h>
 #include "sdkconfig.h"
@@ -127,21 +128,21 @@ int IRAM_ATTR adc_get_hw_calibration_chan_compens(adc_unit_t adc_n, adc_channel_
 /*---------------------------------------------------------------
             ADC Hardware Locks
 ---------------------------------------------------------------*/
-K_MUTEX_DEFINE(adc1_lock);
-K_MUTEX_DEFINE(adc2_lock);
+ESP_OS_MUTEX_DEFINE(adc1_lock);
+ESP_OS_MUTEX_DEFINE(adc2_lock);
 
-#define ADC_LOCK_ACQUIRE(lock) do { k_mutex_lock(lock, K_FOREVER); } while(0)
-#define ADC_LOCK_RELEASE(lock) do { k_mutex_unlock(lock); } while(0)
-#define ADC_LOCK_TRY_ACQUIRE(lock) ((k_mutex_lock(lock, K_NO_WAIT) == 0) ? 0 : -1)
+#define ADC_LOCK_ACQUIRE(lock) do { esp_os_mutex_lock(lock, ESP_OS_FOREVER); } while(0)
+#define ADC_LOCK_RELEASE(lock) do { esp_os_mutex_unlock(lock); } while(0)
+#define ADC_LOCK_TRY_ACQUIRE(lock) ((esp_os_mutex_lock(lock, ESP_OS_NO_WAIT) == 0) ? 0 : -1)
 
 esp_err_t adc_lock_acquire(adc_unit_t adc_unit)
 {
     if (adc_unit == ADC_UNIT_1) {
-        ADC_LOCK_ACQUIRE(&adc1_lock);
+        ADC_LOCK_ACQUIRE(adc1_lock);
     }
 
     if (adc_unit == ADC_UNIT_2) {
-        ADC_LOCK_ACQUIRE(&adc2_lock);
+        ADC_LOCK_ACQUIRE(adc2_lock);
     }
 
     return ESP_OK;
@@ -150,13 +151,13 @@ esp_err_t adc_lock_acquire(adc_unit_t adc_unit)
 esp_err_t adc_lock_release(adc_unit_t adc_unit)
 {
     if (adc_unit == ADC_UNIT_2) {
-        ESP_RETURN_ON_FALSE((adc2_lock.lock_count != 0), ESP_ERR_INVALID_STATE, TAG, "adc2 lock release without acquiring");
-        ADC_LOCK_RELEASE(&adc2_lock);
+        ESP_RETURN_ON_FALSE((esp_os_mutex_lock_count(adc2_lock) != 0), ESP_ERR_INVALID_STATE, TAG, "adc2 lock release without acquiring");
+        ADC_LOCK_RELEASE(adc2_lock);
     }
 
     if (adc_unit == ADC_UNIT_1) {
-        ESP_RETURN_ON_FALSE((adc1_lock.lock_count != 0), ESP_ERR_INVALID_STATE, TAG, "adc1 lock release without acquiring");
-        ADC_LOCK_RELEASE(&adc1_lock);
+        ESP_RETURN_ON_FALSE((esp_os_mutex_lock_count(adc1_lock) != 0), ESP_ERR_INVALID_STATE, TAG, "adc1 lock release without acquiring");
+        ADC_LOCK_RELEASE(adc1_lock);
     }
 
     return ESP_OK;
@@ -165,13 +166,13 @@ esp_err_t adc_lock_release(adc_unit_t adc_unit)
 esp_err_t adc_lock_try_acquire(adc_unit_t adc_unit)
 {
     if (adc_unit == ADC_UNIT_1) {
-        if (ADC_LOCK_TRY_ACQUIRE(&adc1_lock) == -1) {
+        if (ADC_LOCK_TRY_ACQUIRE(adc1_lock) == -1) {
             return ESP_ERR_TIMEOUT;
         }
     }
 
     if (adc_unit == ADC_UNIT_2) {
-        if (ADC_LOCK_TRY_ACQUIRE(&adc2_lock) == -1) {
+        if (ADC_LOCK_TRY_ACQUIRE(adc2_lock) == -1) {
             return ESP_ERR_TIMEOUT;
         }
     }

--- a/components/esp_hw_support/esp_gpio_reserve.c
+++ b/components/esp_hw_support/esp_gpio_reserve.c
@@ -5,6 +5,7 @@
  */
 
 #include "soc/soc_caps.h"
+#include <esp_os.h>
 #include "esp_types.h"
 #include "esp_bit_defs.h"
 #include "esp_private/esp_gpio_reserve.h"
@@ -20,19 +21,19 @@ static uint64_t s_reserved_pin_mask = ~(SOC_GPIO_VALID_GPIO_MASK);
 
 uint64_t esp_gpio_reserve(uint64_t gpio_mask)
 {
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     uint64_t prev = s_reserved_pin_mask;
     s_reserved_pin_mask |= gpio_mask;
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
     return prev;
 }
 
 uint64_t esp_gpio_revoke(uint64_t gpio_mask)
 {
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     uint64_t prev = s_reserved_pin_mask;
     s_reserved_pin_mask &= ~gpio_mask;
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
     return prev;
 }
 

--- a/components/esp_hw_support/lowpower/port/esp32c3/sleep_cpu.c
+++ b/components/esp_hw_support/lowpower/port/esp32c3/sleep_cpu.c
@@ -5,6 +5,7 @@
  */
 
 #include <stddef.h>
+#include <esp_os.h>
 #include <string.h>
 #include <inttypes.h>
 #include <sys/lock.h>
@@ -25,7 +26,7 @@
 static inline void *heap_caps_aligned_calloc(size_t alignment, size_t n, size_t size, uint32_t caps)
 {
     (void)caps;
-    void *ptr = k_aligned_alloc(alignment, n * size);
+    void *ptr = esp_os_aligned_alloc(alignment, n * size);
     if (ptr) {
         memset(ptr, 0, n * size);
     }
@@ -34,7 +35,7 @@ static inline void *heap_caps_aligned_calloc(size_t alignment, size_t n, size_t 
 
 static inline void heap_caps_free(void *ptr)
 {
-    k_free(ptr);
+    esp_os_free(ptr);
 }
 
 #define MALLOC_CAP_RETENTION 0

--- a/components/esp_hw_support/lowpower/port/esp32s3/sleep_cpu.c
+++ b/components/esp_hw_support/lowpower/port/esp32s3/sleep_cpu.c
@@ -5,6 +5,7 @@
  */
 
 #include <stddef.h>
+#include <esp_os.h>
 #include <string.h>
 #include <inttypes.h>
 #include <sys/lock.h>
@@ -27,7 +28,7 @@
 static inline void *heap_caps_aligned_calloc(size_t alignment, size_t n, size_t size, uint32_t caps)
 {
     (void)caps;
-    void *ptr = k_aligned_alloc(alignment, n * size);
+    void *ptr = esp_os_aligned_alloc(alignment, n * size);
     if (ptr) {
         memset(ptr, 0, n * size);
     }
@@ -36,7 +37,7 @@ static inline void *heap_caps_aligned_calloc(size_t alignment, size_t n, size_t 
 
 static inline void heap_caps_free(void *ptr)
 {
-    k_free(ptr);
+    esp_os_free(ptr);
 }
 
 #define MALLOC_CAP_RETENTION 0

--- a/components/esp_hw_support/port/esp32c3/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32c3/sar_periph_ctrl.c
@@ -16,6 +16,7 @@
  */
 
 #include <sys/lock.h>
+#include <esp_os.h>
 #include <zephyr/kernel.h>
 #include "sdkconfig.h"
 #include "esp_log.h"
@@ -29,7 +30,7 @@
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
 extern esp_os_spinlock_t rtc_spinlock;
-K_MUTEX_DEFINE(adc_reset_lock);
+ESP_OS_MUTEX_DEFINE(adc_reset_lock);
 
 
 void sar_periph_ctrl_init(void)
@@ -161,10 +162,10 @@ void sar_periph_ctrl_adc_reset(void)
 
 void adc_reset_lock_acquire(void)
 {
-    k_mutex_lock(&adc_reset_lock, K_FOREVER);
+    esp_os_mutex_lock(adc_reset_lock, ESP_OS_FOREVER);
 }
 
 void adc_reset_lock_release(void)
 {
-    k_mutex_unlock(&adc_reset_lock);
+    esp_os_mutex_unlock(adc_reset_lock);
 }

--- a/components/esp_hw_support/port/esp32c5/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32c5/sar_periph_ctrl.c
@@ -15,6 +15,7 @@
  */
 
 #include <sys/lock.h>
+#include <esp_os.h>
 #include <zephyr/kernel.h>
 #include "sdkconfig.h"
 #include "esp_log.h"
@@ -29,7 +30,7 @@
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
 extern esp_os_spinlock_t rtc_spinlock;
-K_MUTEX_DEFINE(adc_reset_lock);
+ESP_OS_MUTEX_DEFINE(adc_reset_lock);
 
 void sar_periph_ctrl_init(void)
 {
@@ -150,10 +151,10 @@ void sar_periph_ctrl_adc_reset(void)
 
 void adc_reset_lock_acquire(void)
 {
-    k_mutex_lock(&adc_reset_lock, K_FOREVER);
+    esp_os_mutex_lock(adc_reset_lock, ESP_OS_FOREVER);
 }
 
 void adc_reset_lock_release(void)
 {
-    k_mutex_unlock(&adc_reset_lock);
+    esp_os_mutex_unlock(adc_reset_lock);
 }

--- a/components/esp_hw_support/port/esp32c6/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32c6/sar_periph_ctrl.c
@@ -15,6 +15,7 @@
  */
 
 #include <sys/lock.h>
+#include <esp_os.h>
 #include <zephyr/kernel.h>
 #include "sdkconfig.h"
 #include "esp_log.h"
@@ -29,7 +30,7 @@
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
 extern esp_os_spinlock_t rtc_spinlock;
-K_MUTEX_DEFINE(adc_reset_lock);
+ESP_OS_MUTEX_DEFINE(adc_reset_lock);
 
 
 void sar_periph_ctrl_init(void)
@@ -152,10 +153,10 @@ void sar_periph_ctrl_adc_reset(void)
 
 void adc_reset_lock_acquire(void)
 {
-    k_mutex_lock(&adc_reset_lock, K_FOREVER);
+    esp_os_mutex_lock(adc_reset_lock, ESP_OS_FOREVER);
 }
 
 void adc_reset_lock_release(void)
 {
-    k_mutex_unlock(&adc_reset_lock);
+    esp_os_mutex_unlock(adc_reset_lock);
 }

--- a/components/esp_hw_support/port/esp32h2/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32h2/sar_periph_ctrl.c
@@ -15,6 +15,7 @@
  */
 
 #include <sys/lock.h>
+#include <esp_os.h>
 #include <zephyr/kernel.h>
 #include "esp_log.h"
 #include "esp_private/sar_periph_ctrl.h"
@@ -28,7 +29,7 @@
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
 extern esp_os_spinlock_t rtc_spinlock;
-K_MUTEX_DEFINE(adc_reset_lock);
+ESP_OS_MUTEX_DEFINE(adc_reset_lock);
 
 
 void sar_periph_ctrl_init(void)
@@ -150,10 +151,10 @@ void sar_periph_ctrl_adc_reset(void)
 
 void adc_reset_lock_acquire(void)
 {
-    k_mutex_lock(&adc_reset_lock, K_FOREVER);
+    esp_os_mutex_lock(adc_reset_lock, ESP_OS_FOREVER);
 }
 
 void adc_reset_lock_release(void)
 {
-    k_mutex_unlock(&adc_reset_lock);
+    esp_os_mutex_unlock(adc_reset_lock);
 }

--- a/components/esp_hw_support/regi2c_ctrl.c
+++ b/components/esp_hw_support/regi2c_ctrl.c
@@ -6,6 +6,7 @@
 
 
 #include "esp_attr.h"
+#include <esp_os.h>
 #include <stdint.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
@@ -18,9 +19,9 @@ uint8_t regi2c_ctrl_read_reg(uint8_t block, uint8_t host_id, uint8_t reg_add)
 {
     REGI2C_CLOCK_ENABLE();
     int __DECLARE_REGI2C_ATOMIC_ENV __attribute__((unused));
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     uint8_t value = regi2c_impl_read(block, host_id, reg_add);
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
     REGI2C_CLOCK_DISABLE();
     return value;
 }
@@ -29,9 +30,9 @@ uint8_t regi2c_ctrl_read_reg_mask(uint8_t block, uint8_t host_id, uint8_t reg_ad
 {
     REGI2C_CLOCK_ENABLE();
     int __DECLARE_REGI2C_ATOMIC_ENV __attribute__((unused));
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     uint8_t value = regi2c_impl_read_mask(block, host_id, reg_add, msb, lsb);
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
     REGI2C_CLOCK_DISABLE();
     return value;
 }
@@ -40,9 +41,9 @@ void regi2c_ctrl_write_reg(uint8_t block, uint8_t host_id, uint8_t reg_add, uint
 {
     REGI2C_CLOCK_ENABLE();
     int __DECLARE_REGI2C_ATOMIC_ENV __attribute__((unused));
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     regi2c_impl_write(block, host_id, reg_add, data);
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
     REGI2C_CLOCK_DISABLE();
 }
 
@@ -50,9 +51,9 @@ void regi2c_ctrl_write_reg_mask(uint8_t block, uint8_t host_id, uint8_t reg_add,
 {
     REGI2C_CLOCK_ENABLE();
     int __DECLARE_REGI2C_ATOMIC_ENV __attribute__((unused));
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     regi2c_impl_write_mask(block, host_id, reg_add, msb, lsb, data);
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
     REGI2C_CLOCK_DISABLE();
 }
 

--- a/components/esp_hw_support/rtc_module.c
+++ b/components/esp_hw_support/rtc_module.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdlib.h>
+#include <esp_os.h>
 #include <ctype.h>
 #include "sdkconfig.h"
 #include "esp_types.h"
@@ -117,7 +118,7 @@ esp_err_t rtc_isr_register(intr_handler_t handler, void* handler_arg, uint32_t r
         return err;
     }
 
-    rtc_isr_handler_t* item = k_malloc(sizeof(*item));
+    rtc_isr_handler_t* item = esp_os_malloc(sizeof(*item));
     if (item == NULL) {
         return ESP_ERR_NO_MEM;
     }
@@ -158,7 +159,7 @@ esp_err_t rtc_isr_deregister(intr_handler_t handler, void* handler_arg)
             if (it->flags & RTC_INTR_FLAG_IRAM) {
                 s_rtc_isr_noniram_hook_relieve(it->mask);
             }
-            k_free(it);
+            esp_os_free(it);
             break;
         }
         prev = it;

--- a/components/esp_hw_support/sleep_event.c
+++ b/components/esp_hw_support/sleep_event.c
@@ -5,6 +5,7 @@
  */
 
 #include <stddef.h>
+#include <esp_os.h>
 #include <string.h>
 #include <zephyr/kernel.h>
 
@@ -27,7 +28,7 @@ esp_err_t esp_sleep_register_event_callback(esp_sleep_event_cb_index_t event_id,
     if (event_cb_conf == NULL || event_id >= SLEEP_EVENT_CB_INDEX_NUM) {
         return ESP_ERR_INVALID_ARG;
     }
-    esp_sleep_event_cb_config_t *new_config = (esp_sleep_event_cb_config_t *)k_malloc(sizeof(esp_sleep_event_cb_config_t));
+    esp_sleep_event_cb_config_t *new_config = (esp_sleep_event_cb_config_t *)esp_os_malloc(sizeof(esp_sleep_event_cb_config_t));
     if (new_config == NULL) {
         return ESP_ERR_NO_MEM; /* Memory allocation failed */
     }
@@ -36,7 +37,7 @@ esp_err_t esp_sleep_register_event_callback(esp_sleep_event_cb_index_t event_id,
     esp_sleep_event_cb_config_t **current_ptr = &(g_sleep_event_cbs_config.sleep_event_cb_config[event_id]);
     while (*current_ptr != NULL) {
         if (((*current_ptr)->cb) == (event_cb_conf->cb)) {
-            k_free(new_config);
+            esp_os_free(new_config);
             esp_os_exit_critical(&s_sleep_event_mutex);
             return ESP_FAIL;
         }
@@ -63,7 +64,7 @@ esp_err_t esp_sleep_unregister_event_callback(esp_sleep_event_cb_index_t event_i
         if (((*current_ptr)->cb) == cb) {
             esp_sleep_event_cb_config_t *temp = *current_ptr;
             *current_ptr = (*current_ptr)->next;
-            k_free(temp);
+            esp_os_free(temp);
             break;
         }
         current_ptr = &((*current_ptr)->next);

--- a/components/esp_hw_support/sleep_modem.c
+++ b/components/esp_hw_support/sleep_modem.c
@@ -5,6 +5,7 @@
  */
 
 #include <stddef.h>
+#include <esp_os.h>
 #include <string.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
@@ -35,7 +36,7 @@ static void esp_pm_light_sleep_default_params_config(int min_freq_mhz, int max_f
 #if SOC_PM_RETENTION_HAS_CLOCK_BUG && CONFIG_MAC_BB_PD
 static bool s_modem_sleep = false;
 static uint8_t s_modem_prepare_ref = 0;
-K_MUTEX_DEFINE(s_modem_prepare_lock);
+ESP_OS_MUTEX_DEFINE(s_modem_prepare_lock);
 #endif // SOC_PM_RETENTION_HAS_CLOCK_BUG && CONFIG_MAC_BB_PD
 
 #if CONFIG_MAC_BB_PD
@@ -327,24 +328,24 @@ static void esp_pm_light_sleep_default_params_config(int min_freq_mhz, int max_f
 void sleep_modem_register_mac_bb_module_prepare_callback(mac_bb_power_down_cb_t pd_cb,
                                                          mac_bb_power_up_cb_t pu_cb)
 {
-    k_mutex_lock(&s_modem_prepare_lock, K_FOREVER);
+    esp_os_mutex_lock(s_modem_prepare_lock, ESP_OS_FOREVER);
     if (s_modem_prepare_ref++ == 0) {
         esp_register_mac_bb_pd_callback(pd_cb);
         esp_register_mac_bb_pu_callback(pu_cb);
     }
-    k_mutex_unlock(&s_modem_prepare_lock);
+    esp_os_mutex_unlock(s_modem_prepare_lock);
 }
 
 void sleep_modem_unregister_mac_bb_module_prepare_callback(mac_bb_power_down_cb_t pd_cb,
                                                            mac_bb_power_up_cb_t pu_cb)
 {
-    k_mutex_lock(&s_modem_prepare_lock, K_FOREVER);
+    esp_os_mutex_lock(s_modem_prepare_lock, ESP_OS_FOREVER);
     assert(s_modem_prepare_ref);
     if (--s_modem_prepare_ref == 0) {
         esp_unregister_mac_bb_pd_callback(pd_cb);
         esp_unregister_mac_bb_pu_callback(pu_cb);
     }
-    k_mutex_unlock(&s_modem_prepare_lock);
+    esp_os_mutex_unlock(s_modem_prepare_lock);
 }
 
 /**

--- a/components/esp_hw_support/sleep_retention.c
+++ b/components/esp_hw_support/sleep_retention.c
@@ -7,24 +7,24 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>
-#include <zephyr/kernel.h>
+#include <esp_os.h>
 
 /* Zephyr lock compatibility */
-typedef struct k_mutex *_lock_t;
-static struct k_mutex _retention_mutex;
+typedef esp_os_mutex_t _lock_t;
+static esp_os_mutex_t _retention_mutex;
 static bool _retention_mutex_init = false;
 #define _lock_init_recursive(lock) do { \
-    if (!_retention_mutex_init) { k_mutex_init(&_retention_mutex); _retention_mutex_init = true; } \
-    *(lock) = &_retention_mutex; \
+    if (!_retention_mutex_init) { _retention_mutex = esp_os_mutex_create(); _retention_mutex_init = true; } \
+    *(lock) = _retention_mutex; \
 } while(0)
 #define _lock_close_recursive(lock) do { \
     *(lock) = NULL; \
 } while(0)
 #define _lock_acquire_recursive(lock) do { \
-    if (!_retention_mutex_init) { k_mutex_init(&_retention_mutex); _retention_mutex_init = true; } \
-    k_mutex_lock(&_retention_mutex, K_FOREVER); \
+    if (!_retention_mutex_init) { _retention_mutex = esp_os_mutex_create(); _retention_mutex_init = true; } \
+    esp_os_mutex_lock(_retention_mutex, ESP_OS_FOREVER); \
 } while(0)
-#define _lock_release_recursive(lock) k_mutex_unlock(&_retention_mutex)
+#define _lock_release_recursive(lock) esp_os_mutex_unlock(_retention_mutex)
 
 #include "esp_err.h"
 #include "esp_attr.h"

--- a/components/esp_mm/esp_cache_msync.c
+++ b/components/esp_mm/esp_cache_msync.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/sys/util.h>
+#include <esp_os.h>
 #include <inttypes.h>
 #include <string.h>
 #include "sys/lock.h"
@@ -30,7 +31,7 @@ static const char *TAG = "cache";
 
 DEFINE_CRIT_SECTION_LOCK_STATIC(s_spinlock);
 #if CONFIG_ESP_MM_CACHE_MSYNC_C2M_CHUNKED_OPS
-K_MUTEX_DEFINE(s_mutex);
+ESP_OS_MUTEX_DEFINE(s_mutex);
 #endif
 
 void esp_cache_sync_ops_enter_critical_section(void)
@@ -47,7 +48,7 @@ void esp_cache_sync_ops_exit_critical_section(void)
 static void s_c2m_ops(uint32_t vaddr, size_t size)
 {
 #if CONFIG_ESP_MM_CACHE_MSYNC_C2M_CHUNKED_OPS
-    if (!k_is_in_isr()) {
+    if (!esp_os_is_in_isr()) {
         bool valid = true;
         size_t offset = 0;
         while (offset < size) {
@@ -75,8 +76,8 @@ static void s_c2m_ops(uint32_t vaddr, size_t size)
 static void s_acquire_mutex_from_task_context(void)
 {
 #if CONFIG_ESP_MM_CACHE_MSYNC_C2M_CHUNKED_OPS
-    if (!k_is_in_isr() && !k_is_pre_kernel()) {
-        k_mutex_lock(&s_mutex, K_FOREVER);
+    if (!esp_os_is_in_isr() && !esp_os_is_pre_kernel()) {
+        esp_os_mutex_lock(s_mutex, ESP_OS_FOREVER);
         ESP_LOGD(TAG, "mutex is taken");
     }
 #endif  //#if CONFIG_ESP_MM_CACHE_MSYNC_C2M_CHUNKED_OPS
@@ -86,8 +87,8 @@ static void s_acquire_mutex_from_task_context(void)
 static void s_release_mutex_from_task_context(void)
 {
 #if CONFIG_ESP_MM_CACHE_MSYNC_C2M_CHUNKED_OPS
-    if (!k_is_in_isr() && !k_is_pre_kernel()) {
-        k_mutex_unlock(&s_mutex);
+    if (!esp_os_is_in_isr() && !esp_os_is_pre_kernel()) {
+        esp_os_mutex_unlock(s_mutex);
         ESP_LOGD(TAG, "mutex is free");
     }
 #endif  //#if CONFIG_ESP_MM_CACHE_MSYNC_C2M_CHUNKED_OPS

--- a/components/esp_mm/esp_mmu_map.c
+++ b/components/esp_mm/esp_mmu_map.c
@@ -10,6 +10,7 @@
 #include <sys/queue.h>
 #include <inttypes.h>
 #include <zephyr/kernel.h>
+#include <esp_os.h>
 #include "sdkconfig.h"
 #include "esp_attr.h"
 #include "esp_log.h"
@@ -111,7 +112,7 @@ typedef struct {
     /**
      * driver layer mutex lock
      */
-    struct k_mutex mutex;
+    esp_os_mutex_t mutex;
 } mmu_ctx_t;
 
 static mmu_ctx_t s_mmu_ctx;
@@ -258,7 +259,7 @@ void esp_mmu_map_init(void)
         TAILQ_INIT(&s_mmu_ctx.mem_regions[i].mem_block_head);
     }
 
-    k_mutex_init(&s_mmu_ctx.mutex);
+    s_mmu_ctx.mutex = esp_os_mutex_create();
 
     assert(available_region_idx == region_num);
 }
@@ -281,7 +282,7 @@ esp_err_t esp_mmu_map_get_max_consecutive_free_block_size(mmu_mem_caps_t caps, m
     ESP_RETURN_ON_ERROR(s_mem_caps_check(caps), TAG, "invalid caps");
     *out_len = 0;
 
-    unsigned int key = irq_lock();
+    unsigned int key = esp_os_irq_lock();
     size_t max = 0;
 
     for (int i = 0; i < s_mmu_ctx.num_regions; i++) {
@@ -293,7 +294,7 @@ esp_err_t esp_mmu_map_get_max_consecutive_free_block_size(mmu_mem_caps_t caps, m
     }
 
     *out_len = max;
-    irq_unlock(key);
+    esp_os_irq_unlock(key);
 
     return ESP_OK;
 }
@@ -516,7 +517,7 @@ esp_err_t esp_mmu_map_virt(esp_vaddr_t vaddr_start, esp_paddr_t paddr_start, siz
     ESP_RETURN_ON_FALSE((vaddr_start % CONFIG_MMU_PAGE_SIZE == 0), ESP_ERR_INVALID_ARG, TAG, "vaddr must be rounded up to the nearest multiple of CONFIG_MMU_PAGE_SIZE");
     ESP_RETURN_ON_ERROR(s_mem_caps_check(caps), TAG, "invalid caps");
 
-    k_mutex_lock(&s_mmu_ctx.mutex, K_FOREVER);
+    esp_os_mutex_lock(s_mmu_ctx.mutex, ESP_OS_FOREVER);
     mem_block_t *dummy_head = NULL;
     mem_block_t *dummy_tail = NULL;
     size_t aligned_size = ALIGN_UP_BY(size, CONFIG_MMU_PAGE_SIZE);
@@ -684,23 +685,23 @@ esp_err_t esp_mmu_map_virt(esp_vaddr_t vaddr_start, esp_paddr_t paddr_start, siz
     if (out_ptr) {
         *out_ptr = (void *)new_block->vaddr_start;
     }
-    k_mutex_unlock(&s_mmu_ctx.mutex);
+    esp_os_mutex_unlock(s_mmu_ctx.mutex);
 
     return ESP_OK;
 
 err:
     if (new_block) {
-        k_free(new_block);
+        esp_os_free(new_block);
     }
     if (dummy_tail) {
         TAILQ_REMOVE(&found_region->mem_block_head, dummy_tail, entries);
-        k_free(dummy_tail);
+        esp_os_free(dummy_tail);
     }
     if (dummy_head) {
         TAILQ_REMOVE(&found_region->mem_block_head, dummy_head, entries);
-        k_free(dummy_head);
+        esp_os_free(dummy_head);
     }
-    k_mutex_unlock(&s_mmu_ctx.mutex);
+    esp_os_mutex_unlock(s_mmu_ctx.mutex);
 
     return ret;
 }
@@ -753,7 +754,7 @@ esp_err_t esp_mmu_unmap(void *ptr)
     uint32_t ptr_laddr = mmu_ll_vaddr_to_laddr((uint32_t)ptr);
     size_t slot_len = 0;
 
-    k_mutex_lock(&s_mmu_ctx.mutex, K_FOREVER);
+    esp_os_mutex_lock(s_mmu_ctx.mutex, ESP_OS_FOREVER);
     for (int i = 0; i < s_mmu_ctx.num_regions; i++) {
         ESP_COMPILER_DIAGNOSTIC_PUSH_IGNORE("-Wanalyzer-out-of-bounds")
         if (ptr_laddr >= s_mmu_ctx.mem_regions[i].free_head && ptr_laddr < s_mmu_ctx.mem_regions[i].end) {
@@ -789,15 +790,15 @@ esp_err_t esp_mmu_unmap(void *ptr)
 
     //do unmap
     s_do_unmapping(mem_block->vaddr_start, mem_block->size);
-    k_free(found_block);
+    esp_os_free(found_block);
 
-    k_mutex_unlock(&s_mmu_ctx.mutex);
+    esp_os_mutex_unlock(s_mmu_ctx.mutex);
 
     return ESP_OK;
 
 err:
 
-    k_mutex_unlock(&s_mmu_ctx.mutex);
+    esp_os_mutex_unlock(s_mmu_ctx.mutex);
     return ret;
 }
 
@@ -879,7 +880,7 @@ static bool s_vaddr_to_paddr(uint32_t vaddr, esp_paddr_t *out_paddr, mmu_target_
 {
     uint32_t mmu_id = 0;
 
-    k_mutex_lock(&s_mmu_ctx.mutex, K_FOREVER);
+    esp_os_mutex_lock(s_mmu_ctx.mutex, ESP_OS_FOREVER);
 
 #if SOC_MMU_PER_EXT_MEM_TARGET
     mmu_id = mmu_hal_get_id_from_vaddr(vaddr);
@@ -891,7 +892,7 @@ static bool s_vaddr_to_paddr(uint32_t vaddr, esp_paddr_t *out_paddr, mmu_target_
     }
 #endif
 
-    k_mutex_unlock(&s_mmu_ctx.mutex);
+    esp_os_mutex_unlock(s_mmu_ctx.mutex);
 
     return is_mapped;
 }
@@ -915,7 +916,7 @@ esp_err_t esp_mmu_vaddr_to_paddr(void *vaddr, esp_paddr_t *out_paddr, mmu_target
 
 static bool s_paddr_to_vaddr(esp_paddr_t paddr, mmu_target_t target, mmu_vaddr_t type, uint32_t *out_vaddr)
 {
-    k_mutex_lock(&s_mmu_ctx.mutex, K_FOREVER);
+    esp_os_mutex_lock(s_mmu_ctx.mutex, ESP_OS_FOREVER);
 
     uint32_t mmu_id = 0;
 #if SOC_MMU_PER_EXT_MEM_TARGET
@@ -923,7 +924,7 @@ static bool s_paddr_to_vaddr(esp_paddr_t paddr, mmu_target_t target, mmu_vaddr_t
 #endif
     bool found = mmu_hal_paddr_to_vaddr(mmu_id, paddr, target, type, out_vaddr);
 
-    k_mutex_unlock(&s_mmu_ctx.mutex);
+    esp_os_mutex_unlock(s_mmu_ctx.mutex);
 
     return found;
 }

--- a/components/esp_phy/include/esp_private/phy.h
+++ b/components/esp_phy/include/esp_private/phy.h
@@ -8,6 +8,7 @@
 #include "sdkconfig.h"
 #include "esp_phy_init.h"
 #include "soc/soc_caps.h"
+#include <esp_os.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -172,7 +173,7 @@ esp_phy_modem_t phy_get_modem_flag(void);
  * @brief Get the PHY lock, only used in esp_phy, the user should not use this function.
  *
  */
-struct k_mutex *phy_get_lock(void);
+esp_os_mutex_t phy_get_lock(void);
 
 /**
  * @brief Call this funnction to track pll immediately.

--- a/components/esp_phy/src/btbb_init.c
+++ b/components/esp_phy/src/btbb_init.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdint.h>
+#include <esp_os.h>
 #include "esp_check.h"
 #include "esp_log.h"
 #include "esp_private/btbb.h"
@@ -13,7 +14,7 @@
 
 #define BTBB_ENABLE_VERSION_PRINT 1
 
-K_MUTEX_DEFINE(s_btbb_access_lock);
+ESP_OS_MUTEX_DEFINE(s_btbb_access_lock);
 /* Reference count of enabling BT BB */
 static uint8_t s_btbb_access_ref = 0;
 
@@ -93,29 +94,29 @@ static esp_err_t btbb_sleep_retention_enable(void)
 
 void esp_btbb_enable(void)
 {
-    k_mutex_lock(&s_btbb_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_btbb_access_lock, ESP_OS_FOREVER);
     if (s_btbb_access_ref == 0) {
         bt_bb_v2_init_cmplx(BTBB_ENABLE_VERSION_PRINT);
 #if SOC_PM_MODEM_RETENTION_BY_REGDMA && CONFIG_FREERTOS_USE_TICKLESS_IDLE
         esp_err_t err = btbb_sleep_retention_enable();
         if (err != ESP_OK) {
             btbb_sleep_retention_disable();
-            k_mutex_unlock(&s_btbb_access_lock);
+            esp_os_mutex_unlock(s_btbb_access_lock);
             return;
         }
 #endif // SOC_PM_MODEM_RETENTION_BY_REGDMA && CONFIG_FREERTOS_USE_TICKLESS_IDLE
     }
     s_btbb_access_ref++;
-    k_mutex_unlock(&s_btbb_access_lock);
+    esp_os_mutex_unlock(s_btbb_access_lock);
 }
 
 void esp_btbb_disable(void)
 {
-    k_mutex_lock(&s_btbb_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_btbb_access_lock, ESP_OS_FOREVER);
     if (s_btbb_access_ref && (--s_btbb_access_ref == 0)) {
 #if SOC_PM_MODEM_RETENTION_BY_REGDMA && CONFIG_FREERTOS_USE_TICKLESS_IDLE
         btbb_sleep_retention_disable();
 #endif // SOC_PM_MODEM_RETENTION_BY_REGDMA && CONFIG_FREERTOS_USE_TICKLESS_IDLE
     }
-    k_mutex_unlock(&s_btbb_access_lock);
+    esp_os_mutex_unlock(s_btbb_access_lock);
 }

--- a/components/esp_phy/src/phy_common.c
+++ b/components/esp_phy/src/phy_common.c
@@ -19,6 +19,7 @@
 #include "esp_attr.h"
 
 #include <zephyr/kernel.h>
+#include <esp_os.h>
 
 #if SOC_PM_SUPPORT_PMU_MODEM_STATE && CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP
 #include "hal/temperature_sensor_ll.h"
@@ -113,10 +114,10 @@ static void phy_track_pll_internal(void)
 
 static void phy_track_pll_timer_callback(void* arg)
 {
-    struct k_mutex *phy_lock = phy_get_lock();
-    k_mutex_lock(phy_lock, K_FOREVER);
+    esp_os_mutex_t phy_lock = phy_get_lock();
+    esp_os_mutex_lock(phy_lock, ESP_OS_FOREVER);
     phy_track_pll_internal();
-    k_mutex_unlock(phy_lock);
+    esp_os_mutex_unlock(phy_lock);
 }
 
 void phy_track_pll_init(void)

--- a/components/esp_phy/src/phy_init.c
+++ b/components/esp_phy/src/phy_init.c
@@ -5,6 +5,7 @@
  */
 
 #include <stddef.h>
+#include <esp_os.h>
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
@@ -76,12 +77,12 @@ extern bool pm_get_wifimac_regdma_link_selection(void);
 
 static const char* TAG __attribute__((unused)) = "phy_init";
 
-K_MUTEX_DEFINE(s_phy_access_lock);
+ESP_OS_MUTEX_DEFINE(s_phy_access_lock);
 
 #if SOC_PM_SUPPORT_MODEM_PD || SOC_PM_SUPPORT_WIFI_PD
 #if SOC_PM_MODEM_PD_BY_SW // TODO: [ESP32C5] IDF-8667
 static DRAM_ATTR int s_wifi_bt_pd_count;
-K_MUTEX_DEFINE(s_wifi_bt_pd_lock);
+ESP_OS_MUTEX_DEFINE(s_wifi_bt_pd_lock);
 #endif // SOC_PM_MODEM_PD_BY_SW
 #endif // SOC_PM_SUPPORT_MODEM_PD || SOC_PM_SUPPORT_WIFI_PD
 
@@ -206,13 +207,13 @@ esp_err_t phy_query_used_time(uint64_t *used_time, esp_phy_modem_t modem) {
         return ESP_ERR_INVALID_ARG;
     }
     uint8_t index = __builtin_ctz(modem);
-    k_mutex_lock(&s_phy_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_phy_access_lock, ESP_OS_FOREVER);
     *used_time = s_phy_rf_used_info[index].used_time;
     if (s_phy_rf_used_info[index].disabled_time < s_phy_rf_used_info[index].enabled_time) {
         // phy is being used
         *used_time += esp_timer_get_time() - s_phy_rf_used_info[index].enabled_time;
     }
-    k_mutex_unlock(&s_phy_access_lock);
+    esp_os_mutex_unlock(s_phy_access_lock);
     return ESP_OK;
 }
 
@@ -221,7 +222,7 @@ esp_err_t phy_clear_used_time(esp_phy_modem_t modem) {
         return ESP_ERR_INVALID_ARG;
     }
     uint8_t index = __builtin_ctz(modem);
-    k_mutex_lock(&s_phy_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_phy_access_lock, ESP_OS_FOREVER);
     if (s_phy_rf_used_info[index].enabled_time > s_phy_rf_used_info[index].disabled_time) {
         // phy is being used
         s_phy_rf_used_info[index].enabled_time = esp_timer_get_time();
@@ -229,7 +230,7 @@ esp_err_t phy_clear_used_time(esp_phy_modem_t modem) {
         s_phy_rf_used_info[index].enabled_time = s_phy_rf_used_info[index].disabled_time;
     }
     s_phy_rf_used_info[index].used_time = 0;
-    k_mutex_unlock(&s_phy_access_lock);
+    esp_os_mutex_unlock(s_phy_access_lock);
     return ESP_OK;
 }
 #endif
@@ -312,7 +313,7 @@ void IRAM_ATTR esp_phy_modem_rf_flag_update(void)
 
 void esp_phy_enable(esp_phy_modem_t modem)
 {
-    k_mutex_lock(&s_phy_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_phy_access_lock, ESP_OS_FOREVER);
     if (phy_get_modem_flag() == 0) {
 #if CONFIG_IDF_TARGET_ESP32
         s_phy_rf_en_ts = esp_timer_get_time();
@@ -389,12 +390,12 @@ void esp_phy_enable(esp_phy_modem_t modem)
 #if CONFIG_ESP_PHY_RECORD_USED_TIME
     phy_record_time(true, modem);
 #endif
-    k_mutex_unlock(&s_phy_access_lock);
+    esp_os_mutex_unlock(s_phy_access_lock);
 }
 
 void esp_phy_disable(esp_phy_modem_t modem)
 {
-    k_mutex_lock(&s_phy_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_phy_access_lock, ESP_OS_FOREVER);
 #if CONFIG_ESP_PHY_RECORD_USED_TIME
     phy_record_time(false, modem);
 #endif
@@ -434,14 +435,14 @@ void esp_phy_disable(esp_phy_modem_t modem)
         // Disable WiFi/BT common peripheral clock. Do not disable clock for hardware RNG
         esp_phy_common_clock_disable();
     }
-    k_mutex_unlock(&s_phy_access_lock);
+    esp_os_mutex_unlock(s_phy_access_lock);
 }
 
 void IRAM_ATTR esp_wifi_bt_power_domain_on(void)
 {
 #if SOC_PM_SUPPORT_MODEM_PD || SOC_PM_SUPPORT_WIFI_PD
 #if SOC_PM_MODEM_PD_BY_SW // TODO: [ESP32C5] IDF-8667
-    k_mutex_lock(&s_wifi_bt_pd_lock, K_FOREVER);
+    esp_os_mutex_lock(s_wifi_bt_pd_lock, ESP_OS_FOREVER);
     if (s_wifi_bt_pd_count++ == 0) {
         RTC_CNTL_ATOMIC() {
             CLEAR_PERI_REG_MASK(RTC_CNTL_DIG_PWC_REG, RTC_CNTL_WIFI_FORCE_PD);
@@ -460,7 +461,7 @@ void IRAM_ATTR esp_wifi_bt_power_domain_on(void)
         }
         wifi_bt_common_module_disable();
     }
-    k_mutex_unlock(&s_wifi_bt_pd_lock);
+    esp_os_mutex_unlock(s_wifi_bt_pd_lock);
 #endif // SOC_PM_MODEM_PD_BY_SW
 #endif // SOC_PM_SUPPORT_MODEM_PD || SOC_PM_SUPPORT_WIFI_PD
 }
@@ -469,14 +470,14 @@ void esp_wifi_bt_power_domain_off(void)
 {
 #if SOC_PM_SUPPORT_MODEM_PD || SOC_PM_SUPPORT_WIFI_PD
 #if SOC_PM_MODEM_PD_BY_SW // TODO: [ESP32C5] IDF-8667
-    k_mutex_lock(&s_wifi_bt_pd_lock, K_FOREVER);
+    esp_os_mutex_lock(s_wifi_bt_pd_lock, ESP_OS_FOREVER);
     if (--s_wifi_bt_pd_count == 0) {
         RTC_CNTL_ATOMIC() {
             SET_PERI_REG_MASK(RTC_CNTL_DIG_ISO_REG, RTC_CNTL_WIFI_FORCE_ISO);
             SET_PERI_REG_MASK(RTC_CNTL_DIG_PWC_REG, RTC_CNTL_WIFI_FORCE_PD);
         }
     }
-    k_mutex_unlock(&s_wifi_bt_pd_lock);
+    esp_os_mutex_unlock(s_wifi_bt_pd_lock);
 #endif // SOC_PM_MODEM_PD_BY_SW
 #endif // SOC_PM_SUPPORT_MODEM_PD || SOC_PM_SUPPORT_WIFI_PD
 }
@@ -484,7 +485,7 @@ void esp_wifi_bt_power_domain_off(void)
 void esp_phy_modem_init(void)
 {
 #if SOC_PM_MODEM_RETENTION_BY_BACKUPDMA || CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP
-    k_mutex_lock(&s_phy_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_phy_access_lock, ESP_OS_FOREVER);
     s_phy_modem_init_ref++;
 #if SOC_PM_MODEM_RETENTION_BY_BACKUPDMA
     if (s_phy_digital_regs_mem == NULL) {
@@ -494,20 +495,20 @@ void esp_phy_modem_init(void)
 #if SOC_PM_SUPPORT_PMU_MODEM_STATE && CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP
     sleep_modem_wifi_modem_state_init();
 #endif // CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP
-    k_mutex_unlock(&s_phy_access_lock);
+    esp_os_mutex_unlock(s_phy_access_lock);
 #endif // SOC_PM_MODEM_RETENTION_BY_BACKUPDMA || CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP
 }
 
 void esp_phy_modem_deinit(void)
 {
 #if SOC_PM_MODEM_RETENTION_BY_BACKUPDMA || CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP
-    k_mutex_lock(&s_phy_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_phy_access_lock, ESP_OS_FOREVER);
 
     s_phy_modem_init_ref--;
     if (s_phy_modem_init_ref == 0) {
 #if SOC_PM_MODEM_RETENTION_BY_BACKUPDMA
         s_is_phy_reg_stored = false;
-        k_free(s_phy_digital_regs_mem);
+        esp_os_free(s_phy_digital_regs_mem);
         s_phy_digital_regs_mem = NULL;
         /* Fix the issue caused by the power domain off.
         * This issue is only on ESP32C3.
@@ -520,7 +521,7 @@ void esp_phy_modem_deinit(void)
         sleep_modem_wifi_modem_state_deinit();
 #endif // CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP
     }
-    k_mutex_unlock(&s_phy_access_lock);
+    esp_os_mutex_unlock(s_phy_access_lock);
 #endif // SOC_PM_MODEM_RETENTION_BY_BACKUPDMA || CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP
 }
 
@@ -538,12 +539,12 @@ void esp_mac_bb_pd_mem_init(void)
 #if SOC_PM_MODEM_RETENTION_BY_BACKUPDMA
     extern void esp_apb_backup_dma_lock_init(void);
     esp_apb_backup_dma_lock_init();
-    k_mutex_lock(&s_phy_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_phy_access_lock, ESP_OS_FOREVER);
     s_macbb_backup_mem_ref++;
     if (s_mac_bb_pd_mem == NULL) {
         s_mac_bb_pd_mem = (uint32_t *)heap_caps_malloc(SOC_MAC_BB_PD_MEM_SIZE, MALLOC_CAP_DMA|MALLOC_CAP_INTERNAL);
     }
-    k_mutex_unlock(&s_phy_access_lock);
+    esp_os_mutex_unlock(s_phy_access_lock);
 #elif SOC_PM_MODEM_RETENTION_BY_REGDMA
     esp_phy_sleep_data_init();
 #endif
@@ -552,13 +553,13 @@ void esp_mac_bb_pd_mem_init(void)
 void esp_mac_bb_pd_mem_deinit(void)
 {
 #if SOC_PM_MODEM_RETENTION_BY_BACKUPDMA
-    k_mutex_lock(&s_phy_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_phy_access_lock, ESP_OS_FOREVER);
     s_macbb_backup_mem_ref--;
     if (s_macbb_backup_mem_ref == 0) {
-        k_free(s_mac_bb_pd_mem);
+        esp_os_free(s_mac_bb_pd_mem);
         s_mac_bb_pd_mem = NULL;
     }
-    k_mutex_unlock(&s_phy_access_lock);
+    esp_os_mutex_unlock(s_phy_access_lock);
 #elif SOC_PM_MODEM_RETENTION_BY_REGDMA
     esp_phy_sleep_data_deinit();
 #endif
@@ -607,7 +608,7 @@ const esp_phy_init_data_t* esp_phy_get_init_data(void)
 #if CONFIG_ESP_PHY_MULTIPLE_INIT_DATA_BIN_EMBED
     size_t init_data_store_length = PHY_INIT_MAGIC_LEN +
             sizeof(esp_phy_init_data_t) + PHY_INIT_MAGIC_LEN;
-    uint8_t* init_data_store = (uint8_t*) k_malloc(init_data_store_length);
+    uint8_t* init_data_store = (uint8_t*) esp_os_malloc(init_data_store_length);
     if (init_data_store == NULL) {
         ESP_LOGE(TAG, "failed to allocate memory for updated country code PHY init data");
         return NULL;
@@ -624,7 +625,7 @@ const esp_phy_init_data_t* esp_phy_get_init_data(void)
     ESP_LOGD(TAG, "loading PHY init data from partition at offset 0x%" PRIx32 "", partition->address);
     size_t init_data_store_length = PHY_INIT_MAGIC_LEN +
             sizeof(esp_phy_init_data_t) + PHY_INIT_MAGIC_LEN;
-    uint8_t* init_data_store = (uint8_t*) k_malloc(init_data_store_length);
+    uint8_t* init_data_store = (uint8_t*) esp_os_malloc(init_data_store_length);
     if (init_data_store == NULL) {
         ESP_LOGE(TAG, "failed to allocate memory for PHY init data");
         return NULL;
@@ -633,7 +634,7 @@ const esp_phy_init_data_t* esp_phy_get_init_data(void)
     esp_err_t err = esp_partition_read(partition, 0, init_data_store, init_data_store_length);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "failed to read PHY data partition (0x%x)", err);
-        k_free(init_data_store);
+        esp_os_free(init_data_store);
         return NULL;
     }
 #endif
@@ -643,12 +644,12 @@ const esp_phy_init_data_t* esp_phy_get_init_data(void)
                 PHY_INIT_MAGIC, PHY_INIT_MAGIC_LEN) != 0) {
 #if CONFIG_ESP_PHY_MULTIPLE_INIT_DATA_BIN_EMBED
         ESP_LOGE(TAG, "failed to validate embedded PHY init data");
-        k_free(init_data_store);
+        esp_os_free(init_data_store);
         return NULL;
 #else
 #ifndef CONFIG_ESP_PHY_DEFAULT_INIT_IF_INVALID
         ESP_LOGE(TAG, "failed to validate PHY data partition");
-        k_free(init_data_store);
+        esp_os_free(init_data_store);
         return NULL;
 #else
         ESP_LOGE(TAG, "failed to validate PHY data partition, restoring default data into flash...");
@@ -667,7 +668,7 @@ const esp_phy_init_data_t* esp_phy_get_init_data(void)
         err = esp_partition_erase_range(partition, 0, partition->size);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "failed to erase partition (0x%x)!", err);
-            k_free(init_data_store);
+            esp_os_free(init_data_store);
             return NULL;
         }
 
@@ -675,7 +676,7 @@ const esp_phy_init_data_t* esp_phy_get_init_data(void)
         err = esp_partition_write(partition, 0, init_data_store, init_data_store_length);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "failed to write default PHY data partition (0x%x)", err);
-            k_free(init_data_store);
+            esp_os_free(init_data_store);
             return NULL;
         }
 #endif // CONFIG_ESP_PHY_DEFAULT_INIT_IF_INVALID
@@ -695,7 +696,7 @@ const esp_phy_init_data_t* esp_phy_get_init_data(void)
 
 void esp_phy_release_init_data(const esp_phy_init_data_t* init_data)
 {
-    k_free((uint8_t*) init_data - PHY_INIT_MAGIC_LEN);
+    esp_os_free((uint8_t*) init_data - PHY_INIT_MAGIC_LEN);
 }
 
 #else // CONFIG_ESP_PHY_INIT_DATA_IN_PARTITION
@@ -895,7 +896,7 @@ void esp_phy_load_cal_and_init(void)
 #endif
 
     esp_phy_calibration_data_t* cal_data =
-            (esp_phy_calibration_data_t*) k_calloc(1, sizeof(esp_phy_calibration_data_t));
+            (esp_phy_calibration_data_t*) esp_os_calloc(1, sizeof(esp_phy_calibration_data_t));
     if (cal_data == NULL) {
         abort();
     }
@@ -906,7 +907,7 @@ void esp_phy_load_cal_and_init(void)
         abort();
     }
 
-    esp_phy_init_data_t* init_data = (esp_phy_init_data_t*) k_malloc(sizeof(esp_phy_init_data_t));
+    esp_phy_init_data_t* init_data = (esp_phy_init_data_t*) esp_os_malloc(sizeof(esp_phy_init_data_t));
     if (init_data == NULL) {
         abort();
     }
@@ -961,7 +962,7 @@ void esp_phy_load_cal_and_init(void)
 
 #if CONFIG_ESP_PHY_REDUCE_TX_POWER
     esp_phy_release_init_data(phy_init_data);
-    k_free(init_data);
+    esp_os_free(init_data);
 #else
     esp_phy_release_init_data(init_data);
 #endif
@@ -974,7 +975,7 @@ void esp_phy_load_cal_and_init(void)
 #endif
 #endif
 
-    k_free(cal_data); /* PHY maintains a copy of calibration data, so we can free this */
+    esp_os_free(cal_data); /* PHY maintains a copy of calibration data, so we can free this */
 }
 
 #if CONFIG_ESP_PHY_MULTIPLE_INIT_DATA_BIN
@@ -1038,7 +1039,7 @@ static esp_err_t phy_get_multiple_init_data(const esp_partition_t* partition,
         size_t init_data_store_length,
         phy_init_data_type_t init_data_type)
 {
-    phy_control_info_data_t* init_data_control_info = (phy_control_info_data_t*) k_malloc(sizeof(phy_control_info_data_t));
+    phy_control_info_data_t* init_data_control_info = (phy_control_info_data_t*) esp_os_malloc(sizeof(phy_control_info_data_t));
     if (init_data_control_info == NULL) {
         ESP_LOGE(TAG, "failed to allocate memory for PHY init data control info");
         return ESP_FAIL;
@@ -1049,7 +1050,7 @@ static esp_err_t phy_get_multiple_init_data(const esp_partition_t* partition,
 #else
     err = esp_partition_read(partition, init_data_store_length, init_data_control_info, sizeof(phy_control_info_data_t));
     if (err != ESP_OK) {
-        k_free(init_data_control_info);
+        esp_os_free(init_data_control_info);
         ESP_LOGE(TAG, "failed to read PHY control info data partition (0x%x)", err);
         return ESP_FAIL;
     }
@@ -1058,19 +1059,19 @@ static esp_err_t phy_get_multiple_init_data(const esp_partition_t* partition,
         err =  phy_crc_check_init_data(init_data_control_info->multiple_bin_checksum, init_data_control_info->control_info_checksum,
                 sizeof(phy_control_info_data_t) - sizeof(init_data_control_info->control_info_checksum));
         if (err != ESP_OK) {
-            k_free(init_data_control_info);
+            esp_os_free(init_data_control_info);
             ESP_LOGE(TAG, "PHY init data control info check error");
             return ESP_FAIL;
         }
     } else {
-        k_free(init_data_control_info);
+        esp_os_free(init_data_control_info);
         ESP_LOGE(TAG, "Check algorithm not CRC, PHY init data update failed");
         return ESP_FAIL;
     }
 
-    uint8_t* init_data_multiple = (uint8_t*) k_malloc(sizeof(esp_phy_init_data_t) * init_data_control_info->number);
+    uint8_t* init_data_multiple = (uint8_t*) esp_os_malloc(sizeof(esp_phy_init_data_t) * init_data_control_info->number);
     if (init_data_multiple == NULL) {
-        k_free(init_data_control_info);
+        esp_os_free(init_data_control_info);
         ESP_LOGE(TAG, "failed to allocate memory for PHY init data multiple bin");
         return ESP_FAIL;
     }
@@ -1081,8 +1082,8 @@ static esp_err_t phy_get_multiple_init_data(const esp_partition_t* partition,
     err = esp_partition_read(partition, init_data_store_length + sizeof(phy_control_info_data_t),
             init_data_multiple, sizeof(esp_phy_init_data_t) * init_data_control_info->number);
     if (err != ESP_OK) {
-        k_free(init_data_multiple);
-        k_free(init_data_control_info);
+        esp_os_free(init_data_multiple);
+        esp_os_free(init_data_control_info);
         ESP_LOGE(TAG, "failed to read PHY init data multiple bin partition (0x%x)", err);
         return ESP_FAIL;
     }
@@ -1091,14 +1092,14 @@ static esp_err_t phy_get_multiple_init_data(const esp_partition_t* partition,
         err = phy_crc_check_init_data(init_data_multiple, init_data_control_info->multiple_bin_checksum,
                 sizeof(esp_phy_init_data_t) * init_data_control_info->number);
         if (err != ESP_OK) {
-            k_free(init_data_multiple);
-            k_free(init_data_control_info);
+            esp_os_free(init_data_multiple);
+            esp_os_free(init_data_control_info);
             ESP_LOGE(TAG, "PHY init data multiple bin check error");
             return ESP_FAIL;
         }
     } else {
-        k_free(init_data_multiple);
-        k_free(init_data_control_info);
+        esp_os_free(init_data_multiple);
+        esp_os_free(init_data_control_info);
         ESP_LOGE(TAG, "Check algorithm not CRC, PHY init data update failed");
         return ESP_FAIL;
     }
@@ -1111,8 +1112,8 @@ static esp_err_t phy_get_multiple_init_data(const esp_partition_t* partition,
         s_phy_init_data_type = init_data_type;
     }
 
-    k_free(init_data_multiple);
-    k_free(init_data_control_info);
+    esp_os_free(init_data_multiple);
+    esp_os_free(init_data_control_info);
     return ESP_OK;
 }
 
@@ -1123,7 +1124,7 @@ esp_err_t esp_phy_update_init_data(phy_init_data_type_t init_data_type)
     const esp_partition_t* partition = NULL;
     size_t init_data_store_length = PHY_INIT_MAGIC_LEN +
         sizeof(esp_phy_init_data_t) + PHY_INIT_MAGIC_LEN;
-    uint8_t* init_data_store = (uint8_t*) k_malloc(init_data_store_length);
+    uint8_t* init_data_store = (uint8_t*) esp_os_malloc(init_data_store_length);
     if (init_data_store == NULL) {
         ESP_LOGE(TAG, "failed to allocate memory for updated country code PHY init data");
         return ESP_ERR_NO_MEM;
@@ -1139,7 +1140,7 @@ esp_err_t esp_phy_update_init_data(phy_init_data_type_t init_data_type)
     }
     size_t init_data_store_length = PHY_INIT_MAGIC_LEN +
         sizeof(esp_phy_init_data_t) + PHY_INIT_MAGIC_LEN;
-    uint8_t* init_data_store = (uint8_t*) k_malloc(init_data_store_length);
+    uint8_t* init_data_store = (uint8_t*) esp_os_malloc(init_data_store_length);
     if (init_data_store == NULL) {
         ESP_LOGE(TAG, "failed to allocate memory for updated country code PHY init data");
         return ESP_ERR_NO_MEM;
@@ -1147,7 +1148,7 @@ esp_err_t esp_phy_update_init_data(phy_init_data_type_t init_data_type)
 
     esp_err_t err = esp_partition_read(partition, 0, init_data_store, init_data_store_length);
     if (err != ESP_OK) {
-        k_free(init_data_store);
+        esp_os_free(init_data_store);
         ESP_LOGE(TAG, "failed to read updated country code PHY data partition (0x%x)", err);
         return ESP_FAIL;
     }
@@ -1155,7 +1156,7 @@ esp_err_t esp_phy_update_init_data(phy_init_data_type_t init_data_type)
     if (memcmp(init_data_store, PHY_INIT_MAGIC, PHY_INIT_MAGIC_LEN) != 0 ||
             memcmp(init_data_store + init_data_store_length - PHY_INIT_MAGIC_LEN,
                 PHY_INIT_MAGIC, PHY_INIT_MAGIC_LEN) != 0) {
-        k_free(init_data_store);
+        esp_os_free(init_data_store);
         ESP_LOGE(TAG, "failed to validate updated country code PHY data partition");
         return ESP_FAIL;
     }
@@ -1164,7 +1165,7 @@ esp_err_t esp_phy_update_init_data(phy_init_data_type_t init_data_type)
     if (init_data_type != ESP_PHY_INIT_DATA_TYPE_DEFAULT) {
         err = phy_get_multiple_init_data(partition, init_data_store, init_data_store_length, init_data_type);
         if (err != ESP_OK) {
-            k_free(init_data_store);
+            esp_os_free(init_data_store);
 #if CONFIG_ESP_PHY_INIT_DATA_ERROR
             abort();
 #else
@@ -1179,7 +1180,7 @@ esp_err_t esp_phy_update_init_data(phy_init_data_type_t init_data_type)
         err = esp_phy_apply_phy_init_data(init_data_store + PHY_INIT_MAGIC_LEN);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "PHY init data failed to load");
-            k_free(init_data_store);
+            esp_os_free(init_data_store);
             return ESP_FAIL;
         }
 
@@ -1188,7 +1189,7 @@ esp_err_t esp_phy_update_init_data(phy_init_data_type_t init_data_type)
         s_current_apply_phy_init_data = s_phy_init_data_type;
     }
 
-    k_free(init_data_store);
+    esp_os_free(init_data_store);
     return ESP_OK;
 }
 #endif
@@ -1226,7 +1227,7 @@ esp_err_t esp_phy_update_country_info(const char *country)
 void esp_wifi_power_domain_on(void) __attribute__((alias("esp_wifi_bt_power_domain_on")));
 void esp_wifi_power_domain_off(void) __attribute__((alias("esp_wifi_bt_power_domain_off")));
 
-struct k_mutex *phy_get_lock(void)
+esp_os_mutex_t phy_get_lock(void)
 {
-    return &s_phy_access_lock;
+    return s_phy_access_lock;
 }

--- a/components/esp_phy/src/phy_init_esp32hxx.c
+++ b/components/esp_phy/src/phy_init_esp32hxx.c
@@ -5,6 +5,7 @@
  */
 
 #include "esp_attr.h"
+#include <esp_os.h>
 #include <zephyr/kernel.h>
 #include "esp_phy_init.h"
 #include "esp_private/phy.h"
@@ -28,7 +29,7 @@
 static DRAM_ATTR esp_os_spinlock_t s_phy_int_mux = ESP_OS_SPINLOCK_INIT;
 
 extern void phy_version_print(void);
-K_MUTEX_DEFINE(s_phy_access_lock);
+ESP_OS_MUTEX_DEFINE(s_phy_access_lock);
 
 /* Reference count of enabling PHY */
 static bool s_phy_is_enabled = false;
@@ -58,13 +59,13 @@ esp_err_t phy_query_used_time(uint64_t *used_time, esp_phy_modem_t modem) {
         return ESP_ERR_INVALID_ARG;
     }
     uint8_t index = __builtin_ctz(modem);
-    k_mutex_lock(&s_phy_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_phy_access_lock, ESP_OS_FOREVER);
     *used_time = s_phy_rf_used_info[index].used_time;
     if (s_phy_rf_used_info[index].disabled_time < s_phy_rf_used_info[index].enabled_time) {
         // phy is being used
         *used_time += esp_timer_get_time() - s_phy_rf_used_info[index].enabled_time;
     }
-    k_mutex_unlock(&s_phy_access_lock);
+    esp_os_mutex_unlock(s_phy_access_lock);
     return ESP_OK;
 }
 
@@ -73,7 +74,7 @@ esp_err_t phy_clear_used_time(esp_phy_modem_t modem) {
         return ESP_ERR_INVALID_ARG;
     }
     uint8_t index = __builtin_ctz(modem);
-    k_mutex_lock(&s_phy_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_phy_access_lock, ESP_OS_FOREVER);
     if (s_phy_rf_used_info[index].enabled_time > s_phy_rf_used_info[index].disabled_time) {
         // phy is being used
         s_phy_rf_used_info[index].enabled_time = esp_timer_get_time();
@@ -81,7 +82,7 @@ esp_err_t phy_clear_used_time(esp_phy_modem_t modem) {
         s_phy_rf_used_info[index].enabled_time = s_phy_rf_used_info[index].disabled_time;
     }
     s_phy_rf_used_info[index].used_time = 0;
-    k_mutex_unlock(&s_phy_access_lock);
+    esp_os_mutex_unlock(s_phy_access_lock);
     return ESP_OK;
 }
 #endif
@@ -100,7 +101,7 @@ void IRAM_ATTR phy_exit_critical(uint32_t level)
 
 void esp_phy_enable(esp_phy_modem_t modem)
 {
-    k_mutex_lock(&s_phy_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_phy_access_lock, ESP_OS_FOREVER);
     if (phy_get_modem_flag() == 0) {
 #if SOC_MODEM_CLOCK_IS_INDEPENDENT
         modem_clock_module_enable(PERIPH_PHY_MODULE);
@@ -132,12 +133,12 @@ void esp_phy_enable(esp_phy_modem_t modem)
 #if CONFIG_ESP_PHY_RECORD_USED_TIME
     phy_record_time(true, modem);
 #endif
-    k_mutex_unlock(&s_phy_access_lock);
+    esp_os_mutex_unlock(s_phy_access_lock);
 }
 
 void esp_phy_disable(esp_phy_modem_t modem)
 {
-    k_mutex_lock(&s_phy_access_lock, K_FOREVER);
+    esp_os_mutex_lock(s_phy_access_lock, ESP_OS_FOREVER);
 #if CONFIG_ESP_PHY_RECORD_USED_TIME
     phy_record_time(false, modem);
 #endif
@@ -155,10 +156,10 @@ void esp_phy_disable(esp_phy_modem_t modem)
         modem_clock_module_disable(PERIPH_PHY_MODULE);
 #endif
     }
-    k_mutex_unlock(&s_phy_access_lock);
+    esp_os_mutex_unlock(s_phy_access_lock);
 }
 
-struct k_mutex *phy_get_lock(void)
+esp_os_mutex_t phy_get_lock(void)
 {
-    return &s_phy_access_lock;
+    return s_phy_access_lock;
 }

--- a/components/esp_timer/src/esp_timer.c
+++ b/components/esp_timer/src/esp_timer.c
@@ -24,6 +24,7 @@
 #include "sdkconfig.h"
 
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+#include <esp_os.h>
 
 #ifdef CONFIG_ESP_TIMER_PROFILING
 #define WITH_PROFILING 1
@@ -89,11 +90,10 @@ static LIST_HEAD(esp_inactive_timer_list, esp_timer) s_inactive_timers[ESP_TIMER
 };
 #endif
 
-K_KERNEL_STACK_MEMBER(timer_task_stack, CONFIG_ESP32_TIMER_TASK_STACK_SIZE);
-// task used to dispatch timer callbacks
-static struct k_thread s_timer_task;
+/* handle for the timer dispatch task */
+static esp_os_thread_t s_timer_task_handle;
 /* counting semaphore used to notify the timer task from ISR */
-static struct k_sem s_timer_semaphore;
+static esp_os_sem_t s_timer_semaphore;
 static bool s_timer_task_created = false;
 
 /* lock key for critical sections */
@@ -116,7 +116,7 @@ esp_err_t esp_timer_create(const esp_timer_create_args_t* args,
             args->dispatch_method < 0 || args->dispatch_method >= ESP_TIMER_MAX) {
         return ESP_ERR_INVALID_ARG;
     }
-    esp_timer_handle_t result = (esp_timer_handle_t) k_calloc(1, sizeof(*result));
+    esp_timer_handle_t result = (esp_timer_handle_t) esp_os_calloc(1, sizeof(*result));
     if (result == NULL) {
         return ESP_ERR_NO_MEM;
     }
@@ -326,11 +326,11 @@ esp_err_t esp_timer_stop_blocking(esp_timer_handle_t timer, uint32_t timeout_tic
          */
 
         // In ISR context: do not wait to avoid blocking
-        if (k_is_in_isr()) {
+        if (esp_os_is_in_isr()) {
             return ESP_ERR_NOT_FINISHED;
         }
 
-        if (k_current_get() == &s_timer_task) {
+        if (esp_os_thread_current() == s_timer_task_handle) {
             /*
              * Called from the esp_timer task context (i.e., the callback owner is a TASK-dispatch timer).
              * Concurrency model:
@@ -356,15 +356,15 @@ esp_err_t esp_timer_stop_blocking(esp_timer_handle_t timer, uint32_t timeout_tic
             return ESP_ERR_NOT_FINISHED;
         }
 
-        int64_t start_time = k_uptime_get();
+        int64_t start_time = esp_os_uptime_ms();
         while (is_callback_running(timer, dispatch_method)) {
-            if (timeout_ticks != K_FOREVER.ticks) {
-                int64_t elapsed = k_uptime_get() - start_time;
-                if (elapsed >= k_ticks_to_ms_floor64(timeout_ticks)) {
+            if (timeout_ticks != ESP_OS_TICKS_FOREVER) {
+                int64_t elapsed = esp_os_uptime_ms() - start_time;
+                if (elapsed >= esp_os_ticks_to_ms(timeout_ticks)) {
                     return ESP_ERR_TIMEOUT;
                 }
             }
-            k_sleep(K_MSEC(1));
+            esp_os_sleep_ms(1);
         }
     }
 
@@ -512,7 +512,7 @@ static bool timer_process_alarm(esp_timer_dispatch_t dispatch_method)
             // It is handled only by ESP_TIMER_TASK (see esp_timer_delete()).
             // All the ESP_TIMER_ISR timers which should be deleted are moved by esp_timer_delete() to the ESP_TIMER_TASK list.
             // We want to free memory of the timer in a task context instead of an isr context.
-            k_free(it);
+            esp_os_free(it);
             it = NULL;
         } else {
             it->flags |= FL_CALLBACK_IS_RUNNING;
@@ -568,8 +568,8 @@ static void timer_task(void *p1, void *p2, void *p3)
     ARG_UNUSED(p3);
 
     while (true) {
-        k_sem_take(&s_timer_semaphore, K_FOREVER);
-        // all deferred events are processed at a time
+        esp_os_sem_take(s_timer_semaphore, ESP_OS_FOREVER);
+        /* all deferred events are processed at a time */
         timer_process_alarm(ESP_TIMER_TASK);
     }
 }
@@ -577,7 +577,7 @@ static void timer_task(void *p1, void *p2, void *p3)
 #ifdef CONFIG_ESP_TIMER_SUPPORTS_ISR_DISPATCH_METHOD
 ESP_TIMER_IRAM_ATTR void esp_timer_isr_dispatch_need_yield(void)
 {
-    __ASSERT(k_is_in_isr(), "esp_timer_isr_dispatch_need_yield must be called from ISR context");
+    __ASSERT(esp_os_is_in_isr(), "esp_timer_isr_dispatch_need_yield must be called from ISR context");
     s_isr_dispatch_need_yield = true;
 }
 #endif
@@ -595,7 +595,7 @@ static void ESP_TIMER_IRAM_ATTR timer_alarm_handler(void *arg)
 #endif
 
     if (isr_timers_processed == false) {
-        k_sem_give(&s_timer_semaphore);
+        esp_os_sem_give(s_timer_semaphore);
     }
 }
 
@@ -611,13 +611,11 @@ static esp_err_t init_timer_task(void)
         ESP_EARLY_LOGE(TAG, "Task is already initialized");
         err = ESP_ERR_INVALID_STATE;
     } else {
-        k_sem_init(&s_timer_semaphore, 0, 1);
+        s_timer_semaphore = esp_os_sem_create(0, 1);
 
-        k_thread_create(&s_timer_task, timer_task_stack,
-                        CONFIG_ESP32_TIMER_TASK_STACK_SIZE,
-                        timer_task, NULL, NULL, NULL,
-                        K_PRIO_PREEMPT(CONFIG_ESP32_TIMER_TASK_PRIO), 0, K_NO_WAIT);
-        k_thread_name_set(&s_timer_task, "esp_timer");
+        s_timer_task_handle = esp_os_thread_create(
+            (esp_os_thread_entry_t)timer_task, NULL, CONFIG_ESP32_TIMER_TASK_STACK_SIZE,
+            K_PRIO_PREEMPT(CONFIG_ESP32_TIMER_TASK_PRIO), "esp_timer");
         s_timer_task_created = true;
     }
     return err;
@@ -626,7 +624,7 @@ static esp_err_t init_timer_task(void)
 static void deinit_timer_task(void)
 {
     if (s_timer_task_created) {
-        k_thread_abort(&s_timer_task);
+        esp_os_thread_delete(s_timer_task_handle);
         s_timer_task_created = false;
     }
 }
@@ -734,7 +732,7 @@ esp_err_t esp_timer_dump(FILE* stream)
      * slightly more and the output will be truncated if that is not enough.
      */
     size_t buf_size = TIMER_INFO_LINE_LEN * (timer_count + 3);
-    char* print_buf = k_calloc(1, buf_size + 1);
+    char* print_buf = esp_os_calloc(1, buf_size + 1);
     if (print_buf == NULL) {
         return ESP_ERR_NO_MEM;
     }
@@ -767,7 +765,7 @@ esp_err_t esp_timer_dump(FILE* stream)
         fputs(print_buf, stream);
     }
 
-    k_free(print_buf);
+    esp_os_free(print_buf);
     return ESP_OK;
 }
 

--- a/components/esp_wifi/esp32/esp_adapter.c
+++ b/components/esp_wifi/esp32/esp_adapter.c
@@ -16,6 +16,7 @@
 #include <zephyr/random/random.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 
 #define CONFIG_POSIX_FS
 
@@ -47,17 +48,6 @@
 LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #define TAG "esp_adapter"
-
-struct wifi_task {
-    struct k_thread thread;
-    k_thread_stack_t *stack;
-    struct k_work cleanup_work;
-};
-
-struct wifi_adapter_msgq {
-    struct k_msgq msgq;
-    void *buffer;
-};
 
 #ifdef CONFIG_PM
 extern void wifi_apb80m_request(void);
@@ -110,20 +100,6 @@ static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
     return wifi_calloc(1, size);
 }
 
-static void wifi_task_cleanup_work(struct k_work *work)
-{
-    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
-
-    k_thread_join(&t->thread, K_FOREVER);
-    if (t->thread.custom_data) {
-        esp_wifi_free_func(t->thread.custom_data);
-    }
-
-    k_thread_stack_free(t->stack);
-    k_object_release(&t->thread);
-    esp_wifi_free_func(t);
-}
-
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 {
     wifi_static_queue_t *queue = NULL;
@@ -134,22 +110,13 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
         return NULL;
     }
 
-    queue->storage = wifi_malloc(queue_len * item_size);
-    if (queue->storage == NULL) {
-        LOG_ERR("msg buffer allocation failed");
-        esp_wifi_free(queue);
-        return NULL;
-    }
-
-    queue->handle = wifi_malloc(sizeof(struct k_msgq));
+    queue->storage = NULL;
+    queue->handle = esp_os_queue_create(queue_len, item_size);
     if (queue->handle == NULL) {
-        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
         LOG_ERR("queue handle allocation failed");
         return NULL;
     }
-
-    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
 }
@@ -157,8 +124,7 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
-        esp_wifi_free(queue->handle);
-        esp_wifi_free(queue->storage);
+        esp_os_queue_delete(queue->handle);
         esp_wifi_free(queue);
     }
 }
@@ -184,138 +150,106 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-    irq_disable(n);
-    irq_connect_dynamic(n, 0, f, arg, 0);
-    irq_enable(n);
+    esp_os_irq_disable(n);
+    esp_os_irq_connect(n, 0, f, arg, 0);
+    esp_os_irq_enable(n);
 }
 
 static void intr_on(unsigned int mask)
 {
-    irq_enable(__builtin_ctz(mask));
+    esp_os_irq_enable(__builtin_ctz(mask));
 }
 
 static void intr_off(unsigned int mask)
 {
-    irq_disable(__builtin_ctz(mask));
+    esp_os_irq_disable(__builtin_ctz(mask));
 }
 
 static void *wifi_thread_semphr_get_wrapper(void)
 {
-    struct k_sem *sem = NULL;
+    esp_os_sem_t sem = esp_os_thread_custom_data_get();
 
-    sem = k_thread_custom_data_get();
     if (!sem) {
-        sem = (struct k_sem *) wifi_malloc(sizeof(struct k_sem));
+        sem = esp_os_sem_create(0, 1);
         if (sem == NULL) {
             LOG_ERR("wifi_thread_semphr_get_wrapper allocation failed");
+            return NULL;
         }
-        k_sem_init(sem, 0, 1);
-        if (sem) {
-            k_thread_custom_data_set(sem);
-        }
+        esp_os_thread_custom_data_set(sem);
     }
     return (void *)sem;
 }
 
 static void *recursive_mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *) wifi_malloc(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("recursive_mutex_create_wrapper allocation failed");
+        return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return (void *)my_mutex;
+    return (void *)mutex;
 }
 
 static void *mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *) wifi_malloc(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("mutex_create_wrapper allocation failed");
+        return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return (void *)my_mutex;
+    return (void *)mutex;
 }
 
 static void mutex_delete_wrapper(void *mutex)
 {
-    esp_wifi_free(mutex);
+    esp_os_mutex_delete(mutex);
 }
 
 static int32_t IRAM_ATTR mutex_lock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *) mutex;
-
-    k_mutex_lock(my_mutex, K_FOREVER);
+    esp_os_mutex_lock(mutex, ESP_OS_FOREVER);
     return 0;
 }
 
 static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *) mutex;
-
-    k_mutex_unlock(my_mutex);
+    esp_os_mutex_unlock(mutex);
     return 0;
 }
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
+    esp_os_queue_t queue = esp_os_queue_create(queue_len, item_size);
 
     if (queue == NULL) {
         LOG_ERR("queue malloc failed");
         return NULL;
     }
 
-    queue->buffer = wifi_malloc(queue_len * item_size);
-    if (queue->buffer == NULL) {
-        LOG_ERR("queue buffer malloc failed");
-        esp_wifi_free(queue);
-        return NULL;
-    }
-
-    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
-
     return (void *)queue;
 }
 
 static void queue_delete_wrapper(void *handle)
 {
-    if (handle != NULL) {
-        struct wifi_adapter_msgq *queue = handle;
-
-        esp_wifi_free(queue->buffer);
-        esp_wifi_free(queue);
-    }
+    esp_os_queue_delete(handle);
 }
 
 static void task_delete_wrapper(void *handle)
 {
-    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
-    struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
+    esp_os_thread_delete((esp_os_thread_t)handle);
+}
 
-    if (tid == k_current_get()) {
-        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
-        k_work_submit(&t->cleanup_work);
-        k_thread_abort(k_current_get());
-        CODE_UNREACHABLE;
+static uint32_t queue_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
     }
 
-    k_thread_abort(tid);
-
-    if (tid->custom_data) {
-        esp_wifi_free(tid->custom_data);
-    }
-    
-    k_thread_stack_free(t->stack);
-    k_object_release(tid);
-    esp_wifi_free(t);
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
 }
 
 static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
@@ -327,12 +261,7 @@ static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_send(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -347,8 +276,7 @@ static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, v
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
+    ret = esp_os_queue_send(handle, item, ESP_OS_NO_WAIT);
     if (hpt) {
         *hpt = 0;
     }
@@ -371,8 +299,7 @@ static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t bl
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put_front(&queue->msgq, item);
+    ret = esp_os_queue_send_to_front(handle, item);
 
     return ret == 0 ? 1 : 0;
 }
@@ -386,12 +313,7 @@ static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_recv(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -403,8 +325,7 @@ static uint32_t queue_msg_waiting_wrapper(void *handle)
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    return k_msgq_num_used_get(&queue->msgq);
+    return esp_os_queue_num_used(handle);
 }
 
 static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
@@ -418,24 +339,12 @@ static int32_t task_create_pinned_to_core_wrapper(void *task_func, const char *n
     ARG_UNUSED(core_id);
 
     uint32_t stack_size = MAX(stack_depth, CONFIG_ESP32_WIFI_TASK_STACK_SIZE);
-    struct wifi_task *t = wifi_malloc(sizeof(*t));
+    esp_os_thread_t tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+                                               stack_size, prio, name);
 
-    if (t == NULL) {
+    if (tid == NULL) {
         return 0;
     }
-
-    t->stack = k_thread_stack_alloc(stack_size,
-                                    IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0);
-    if (t->stack == NULL) {
-        esp_wifi_free(t);
-        return 0;
-    }
-
-    k_tid_t tid = k_thread_create(&t->thread, t->stack, stack_size,
-                      (k_thread_entry_t)task_func, param, NULL, NULL,
-                      prio, K_INHERIT_PERMS, K_NO_WAIT);
-
-    k_thread_name_set(tid, name);
 
     *(int32_t *)task_handle = (int32_t)tid;
     return 1;
@@ -448,7 +357,7 @@ static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t s
 
 static int32_t IRAM_ATTR task_ms_to_tick_wrapper(uint32_t ms)
 {
-    return (int32_t)(k_ms_to_ticks_ceil32(ms));
+    return esp_os_ms_to_ticks(ms);
 }
 
 static int32_t task_get_max_priority_wrapper(void)
@@ -514,12 +423,12 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-    return k_calloc(n, size);
+    return esp_os_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-    return k_calloc(1, size);
+    return esp_os_calloc(1, size);
 }
 
 void *xEventGroupCreate(void)
@@ -544,7 +453,7 @@ uint32_t xEventGroupClearBits(void *ptr, uint32_t data)
 
 void task_delay(uint32_t ticks)
 {
-    k_sleep(K_TICKS(ticks));
+    esp_os_sleep_ticks(ticks);
 }
 
 uint32_t esp_get_free_heap_size(void)
@@ -855,7 +764,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._set_isr = set_isr_wrapper,
     ._ints_on = intr_on,
     ._ints_off = intr_off,
-    ._is_from_isr = k_is_in_isr,
+    ._is_from_isr = esp_os_is_in_isr,
     ._spin_lock_create = esp_coex_common_spin_lock_create_wrapper,
     ._spin_lock_delete = esp_wifi_free,
     ._wifi_int_disable = esp_coex_common_int_disable_wrapper,
@@ -889,7 +798,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._task_delete = task_delete_wrapper,
     ._task_delay = task_delay,
     ._task_ms_to_tick = task_ms_to_tick_wrapper,
-    ._task_get_current_task = (void *(*)(void))k_current_get,
+    ._task_get_current_task = esp_os_thread_current,
     ._task_get_max_priority = task_get_max_priority_wrapper,
     ._malloc = wifi_malloc,
     ._free = esp_wifi_free,
@@ -934,7 +843,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._random = random,
     ._log_write = esp_log_write_wrapper,
     ._log_writev = esp_log_writev_wrapper,
-    ._log_timestamp = k_uptime_get_32,
+    ._log_timestamp = esp_os_uptime_ms32,
     ._malloc_internal = esp_coex_common_malloc_internal_wrapper,
     ._realloc_internal = realloc_internal_wrapper,
     ._calloc_internal = calloc_internal_wrapper,

--- a/components/esp_wifi/esp32c2/esp_adapter.c
+++ b/components/esp_wifi/esp32c2/esp_adapter.c
@@ -14,6 +14,7 @@
 #include <zephyr/random/random.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 LOG_MODULE_REGISTER(esp32c2_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include "esp_types.h"
@@ -40,17 +41,6 @@ LOG_MODULE_REGISTER(esp32c2_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 #include <riscv/interrupt.h>
 
 #define TAG "esp_adapter"
-
-struct wifi_task {
-    struct k_thread thread;
-    k_thread_stack_t *stack;
-    struct k_work cleanup_work;
-};
-
-struct wifi_adapter_msgq {
-    struct k_msgq msgq;
-    void *buffer;
-};
 
 #ifdef CONFIG_PM
 extern void wifi_apb80m_request(void);
@@ -98,20 +88,6 @@ static void esp_wifi_free(void *mem)
     esp_wifi_free_func(mem);
 }
 
-static void wifi_task_cleanup_work(struct k_work *work)
-{
-    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
-
-    k_thread_join(&t->thread, K_FOREVER);
-    if (t->thread.custom_data) {
-        esp_wifi_free_func(t->thread.custom_data);
-    }
-
-    k_thread_stack_free(t->stack);
-    k_object_release(&t->thread);
-    esp_wifi_free_func(t);
-}
-
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 {
     wifi_static_queue_t *queue = NULL;
@@ -122,22 +98,13 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
         return NULL;
     }
 
-    queue->storage = wifi_malloc(queue_len * item_size);
-    if (queue->storage == NULL) {
-        LOG_ERR("msg buffer allocation failed");
-        esp_wifi_free(queue);
-        return NULL;
-    }
-
-    queue->handle = wifi_malloc(sizeof(struct k_msgq));
+    queue->storage = NULL;
+    queue->handle = esp_os_queue_create(queue_len, item_size);
     if (queue->handle == NULL) {
-        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
         LOG_ERR("queue handle allocation failed");
         return NULL;
     }
-
-    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
 }
@@ -145,8 +112,7 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
-        esp_wifi_free(queue->handle);
-        esp_wifi_free(queue->storage);
+        esp_os_queue_delete(queue->handle);
         esp_wifi_free(queue);
     }
 }
@@ -178,9 +144,9 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-    irq_disable(n);
-    irq_connect_dynamic(n, 0, f, arg, 0);
-    irq_enable(n);
+    esp_os_irq_disable(n);
+    esp_os_irq_connect(n, 0, f, arg, 0);
+    esp_os_irq_enable(n);
 }
 
 static void enable_intr_wrapper(unsigned int mask)
@@ -195,122 +161,89 @@ static void disable_intr_wrapper(unsigned int mask)
 
 static void *wifi_thread_semphr_get_wrapper(void)
 {
-    struct k_sem *sem = NULL;
+    esp_os_sem_t sem = esp_os_thread_custom_data_get();
 
-    sem = k_thread_custom_data_get();
     if (!sem) {
-        sem = (struct k_sem *)wifi_malloc(sizeof(struct k_sem));
+        sem = esp_os_sem_create(0, 1);
         if (sem == NULL) {
             LOG_ERR("wifi_thread_semphr_get_wrapper allocation failed");
             return NULL;
         }
-        k_sem_init(sem, 0, 1);
-        k_thread_custom_data_set(sem);
+        esp_os_thread_custom_data_set(sem);
     }
     return (void *)sem;
 }
 
 static void *recursive_mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("recursive_mutex_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return (void *)my_mutex;
+    return (void *)mutex;
 }
 
 static void *mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("mutex_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return (void *)my_mutex;
+    return (void *)mutex;
 }
 
 static void mutex_delete_wrapper(void *mutex)
 {
-    esp_wifi_free(mutex);
+    esp_os_mutex_delete(mutex);
 }
 
 static int32_t IRAM_ATTR mutex_lock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-    k_mutex_lock(my_mutex, K_FOREVER);
+    esp_os_mutex_lock(mutex, ESP_OS_FOREVER);
     return 0;
 }
 
 static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-    k_mutex_unlock(my_mutex);
+    esp_os_mutex_unlock(mutex);
     return 0;
 }
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
+    esp_os_queue_t queue = esp_os_queue_create(queue_len, item_size);
 
     if (queue == NULL) {
         LOG_ERR("queue malloc failed");
         return NULL;
     }
 
-    queue->buffer = wifi_malloc(queue_len * item_size);
-    if (queue->buffer == NULL) {
-        LOG_ERR("queue buffer malloc failed");
-        esp_wifi_free(queue);
-        return NULL;
-    }
-
-    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
-
     return (void *)queue;
 }
 
 static void queue_delete_wrapper(void *handle)
 {
-    if (handle != NULL) {
-        struct wifi_adapter_msgq *queue = handle;
-
-        esp_wifi_free(queue->buffer);
-        esp_wifi_free(queue);
-    }
+    esp_os_queue_delete(handle);
 }
 
 static void task_delete_wrapper(void *handle)
 {
-    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
-    struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
+    esp_os_thread_delete((esp_os_thread_t)handle);
+}
 
-    if (tid == k_current_get()) {
-        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
-        k_work_submit(&t->cleanup_work);
-        k_thread_abort(k_current_get());
-        CODE_UNREACHABLE;
+static uint32_t queue_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
     }
 
-    k_thread_abort(tid);
-
-    if (tid->custom_data) {
-        esp_wifi_free(tid->custom_data);
-    }
-    
-    k_thread_stack_free(t->stack);
-    k_object_release(tid);
-    esp_wifi_free(t);
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
 }
 
 static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
@@ -322,12 +255,7 @@ static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_send(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -342,8 +270,7 @@ static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, v
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
+    ret = esp_os_queue_send(handle, item, ESP_OS_NO_WAIT);
     if (hpt) {
         *hpt = 0;
     }
@@ -366,8 +293,7 @@ static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t bl
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put_front(&queue->msgq, item);
+    ret = esp_os_queue_send_to_front(handle, item);
 
     return ret == 0 ? 1 : 0;
 }
@@ -381,12 +307,7 @@ static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_recv(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -398,8 +319,7 @@ static uint32_t queue_msg_waiting_wrapper(void *handle)
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    return k_msgq_num_used_get(&queue->msgq);
+    return esp_os_queue_num_used(handle);
 }
 
 static void *event_group_create_wrapper(void)
@@ -445,24 +365,12 @@ static int32_t task_create_pinned_to_core_wrapper(void *task_func, const char *n
     ARG_UNUSED(core_id);
 
     uint32_t stack_size = MAX(stack_depth, CONFIG_ESP32_WIFI_TASK_STACK_SIZE);
-    struct wifi_task *t = wifi_malloc(sizeof(*t));
+    esp_os_thread_t tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+                                               stack_size, prio, name);
 
-    if (t == NULL) {
+    if (tid == NULL) {
         return 0;
     }
-
-    t->stack = k_thread_stack_alloc(stack_size,
-                                    IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0);
-    if (t->stack == NULL) {
-        esp_wifi_free(t);
-        return 0;
-    }
-
-    k_tid_t tid = k_thread_create(&t->thread, t->stack, stack_size,
-                      (k_thread_entry_t)task_func, param, NULL, NULL,
-                      prio, K_INHERIT_PERMS, K_NO_WAIT);
-
-    k_thread_name_set(tid, name);
 
     *(int32_t *)task_handle = (int32_t)tid;
     return 1;
@@ -475,12 +383,12 @@ static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t s
 
 static void task_delay_wrapper(uint32_t ticks)
 {
-    k_sleep(K_TICKS(ticks));
+    esp_os_sleep_ticks(ticks);
 }
 
 static int32_t IRAM_ATTR task_ms_to_tick_wrapper(uint32_t ms)
 {
-    return (int32_t)(k_ms_to_ticks_ceil32(ms));
+    return esp_os_ms_to_ticks(ms);
 }
 
 static int32_t task_get_max_priority_wrapper(void)
@@ -490,7 +398,7 @@ static int32_t task_get_max_priority_wrapper(void)
 
 static void *task_get_current_task_wrapper(void)
 {
-    return (void *)k_current_get();
+    return esp_os_thread_current();
 }
 
 static int32_t esp_event_post_wrapper(const char *event_base, int32_t event_id, void *event_data, size_t event_data_size, uint32_t ticks_to_wait)
@@ -549,12 +457,12 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-    return k_calloc(n, size);
+    return esp_os_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-    return k_calloc(1, size);
+    return esp_os_calloc(1, size);
 }
 
 static uint32_t esp_get_free_heap_size_wrapper(void)
@@ -887,7 +795,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._set_isr = set_isr_wrapper,
     ._ints_on = enable_intr_wrapper,
     ._ints_off = disable_intr_wrapper,
-    ._is_from_isr = k_is_in_isr,
+    ._is_from_isr = esp_os_is_in_isr,
     ._spin_lock_create = esp_coex_common_spin_lock_create_wrapper,
     ._spin_lock_delete = esp_wifi_free,
     ._wifi_int_disable = esp_coex_common_int_disable_wrapper,
@@ -965,7 +873,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
     ._log_write = esp_log_write_wrapper,
     ._log_writev = esp_log_writev_wrapper,
-    ._log_timestamp = k_uptime_get_32,
+    ._log_timestamp = esp_os_uptime_ms32,
     ._malloc_internal = esp_coex_common_malloc_internal_wrapper,
     ._realloc_internal = realloc_internal_wrapper,
     ._calloc_internal = calloc_internal_wrapper,

--- a/components/esp_wifi/esp32c3/esp_adapter.c
+++ b/components/esp_wifi/esp32c3/esp_adapter.c
@@ -16,6 +16,7 @@
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 LOG_MODULE_REGISTER(esp32c3_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include "esp_types.h"
@@ -52,17 +53,6 @@ LOG_MODULE_REGISTER(esp32c3_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 #define TAG "esp_adapter"
 
 static void esp_wifi_free(void *mem);
-
-struct wifi_adapter_msgq {
-    struct k_msgq msgq;
-    void *buffer;
-};
-
-struct wifi_task {
-    struct k_thread thread;
-    k_thread_stack_t *stack;
-    struct k_work cleanup_work;
-};
 
 #ifdef CONFIG_PM
 extern void wifi_apb80m_request(void);
@@ -110,20 +100,6 @@ static void esp_wifi_free(void *mem)
     esp_wifi_free_func(mem);
 }
 
-static void wifi_task_cleanup_work(struct k_work *work)
-{
-    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
-
-    k_thread_join(&t->thread, K_FOREVER);
-    if (t->thread.custom_data) {
-        esp_wifi_free_func(t->thread.custom_data);
-    }
-
-    k_thread_stack_free(t->stack);
-    k_object_release(&t->thread);
-    esp_wifi_free_func(t);
-}
-
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 {
     wifi_static_queue_t *queue = NULL;
@@ -134,22 +110,13 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
         return NULL;
     }
 
-    queue->storage = wifi_malloc(queue_len * item_size);
-    if (queue->storage == NULL) {
-        LOG_ERR("msg buffer allocation failed");
-        esp_wifi_free(queue);
-        return NULL;
-    }
-
-    queue->handle = wifi_malloc(sizeof(struct k_msgq));
+    queue->storage = NULL;
+    queue->handle = esp_os_queue_create(queue_len, item_size);
     if (queue->handle == NULL) {
-        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
         LOG_ERR("queue handle allocation failed");
         return NULL;
     }
-
-    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
 }
@@ -157,8 +124,7 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
-        esp_wifi_free(queue->handle);
-        esp_wifi_free(queue->storage);
+        esp_os_queue_delete(queue->handle);
         esp_wifi_free(queue);
     }
 }
@@ -190,9 +156,9 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-    irq_disable(n);
-    irq_connect_dynamic(n, 0, f, arg, 0);
-    irq_enable(n);
+    esp_os_irq_disable(n);
+    esp_os_irq_connect(n, 0, f, arg, 0);
+    esp_os_irq_enable(n);
 }
 
 static void enable_intr_wrapper(uint32_t intr_mask)
@@ -207,104 +173,89 @@ static void disable_intr_wrapper(uint32_t intr_mask)
 
 static bool IRAM_ATTR is_from_isr_wrapper(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 static void *wifi_thread_semphr_get_wrapper(void)
 {
-    struct k_sem *sem = NULL;
+    esp_os_sem_t sem = esp_os_thread_custom_data_get();
 
-    sem = k_thread_custom_data_get();
     if (!sem) {
-        sem = (struct k_sem *)wifi_malloc(sizeof(struct k_sem));
+        sem = esp_os_sem_create(0, 1);
         if (sem == NULL) {
             LOG_ERR("wifi_thread_semphr_get_wrapper allocation failed");
             return NULL;
         }
-        k_sem_init(sem, 0, 1);
-        k_thread_custom_data_set(sem);
+        esp_os_thread_custom_data_set(sem);
     }
     return (void *)sem;
 }
 
 static void *recursive_mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("recursive_mutex_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return (void *)my_mutex;
+    return (void *)mutex;
 }
 
 static void *mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("mutex_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return (void *)my_mutex;
+    return (void *)mutex;
 }
 
 static void mutex_delete_wrapper(void *mutex)
 {
-    esp_wifi_free(mutex);
+    esp_os_mutex_delete(mutex);
 }
 
 static int32_t IRAM_ATTR mutex_lock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-    k_mutex_lock(my_mutex, K_FOREVER);
+    esp_os_mutex_lock(mutex, ESP_OS_FOREVER);
     return 0;
 }
 
 static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-    k_mutex_unlock(my_mutex);
+    esp_os_mutex_unlock(mutex);
     return 0;
 }
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
+    esp_os_queue_t queue = esp_os_queue_create(queue_len, item_size);
 
     if (queue == NULL) {
         LOG_ERR("queue malloc failed");
         return NULL;
     }
 
-    queue->buffer = wifi_malloc(queue_len * item_size);
-    if (queue->buffer == NULL) {
-        LOG_ERR("queue buffer malloc failed");
-        esp_wifi_free(queue);
-        return NULL;
-    }
-
-    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
-
     return (void *)queue;
 }
 
 static void queue_delete_wrapper(void *handle)
 {
-    if (handle != NULL) {
-        struct wifi_adapter_msgq *queue = handle;
+    esp_os_queue_delete(handle);
+}
 
-        esp_wifi_free(queue->buffer);
-        esp_wifi_free(queue);
+static uint32_t queue_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
     }
+
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
 }
 
 static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
@@ -316,12 +267,7 @@ static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_send(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -336,8 +282,7 @@ static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, v
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
+    ret = esp_os_queue_send(handle, item, ESP_OS_NO_WAIT);
     if (hpt) {
         *hpt = 0;
     }
@@ -360,8 +305,7 @@ static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t bl
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put_front(&queue->msgq, item);
+    ret = esp_os_queue_send_to_front(handle, item);
 
     return ret == 0 ? 1 : 0;
 }
@@ -375,12 +319,7 @@ static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_recv(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -392,8 +331,7 @@ static uint32_t queue_msg_waiting_wrapper(void *handle)
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    return k_msgq_num_used_get(&queue->msgq);
+    return esp_os_queue_num_used(handle);
 }
 
 static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
@@ -412,24 +350,12 @@ static int32_t task_create_pinned_to_core_wrapper(void *task_func, const char *n
     ARG_UNUSED(core_id);
 
     uint32_t stack_size = MAX(stack_depth, CONFIG_ESP32_WIFI_TASK_STACK_SIZE);
-    struct wifi_task *t = wifi_malloc(sizeof(*t));
+    esp_os_thread_t tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+                                               stack_size, prio, name);
 
-    if (t == NULL) {
+    if (tid == NULL) {
         return 0;
     }
-
-    t->stack = k_thread_stack_alloc(stack_size,
-                                    IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0);
-    if (t->stack == NULL) {
-        esp_wifi_free(t);
-        return 0;
-    }
-
-    k_tid_t tid = k_thread_create(&t->thread, t->stack, stack_size,
-                      (k_thread_entry_t)task_func, param, NULL, NULL,
-                      prio, K_INHERIT_PERMS, K_NO_WAIT);
-
-    k_thread_name_set(tid, name);
 
     *(int32_t *)task_handle = (int32_t)tid;
     return 1;
@@ -442,35 +368,17 @@ static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t s
 
 static void task_delete_wrapper(void *handle)
 {
-    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
-    struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
-
-    if (tid == k_current_get()) {
-        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
-        k_work_submit(&t->cleanup_work);
-        k_thread_abort(k_current_get());
-        CODE_UNREACHABLE;
-    }
-
-    k_thread_abort(tid);
-
-    if (tid->custom_data) {
-        esp_wifi_free(tid->custom_data);
-    }
-    
-    k_thread_stack_free(t->stack);
-    k_object_release(tid);
-    esp_wifi_free(t);
+    esp_os_thread_delete((esp_os_thread_t)handle);
 }
 
 static void task_delay_wrapper(uint32_t ticks)
 {
-    k_sleep(K_TICKS(ticks));
+    esp_os_sleep_ticks(ticks);
 }
 
 static int32_t IRAM_ATTR task_ms_to_tick_wrapper(uint32_t ms)
 {
-    return (int32_t)(k_ms_to_ticks_ceil32(ms));
+    return esp_os_ms_to_ticks(ms);
 }
 
 static int32_t task_get_max_priority_wrapper(void)
@@ -550,12 +458,12 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-    return k_calloc(n, size);
+    return esp_os_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-    return k_calloc(1, size);
+    return esp_os_calloc(1, size);
 }
 
 void *xEventGroupCreate(void)
@@ -587,7 +495,7 @@ uint32_t xEventGroupClearBits(void *ptr, uint32_t data)
 
 void *xTaskGetCurrentTaskHandle(void)
 {
-    return (void *)k_current_get();
+    return esp_os_thread_current();
 }
 
 int32_t nvs_set_i8(uint32_t handle, const char *key, int8_t value)
@@ -965,7 +873,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._task_delete = task_delete_wrapper,
     ._task_delay = task_delay_wrapper,
     ._task_ms_to_tick = task_ms_to_tick_wrapper,
-    ._task_get_current_task = (void *(*)(void))k_current_get,
+    ._task_get_current_task = esp_os_thread_current,
     ._task_get_max_priority = task_get_max_priority_wrapper,
     ._malloc = wifi_malloc,
     ._free = esp_wifi_free,
@@ -1009,7 +917,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
     ._log_write = esp_log_write_wrapper,
     ._log_writev = esp_log_writev_wrapper,
-    ._log_timestamp = k_uptime_get_32,
+    ._log_timestamp = esp_os_uptime_ms32,
     ._malloc_internal = esp_coex_common_malloc_internal_wrapper,
     ._realloc_internal = realloc_internal_wrapper,
     ._calloc_internal = calloc_internal_wrapper,

--- a/components/esp_wifi/esp32c5/esp_adapter.c
+++ b/components/esp_wifi/esp32c5/esp_adapter.c
@@ -17,6 +17,7 @@
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 LOG_MODULE_REGISTER(esp32c5_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include <riscv/interrupt.h>
@@ -61,17 +62,6 @@ LOG_MODULE_REGISTER(esp32c5_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 #define TAG "esp_adapter"
 
 static void esp_wifi_free(void *mem);
-
-struct wifi_adapter_msgq {
-    struct k_msgq msgq;
-    void *buffer;
-};
-
-struct wifi_task {
-    struct k_thread thread;
-    k_thread_stack_t *stack;
-    struct k_work cleanup_work;
-};
 
 #ifdef CONFIG_PM
 extern void wifi_apb80m_request(void);
@@ -119,20 +109,6 @@ static void esp_wifi_free(void *mem)
     esp_wifi_free_func(mem);
 }
 
-static void wifi_task_cleanup_work(struct k_work *work)
-{
-    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
-
-    k_thread_join(&t->thread, K_FOREVER);
-    if (t->thread.custom_data) {
-        esp_wifi_free_func(t->thread.custom_data);
-    }
-
-    k_thread_stack_free(t->stack);
-    k_object_release(&t->thread);
-    esp_wifi_free_func(t);
-}
-
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 {
     wifi_static_queue_t *queue = NULL;
@@ -143,22 +119,13 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
         return NULL;
     }
 
-    queue->storage = wifi_malloc(queue_len * item_size);
-    if (queue->storage == NULL) {
-        LOG_ERR("msg buffer allocation failed");
-        esp_wifi_free(queue);
-        return NULL;
-    }
-
-    queue->handle = wifi_malloc(sizeof(struct k_msgq));
+    queue->storage = NULL;
+    queue->handle = esp_os_queue_create(queue_len, item_size);
     if (queue->handle == NULL) {
-        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
         LOG_ERR("queue handle allocation failed");
         return NULL;
     }
-
-    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
 }
@@ -166,8 +133,7 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
-        esp_wifi_free(queue->handle);
-        esp_wifi_free(queue->storage);
+        esp_os_queue_delete(queue->handle);
         esp_wifi_free(queue);
     }
 }
@@ -199,9 +165,9 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-    irq_disable(n);
-    irq_connect_dynamic(n, 0, f, arg, 0);
-    irq_enable(n);
+    esp_os_irq_disable(n);
+    esp_os_irq_connect(n, 0, f, arg, 0);
+    esp_os_irq_enable(n);
 }
 
 static void enable_intr_wrapper(uint32_t intr_mask)
@@ -216,104 +182,89 @@ static void disable_intr_wrapper(uint32_t intr_mask)
 
 static bool IRAM_ATTR is_from_isr_wrapper(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 static void *wifi_thread_semphr_get_wrapper(void)
 {
-    struct k_sem *sem = NULL;
+    esp_os_sem_t sem = esp_os_thread_custom_data_get();
 
-    sem = k_thread_custom_data_get();
     if (!sem) {
-        sem = (struct k_sem *)wifi_malloc(sizeof(struct k_sem));
+        sem = esp_os_sem_create(0, 1);
         if (sem == NULL) {
             LOG_ERR("wifi_thread_semphr_get_wrapper allocation failed");
             return NULL;
         }
-        k_sem_init(sem, 0, 1);
-        k_thread_custom_data_set(sem);
+        esp_os_thread_custom_data_set(sem);
     }
     return (void *)sem;
 }
 
 static void *recursive_mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("recursive_mutex_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return (void *)my_mutex;
+    return (void *)mutex;
 }
 
 static void *mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("mutex_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return (void *)my_mutex;
+    return (void *)mutex;
 }
 
 static void mutex_delete_wrapper(void *mutex)
 {
-    esp_wifi_free(mutex);
+    esp_os_mutex_delete(mutex);
 }
 
 static int32_t IRAM_ATTR mutex_lock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-    k_mutex_lock(my_mutex, K_FOREVER);
+    esp_os_mutex_lock(mutex, ESP_OS_FOREVER);
     return 0;
 }
 
 static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-    k_mutex_unlock(my_mutex);
+    esp_os_mutex_unlock(mutex);
     return 0;
 }
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
+    esp_os_queue_t queue = esp_os_queue_create(queue_len, item_size);
 
     if (queue == NULL) {
         LOG_ERR("queue malloc failed");
         return NULL;
     }
 
-    queue->buffer = wifi_malloc(queue_len * item_size);
-    if (queue->buffer == NULL) {
-        LOG_ERR("queue buffer malloc failed");
-        esp_wifi_free(queue);
-        return NULL;
-    }
-
-    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
-
     return (void *)queue;
 }
 
 static void queue_delete_wrapper(void *handle)
 {
-    if (handle != NULL) {
-        struct wifi_adapter_msgq *queue = handle;
+    esp_os_queue_delete(handle);
+}
 
-        esp_wifi_free(queue->buffer);
-        esp_wifi_free(queue);
+static uint32_t queue_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
     }
+
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
 }
 
 static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
@@ -325,12 +276,7 @@ static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_send(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -345,8 +291,7 @@ static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, v
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
+    ret = esp_os_queue_send(handle, item, ESP_OS_NO_WAIT);
     if (hpt) {
         *hpt = 0;
     }
@@ -369,8 +314,7 @@ static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t bl
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put_front(&queue->msgq, item);
+    ret = esp_os_queue_send_to_front(handle, item);
 
     return ret == 0 ? 1 : 0;
 }
@@ -384,12 +328,7 @@ static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_recv(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -401,8 +340,7 @@ static uint32_t queue_msg_waiting_wrapper(void *handle)
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    return k_msgq_num_used_get(&queue->msgq);
+    return esp_os_queue_num_used(handle);
 }
 
 static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
@@ -421,24 +359,12 @@ static int32_t task_create_pinned_to_core_wrapper(void *task_func, const char *n
     ARG_UNUSED(core_id);
 
     uint32_t stack_size = MAX(stack_depth, CONFIG_ESP32_WIFI_TASK_STACK_SIZE);
-    struct wifi_task *t = wifi_malloc(sizeof(*t));
+    esp_os_thread_t tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+                                               stack_size, prio, name);
 
-    if (t == NULL) {
+    if (tid == NULL) {
         return 0;
     }
-
-    t->stack = k_thread_stack_alloc(stack_size,
-                                    IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0);
-    if (t->stack == NULL) {
-        esp_wifi_free(t);
-        return 0;
-    }
-
-    k_tid_t tid = k_thread_create(&t->thread, t->stack, stack_size,
-                      (k_thread_entry_t)task_func, param, NULL, NULL,
-                      prio, K_INHERIT_PERMS, K_NO_WAIT);
-
-    k_thread_name_set(tid, name);
 
     *(int32_t *)task_handle = (int32_t)tid;
     return 1;
@@ -451,35 +377,17 @@ static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t s
 
 static void task_delete_wrapper(void *handle)
 {
-    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
-    struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
-
-    if (tid == k_current_get()) {
-        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
-        k_work_submit(&t->cleanup_work);
-        k_thread_abort(k_current_get());
-        CODE_UNREACHABLE;
-    }
-
-    k_thread_abort(tid);
-
-    if (tid->custom_data) {
-        esp_wifi_free(tid->custom_data);
-    }
-    
-    k_thread_stack_free(t->stack);
-    k_object_release(tid);
-    esp_wifi_free(t);
+    esp_os_thread_delete((esp_os_thread_t)handle);
 }
 
 static void task_delay_wrapper(uint32_t ticks)
 {
-    k_sleep(K_TICKS(ticks));
+    esp_os_sleep_ticks(ticks);
 }
 
 static int32_t IRAM_ATTR task_ms_to_tick_wrapper(uint32_t ms)
 {
-    return (int32_t)(k_ms_to_ticks_ceil32(ms));
+    return esp_os_ms_to_ticks(ms);
 }
 
 static int32_t task_get_max_priority_wrapper(void)
@@ -545,12 +453,12 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-    return k_calloc(n, size);
+    return esp_os_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-    return k_calloc(1, size);
+    return esp_os_calloc(1, size);
 }
 
 void *xEventGroupCreate(void)
@@ -582,7 +490,7 @@ uint32_t xEventGroupClearBits(void *ptr, uint32_t data)
 
 void *xTaskGetCurrentTaskHandle(void)
 {
-    return (void *)k_current_get();
+    return esp_os_thread_current();
 }
 
 int32_t nvs_set_i8(uint32_t handle, const char *key, int8_t value)
@@ -1013,7 +921,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._task_delete = task_delete_wrapper,
     ._task_delay = task_delay_wrapper,
     ._task_ms_to_tick = task_ms_to_tick_wrapper,
-    ._task_get_current_task = (void *(*)(void))k_current_get,
+    ._task_get_current_task = esp_os_thread_current,
     ._task_get_max_priority = task_get_max_priority_wrapper,
     ._malloc = wifi_malloc,
     ._free = esp_wifi_free,
@@ -1057,7 +965,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
     ._log_write = esp_log_write_wrapper,
     ._log_writev = esp_log_writev_wrapper,
-    ._log_timestamp = k_uptime_get_32,
+    ._log_timestamp = esp_os_uptime_ms32,
     ._malloc_internal = esp_coex_common_malloc_internal_wrapper,
     ._realloc_internal = realloc_internal_wrapper,
     ._calloc_internal = calloc_internal_wrapper,

--- a/components/esp_wifi/esp32c6/esp_adapter.c
+++ b/components/esp_wifi/esp32c6/esp_adapter.c
@@ -17,6 +17,7 @@
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 LOG_MODULE_REGISTER(esp32c6_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include <riscv/interrupt.h>
@@ -61,17 +62,6 @@ LOG_MODULE_REGISTER(esp32c6_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 #define TAG "esp_adapter"
 
 static void esp_wifi_free(void *mem);
-
-struct wifi_adapter_msgq {
-	struct k_msgq msgq;
-	void *buffer;
-};
-
-struct wifi_task {
-    struct k_thread thread;
-    k_thread_stack_t *stack;
-    struct k_work cleanup_work;
-};
 
 #ifdef CONFIG_PM
 extern void wifi_apb80m_request(void);
@@ -119,20 +109,6 @@ static void esp_wifi_free(void *mem)
     esp_wifi_free_func(mem);
 }
 
-static void wifi_task_cleanup_work(struct k_work *work)
-{
-    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
-
-    k_thread_join(&t->thread, K_FOREVER);
-    if (t->thread.custom_data) {
-        esp_wifi_free_func(t->thread.custom_data);
-    }
-
-    k_thread_stack_free(t->stack);
-    k_object_release(&t->thread);
-    esp_wifi_free_func(t);
-}
-
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 {
     wifi_static_queue_t *queue = NULL;
@@ -143,22 +119,13 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
         return NULL;
     }
 
-    queue->storage = wifi_malloc(queue_len * item_size);
-    if (queue->storage == NULL) {
-        LOG_ERR("msg buffer allocation failed");
-        esp_wifi_free(queue);
-        return NULL;
-    }
-
-    queue->handle = wifi_malloc(sizeof(struct k_msgq));
+    queue->storage = NULL;
+    queue->handle = esp_os_queue_create(queue_len, item_size);
     if (queue->handle == NULL) {
-        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
         LOG_ERR("queue handle allocation failed");
         return NULL;
     }
-
-    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
 }
@@ -166,8 +133,7 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
-        esp_wifi_free(queue->handle);
-        esp_wifi_free(queue->storage);
+        esp_os_queue_delete(queue->handle);
         esp_wifi_free(queue);
     }
 }
@@ -199,9 +165,9 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-    irq_disable(n);
-    irq_connect_dynamic(n, 0, f, arg, 0);
-    irq_enable(n);
+    esp_os_irq_disable(n);
+    esp_os_irq_connect(n, 0, f, arg, 0);
+    esp_os_irq_enable(n);
 }
 
 static void enable_intr_wrapper(uint32_t intr_mask)
@@ -216,104 +182,89 @@ static void disable_intr_wrapper(uint32_t intr_mask)
 
 static bool IRAM_ATTR is_from_isr_wrapper(void)
 {
-    return k_is_in_isr();
+    return esp_os_is_in_isr();
 }
 
 static void *wifi_thread_semphr_get_wrapper(void)
 {
-    struct k_sem *sem = NULL;
+    esp_os_sem_t sem = esp_os_thread_custom_data_get();
 
-    sem = k_thread_custom_data_get();
     if (!sem) {
-        sem = (struct k_sem *)wifi_malloc(sizeof(struct k_sem));
+        sem = esp_os_sem_create(0, 1);
         if (sem == NULL) {
             LOG_ERR("wifi_thread_semphr_get_wrapper allocation failed");
             return NULL;
         }
-        k_sem_init(sem, 0, 1);
-        k_thread_custom_data_set(sem);
+        esp_os_thread_custom_data_set(sem);
     }
     return (void *)sem;
 }
 
 static void *recursive_mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("recursive_mutex_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return (void *)my_mutex;
+    return (void *)mutex;
 }
 
 static void *mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("mutex_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return (void *)my_mutex;
+    return (void *)mutex;
 }
 
 static void mutex_delete_wrapper(void *mutex)
 {
-    esp_wifi_free(mutex);
+    esp_os_mutex_delete(mutex);
 }
 
 static int32_t IRAM_ATTR mutex_lock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-    k_mutex_lock(my_mutex, K_FOREVER);
+    esp_os_mutex_lock(mutex, ESP_OS_FOREVER);
     return 0;
 }
 
 static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-    k_mutex_unlock(my_mutex);
+    esp_os_mutex_unlock(mutex);
     return 0;
 }
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
+    esp_os_queue_t queue = esp_os_queue_create(queue_len, item_size);
 
     if (!queue) {
         LOG_ERR("queue malloc failed");
         return NULL;
     }
 
-    queue->buffer = wifi_malloc(queue_len * item_size);
-    if (!queue->buffer) {
-        LOG_ERR("queue buffer malloc failed");
-        esp_wifi_free(queue);
-        return NULL;
-    }
-
-    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
-
     return (void *)queue;
 }
 
 static void queue_delete_wrapper(void *handle)
 {
-    if (handle) {
-        struct wifi_adapter_msgq *queue = handle;
+    esp_os_queue_delete(handle);
+}
 
-        esp_wifi_free(queue->buffer);
-        esp_wifi_free(queue);
+static uint32_t queue_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
     }
+
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
 }
 
 static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
@@ -325,12 +276,7 @@ static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_send(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -345,8 +291,7 @@ static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, v
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
+    ret = esp_os_queue_send(handle, item, ESP_OS_NO_WAIT);
     if (hpt) {
         *hpt = 0;
     }
@@ -370,8 +315,7 @@ static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t bl
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put_front(&queue->msgq, item);
+    ret = esp_os_queue_send_to_front(handle, item);
 
     return ret == 0 ? 1 : 0;
 }
@@ -385,12 +329,7 @@ static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_recv(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -402,8 +341,7 @@ static uint32_t queue_msg_waiting_wrapper(void *handle)
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    return k_msgq_num_used_get(&queue->msgq);
+    return esp_os_queue_num_used(handle);
 }
 
 static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
@@ -422,24 +360,12 @@ static int32_t task_create_pinned_to_core_wrapper(void *task_func, const char *n
     ARG_UNUSED(core_id);
 
     uint32_t stack_size = MAX(stack_depth, CONFIG_ESP32_WIFI_TASK_STACK_SIZE);
-    struct wifi_task *t = wifi_malloc(sizeof(*t));
+    esp_os_thread_t tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+                                               stack_size, prio, name);
 
-    if (t == NULL) {
+    if (tid == NULL) {
         return 0;
     }
-
-    t->stack = k_thread_stack_alloc(stack_size,
-                                    IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0);
-    if (t->stack == NULL) {
-        esp_wifi_free(t);
-        return 0;
-    }
-
-    k_tid_t tid = k_thread_create(&t->thread, t->stack, stack_size,
-                      (k_thread_entry_t)task_func, param, NULL, NULL,
-                      prio, K_INHERIT_PERMS, K_NO_WAIT);
-
-    k_thread_name_set(tid, name);
 
     *(int32_t *)task_handle = (int32_t)tid;
     return 1;
@@ -452,35 +378,17 @@ static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t s
 
 static void task_delete_wrapper(void *handle)
 {
-    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
-    struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
-
-    if (tid == k_current_get()) {
-        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
-        k_work_submit(&t->cleanup_work);
-        k_thread_abort(k_current_get());
-        CODE_UNREACHABLE;
-    }
-
-    k_thread_abort(tid);
-
-    if (tid->custom_data) {
-        esp_wifi_free(tid->custom_data);
-    }
-
-    k_thread_stack_free(t->stack);
-    k_object_release(tid);
-    esp_wifi_free(t);
+    esp_os_thread_delete((esp_os_thread_t)handle);
 }
 
 static void task_delay_wrapper(uint32_t ticks)
 {
-    k_sleep(K_TICKS(ticks));
+    esp_os_sleep_ticks(ticks);
 }
 
 static int32_t IRAM_ATTR task_ms_to_tick_wrapper(uint32_t ms)
 {
-    return (int32_t)(k_ms_to_ticks_ceil32(ms));
+    return esp_os_ms_to_ticks(ms);
 }
 
 static int32_t task_get_max_priority_wrapper(void)
@@ -546,12 +454,12 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-    return k_calloc(n, size);
+    return esp_os_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-    return k_calloc(1, size);
+    return esp_os_calloc(1, size);
 }
 
 void *xEventGroupCreate(void)
@@ -583,7 +491,7 @@ uint32_t xEventGroupClearBits(void *ptr, uint32_t data)
 
 void *xTaskGetCurrentTaskHandle(void)
 {
-    return (void *)k_current_get();
+    return esp_os_thread_current();
 }
 
 int32_t nvs_set_i8(uint32_t handle, const char *key, int8_t value)
@@ -1023,7 +931,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._task_delete = task_delete_wrapper,
     ._task_delay = task_delay_wrapper,
     ._task_ms_to_tick = task_ms_to_tick_wrapper,
-    ._task_get_current_task = (void *(*)(void))k_current_get,
+    ._task_get_current_task = esp_os_thread_current,
     ._task_get_max_priority = task_get_max_priority_wrapper,
     ._malloc = wifi_malloc,
     ._free = esp_wifi_free,
@@ -1067,7 +975,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
     ._log_write = esp_log_write_wrapper,
     ._log_writev = esp_log_writev_wrapper,
-    ._log_timestamp = k_uptime_get_32,
+    ._log_timestamp = esp_os_uptime_ms32,
     ._malloc_internal = esp_coex_common_malloc_internal_wrapper,
     ._realloc_internal = realloc_internal_wrapper,
     ._calloc_internal = calloc_internal_wrapper,

--- a/components/esp_wifi/esp32s2/esp_adapter.c
+++ b/components/esp_wifi/esp32s2/esp_adapter.c
@@ -14,6 +14,7 @@
 #include <zephyr/random/random.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 LOG_MODULE_REGISTER(esp32s2_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 
 #include "esp_types.h"
@@ -39,17 +40,6 @@ LOG_MODULE_REGISTER(esp32s2_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
 #include "wifi/wifi_event.h"
 
 #define TAG "esp_adapter"
-
-struct wifi_task {
-    struct k_thread thread;
-    k_thread_stack_t *stack;
-    struct k_work cleanup_work;
-};
-
-struct wifi_adapter_msgq {
-    struct k_msgq msgq;
-    void *buffer;
-};
 
 #ifdef CONFIG_PM
 extern void wifi_apb80m_request(void);
@@ -100,20 +90,6 @@ static void esp_wifi_free(void *mem)
     esp_wifi_free_func(mem);
 }
 
-static void wifi_task_cleanup_work(struct k_work *work)
-{
-    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
-
-    k_thread_join(&t->thread, K_FOREVER);
-    if (t->thread.custom_data) {
-        esp_wifi_free_func(t->thread.custom_data);
-    }
-
-    k_thread_stack_free(t->stack);
-    k_object_release(&t->thread);
-    esp_wifi_free_func(t);
-}
-
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 {
     wifi_static_queue_t *queue = NULL;
@@ -124,22 +100,13 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
         return NULL;
     }
 
-    queue->storage = wifi_malloc(queue_len * item_size);
-    if (queue->storage == NULL) {
-        LOG_ERR("msg buffer allocation failed");
-        esp_wifi_free(queue);
-        return NULL;
-    }
-
-    queue->handle = wifi_malloc(sizeof(struct k_msgq));
+    queue->storage = NULL;
+    queue->handle = esp_os_queue_create(queue_len, item_size);
     if (queue->handle == NULL) {
-        esp_wifi_free(queue->storage);
         esp_wifi_free(queue);
         LOG_ERR("queue handle allocation failed");
         return NULL;
     }
-
-    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
 }
@@ -147,8 +114,7 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
-        esp_wifi_free(queue->handle);
-        esp_wifi_free(queue->storage);
+        esp_os_queue_delete(queue->handle);
         esp_wifi_free(queue);
     }
 }
@@ -174,139 +140,106 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-    irq_disable(n);
-    irq_connect_dynamic(n, 0, f, arg, 0);
-    irq_enable(n);
+    esp_os_irq_disable(n);
+    esp_os_irq_connect(n, 0, f, arg, 0);
+    esp_os_irq_enable(n);
 }
 
 static void intr_on(unsigned int mask)
 {
-    irq_enable(__builtin_ctz(mask));
+    esp_os_irq_enable(__builtin_ctz(mask));
 }
 
 static void intr_off(unsigned int mask)
 {
-    irq_disable(__builtin_ctz(mask));
+    esp_os_irq_disable(__builtin_ctz(mask));
 }
 
 static void *wifi_thread_semphr_get_wrapper(void)
 {
-    struct k_sem *sem = NULL;
+    esp_os_sem_t sem = esp_os_thread_custom_data_get();
 
-    sem = k_thread_custom_data_get();
     if (!sem) {
-        sem = (struct k_sem *)wifi_malloc(sizeof(struct k_sem));
+        sem = esp_os_sem_create(0, 1);
         if (sem == NULL) {
             LOG_ERR("wifi_thread_semphr_get_wrapper allocation failed");
             return NULL;
         }
-        k_sem_init(sem, 0, 1);
-        k_thread_custom_data_set(sem);
+        esp_os_thread_custom_data_set(sem);
     }
     return (void *)sem;
 }
 
 static void *recursive_mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("recursive_mutex_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return (void *)my_mutex;
+    return (void *)mutex;
 }
 
 static void *mutex_create_wrapper(void)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+    esp_os_mutex_t mutex = esp_os_mutex_create();
 
-    if (my_mutex == NULL) {
+    if (mutex == NULL) {
         LOG_ERR("mutex_create_wrapper allocation failed");
         return NULL;
     }
 
-    k_mutex_init(my_mutex);
-
-    return (void *)my_mutex;
+    return (void *)mutex;
 }
 
 static void mutex_delete_wrapper(void *mutex)
 {
-    esp_wifi_free(mutex);
+    esp_os_mutex_delete(mutex);
 }
 
 static int32_t IRAM_ATTR mutex_lock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-    k_mutex_lock(my_mutex, K_FOREVER);
+    esp_os_mutex_lock(mutex, ESP_OS_FOREVER);
     return 0;
 }
 
 static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 {
-    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-    k_mutex_unlock(my_mutex);
+    esp_os_mutex_unlock(mutex);
     return 0;
 }
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
+    esp_os_queue_t queue = esp_os_queue_create(queue_len, item_size);
 
     if (queue == NULL) {
         LOG_ERR("queue malloc failed");
         return NULL;
     }
 
-    queue->buffer = wifi_malloc(queue_len * item_size);
-    if (queue->buffer == NULL) {
-        LOG_ERR("queue buffer malloc failed");
-        esp_wifi_free(queue);
-        return NULL;
-    }
-
-    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
-
     return (void *)queue;
 }
 
 static void queue_delete_wrapper(void *handle)
 {
-    if (handle != NULL) {
-        struct wifi_adapter_msgq *queue = handle;
-
-        esp_wifi_free(queue->buffer);
-        esp_wifi_free(queue);
-    }
+    esp_os_queue_delete(handle);
 }
 
 static void task_delete_wrapper(void *handle)
 {
-    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
-    struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
+    esp_os_thread_delete((esp_os_thread_t)handle);
+}
 
-    if (tid == k_current_get()) {
-        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
-        k_work_submit(&t->cleanup_work);
-        k_thread_abort(k_current_get());
-        CODE_UNREACHABLE;
+static uint32_t queue_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
     }
 
-    k_thread_abort(tid);
-
-    if (tid->custom_data) {
-        esp_wifi_free(tid->custom_data);
-    }
-
-    k_thread_stack_free(t->stack);
-    k_object_release(tid);
-    esp_wifi_free(t);
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
 }
 
 static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
@@ -318,12 +251,7 @@ static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_send(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -338,8 +266,7 @@ static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, v
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
+    ret = esp_os_queue_send(handle, item, ESP_OS_NO_WAIT);
     if (hpt) {
         *hpt = 0;
     }
@@ -362,8 +289,7 @@ static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t bl
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put_front(&queue->msgq, item);
+    ret = esp_os_queue_send_to_front(handle, item);
 
     return ret == 0 ? 1 : 0;
 }
@@ -377,12 +303,7 @@ static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_recv(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -394,8 +315,7 @@ static uint32_t queue_msg_waiting_wrapper(void *handle)
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    return k_msgq_num_used_get(&queue->msgq);
+    return esp_os_queue_num_used(handle);
 }
 
 static void *event_group_create_wrapper(void)
@@ -428,24 +348,12 @@ static int32_t task_create_pinned_to_core_wrapper(void *task_func, const char *n
     ARG_UNUSED(core_id);
 
     uint32_t stack_size = MAX(stack_depth, CONFIG_ESP32_WIFI_TASK_STACK_SIZE);
-    struct wifi_task *t = wifi_malloc(sizeof(*t));
+    esp_os_thread_t tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+                                               stack_size, prio, name);
 
-    if (t == NULL) {
+    if (tid == NULL) {
         return 0;
     }
-
-    t->stack = k_thread_stack_alloc(stack_size,
-                                    IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0);
-    if (t->stack == NULL) {
-        esp_wifi_free(t);
-        return 0;
-    }
-
-    k_tid_t tid = k_thread_create(&t->thread, t->stack, stack_size,
-                      (k_thread_entry_t)task_func, param, NULL, NULL,
-                      prio, K_INHERIT_PERMS, K_NO_WAIT);
-
-    k_thread_name_set(tid, name);
 
     *(int32_t *)task_handle = (int32_t)tid;
     return 1;
@@ -458,12 +366,12 @@ static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t s
 
 static void task_delay_wrapper(uint32_t ticks)
 {
-    k_sleep(K_TICKS(ticks));
+    esp_os_sleep_ticks(ticks);
 }
 
 static int32_t IRAM_ATTR task_ms_to_tick_wrapper(uint32_t ms)
 {
-    return (int32_t)(k_ms_to_ticks_ceil32(ms));
+    return esp_os_ms_to_ticks(ms);
 }
 
 static int32_t task_get_max_priority_wrapper(void)
@@ -473,7 +381,7 @@ static int32_t task_get_max_priority_wrapper(void)
 
 static void *task_get_current_task_wrapper(void)
 {
-    return (void *)k_current_get();
+    return esp_os_thread_current();
 }
 
 static int32_t esp_event_post_wrapper(const char *event_base, int32_t event_id, void *event_data, size_t event_data_size, uint32_t ticks_to_wait)
@@ -529,12 +437,12 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-    return k_calloc(n, size);
+    return esp_os_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-    return k_calloc(1, size);
+    return esp_os_calloc(1, size);
 }
 
 static uint32_t esp_get_free_heap_size_wrapper(void)
@@ -838,7 +746,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._set_isr = set_isr_wrapper,
     ._ints_on = intr_on,
     ._ints_off = intr_off,
-    ._is_from_isr = k_is_in_isr,
+    ._is_from_isr = esp_os_is_in_isr,
     ._spin_lock_create = esp_coex_common_spin_lock_create_wrapper,
     ._spin_lock_delete = esp_wifi_free,
     ._wifi_int_disable = esp_coex_common_int_disable_wrapper,
@@ -918,7 +826,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
     ._log_write = esp_log_write_wrapper,
     ._log_writev = esp_log_writev_wrapper,
-    ._log_timestamp = k_uptime_get_32,
+    ._log_timestamp = esp_os_uptime_ms32,
     ._malloc_internal = esp_coex_common_malloc_internal_wrapper,
     ._realloc_internal = realloc_internal_wrapper,
     ._calloc_internal = calloc_internal_wrapper,

--- a/components/esp_wifi/esp32s3/esp_adapter.c
+++ b/components/esp_wifi/esp32s3/esp_adapter.c
@@ -16,6 +16,7 @@
 #include <zephyr/random/random.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <zephyr/logging/log.h>
+#include <esp_os.h>
 
 #include "esp_types.h"
 #include "esp_random.h"
@@ -45,31 +46,6 @@
 #include "esp_heap_adapter.h"
 
 LOG_MODULE_REGISTER(esp32_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
-
-struct wifi_task {
-	struct k_thread thread;
-	k_thread_stack_t *stack;
-	struct k_work cleanup_work;
-};
-
-static void wifi_task_cleanup_work(struct k_work *work)
-{
-	struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
-
-	k_thread_join(&t->thread, K_FOREVER);
-	if (t->thread.custom_data) {
-		esp_wifi_free_func(t->thread.custom_data);
-	}
-
-	k_thread_stack_free(t->stack);
-	k_object_release(&t->thread);
-	esp_wifi_free_func(t);
-}
-
-struct wifi_adapter_msgq {
-	struct k_msgq msgq;
-	void *buffer;
-};
 
 #ifdef CONFIG_PM
 extern void wifi_apb80m_request(void);
@@ -127,24 +103,14 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 		return NULL;
 	}
 
-	queue->storage = wifi_malloc(queue_len * item_size);
-
-	if (queue->storage == NULL) {
-		LOG_ERR("msg buffer allocation failed");
-		esp_wifi_free(queue);
-		return NULL;
-	}
-
-	queue->handle = wifi_malloc(sizeof(struct k_msgq));
+	queue->storage = NULL;
+	queue->handle = esp_os_queue_create(queue_len, item_size);
 
 	if (queue->handle == NULL) {
-		esp_wifi_free(queue->storage);
 		esp_wifi_free(queue);
 		LOG_ERR("queue handle allocation failed");
 		return NULL;
 	}
-
-	k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
 	return queue;
 }
@@ -152,8 +118,7 @@ wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 void wifi_delete_queue(wifi_static_queue_t *queue)
 {
 	if (queue) {
-		esp_wifi_free(queue->handle);
-		esp_wifi_free(queue->storage);
+		esp_os_queue_delete(queue->handle);
 		esp_wifi_free(queue);
 	}
 }
@@ -180,138 +145,106 @@ static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-	irq_disable(n);
-	irq_connect_dynamic(n, 0, f, arg, 0);
-	irq_enable(n);
+	esp_os_irq_disable(n);
+	esp_os_irq_connect(n, 0, f, arg, 0);
+	esp_os_irq_enable(n);
 }
 
 static void intr_on(unsigned int mask)
 {
-	irq_enable(__builtin_ctz(mask));
+	esp_os_irq_enable(__builtin_ctz(mask));
 }
 
 static void intr_off(unsigned int mask)
 {
-	irq_disable(__builtin_ctz(mask));
+	esp_os_irq_disable(__builtin_ctz(mask));
 }
 
 static void *wifi_thread_semphr_get_wrapper(void)
 {
-	struct k_sem *sem = NULL;
+	esp_os_sem_t sem = esp_os_thread_custom_data_get();
 
-	sem = k_thread_custom_data_get();
 	if (!sem) {
-		sem = (struct k_sem *)wifi_malloc(sizeof(struct k_sem));
+		sem = esp_os_sem_create(0, 1);
 		if (sem == NULL) {
 			LOG_ERR("wifi_thread_semphr_get_wrapper allocation failed");
+			return NULL;
 		}
-		k_sem_init(sem, 0, 1);
-		if (sem) {
-			k_thread_custom_data_set(sem);
-		}
+		esp_os_thread_custom_data_set(sem);
 	}
 	return (void *)sem;
 }
 
 static void *recursive_mutex_create_wrapper(void)
 {
-	struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+	esp_os_mutex_t mutex = esp_os_mutex_create();
 
-	if (my_mutex == NULL) {
+	if (mutex == NULL) {
 		LOG_ERR("recursive_mutex_create_wrapper allocation failed");
+		return NULL;
 	}
 
-	k_mutex_init(my_mutex);
-
-	return (void *)my_mutex;
+	return (void *)mutex;
 }
 
 static void *mutex_create_wrapper(void)
 {
-	struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+	esp_os_mutex_t mutex = esp_os_mutex_create();
 
-	if (my_mutex == NULL) {
-		LOG_ERR("recursive_mutex_create_wrapper allocation failed");
+	if (mutex == NULL) {
+		LOG_ERR("mutex_create_wrapper allocation failed");
+		return NULL;
 	}
 
-	k_mutex_init(my_mutex);
-
-	return (void *)my_mutex;
+	return (void *)mutex;
 }
 
 static void mutex_delete_wrapper(void *mutex)
 {
-	esp_wifi_free(mutex);
+	esp_os_mutex_delete(mutex);
 }
 
 static int32_t IRAM_ATTR mutex_lock_wrapper(void *mutex)
 {
-	struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-	k_mutex_lock(my_mutex, K_FOREVER);
+	esp_os_mutex_lock(mutex, ESP_OS_FOREVER);
 	return 0;
 }
 
 static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 {
-	struct k_mutex *my_mutex = (struct k_mutex *)mutex;
-
-	k_mutex_unlock(my_mutex);
+	esp_os_mutex_unlock(mutex);
 	return 0;
 }
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-	struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
+	esp_os_queue_t queue = esp_os_queue_create(queue_len, item_size);
 
 	if (queue == NULL) {
 		LOG_ERR("queue malloc failed");
 		return NULL;
 	}
 
-	queue->buffer = wifi_malloc(queue_len * item_size);
-	if (queue->buffer == NULL) {
-		LOG_ERR("queue buffer malloc failed");
-		esp_wifi_free(queue);
-		return NULL;
-	}
-
-	k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
-
 	return (void *)queue;
 }
 
 static void queue_delete_wrapper(void *handle)
 {
-	if (handle != NULL) {
-		struct wifi_adapter_msgq *queue = handle;
-
-		esp_wifi_free(queue->buffer);
-		esp_wifi_free(queue);
-	}
+	esp_os_queue_delete(handle);
 }
 
 static void task_delete_wrapper(void *handle)
 {
-	k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
-	struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
+	esp_os_thread_delete((esp_os_thread_t)handle);
+}
 
-	if (tid == k_current_get()) {
-		k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
-		k_work_submit(&t->cleanup_work);
-		k_thread_abort(k_current_get());
-		CODE_UNREACHABLE;
-	}
+static uint32_t queue_block_time_ms(uint32_t block_time_tick)
+{
+    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
+        return ESP_OS_FOREVER;
+    }
 
-	k_thread_abort(tid);
-
-	if (tid->custom_data) {
-		esp_wifi_free(tid->custom_data);
-	}
-	
-	k_thread_stack_free(t->stack);
-	k_object_release(tid);
-	esp_wifi_free(t);
+    return (uint32_t)esp_os_ticks_to_ms(block_time_tick);
 }
 
 static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
@@ -323,12 +256,7 @@ static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_send(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -343,8 +271,7 @@ static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, v
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
+    ret = esp_os_queue_send(handle, item, ESP_OS_NO_WAIT);
     if (hpt) {
         *hpt = 0;
     }
@@ -367,8 +294,7 @@ static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t bl
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    ret = k_msgq_put_front(&queue->msgq, item);
+    ret = esp_os_queue_send_to_front(handle, item);
 
     return ret == 0 ? 1 : 0;
 }
@@ -382,12 +308,7 @@ static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
-    } else {
-        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
-    }
+    ret = esp_os_queue_recv(handle, item, queue_block_time_ms(block_time_tick));
 
     return ret == 0 ? 1 : 0;
 }
@@ -399,8 +320,7 @@ static uint32_t queue_msg_waiting_wrapper(void *handle)
         return 0;
     }
 
-    struct wifi_adapter_msgq *queue = handle;
-    return k_msgq_num_used_get(&queue->msgq);
+    return esp_os_queue_num_used(handle);
 }
 
 static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
@@ -413,24 +333,12 @@ static int32_t task_create_pinned_to_core_wrapper(void *task_func, const char *n
 	ARG_UNUSED(core_id);
 
 	uint32_t stack_size = MAX(stack_depth, CONFIG_ESP32_WIFI_TASK_STACK_SIZE);
-	struct wifi_task *t = wifi_malloc(sizeof(*t));
+	esp_os_thread_t tid = esp_os_thread_create((esp_os_thread_entry_t)task_func, param,
+						   stack_size, prio, name);
 
-	if (t == NULL) {
+	if (tid == NULL) {
 		return 0;
 	}
-
-	t->stack = k_thread_stack_alloc(stack_size,
-					IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0);
-	if (t->stack == NULL) {
-		esp_wifi_free(t);
-		return 0;
-	}
-
-	k_tid_t tid = k_thread_create(&t->thread, t->stack, stack_size,
-				      (k_thread_entry_t)task_func, param, NULL, NULL,
-				      prio, K_INHERIT_PERMS, K_NO_WAIT);
-
-	k_thread_name_set(tid, name);
 
 	*(int32_t *)task_handle = (int32_t)tid;
 	return 1;
@@ -443,7 +351,7 @@ static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t s
 
 static int32_t IRAM_ATTR task_ms_to_tick_wrapper(uint32_t ms)
 {
-	return (int32_t)(k_ms_to_ticks_ceil32(ms));
+	return esp_os_ms_to_ticks(ms);
 }
 
 static int32_t task_get_max_priority_wrapper(void)
@@ -518,12 +426,12 @@ static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-	return k_calloc(n, size);
+	return esp_os_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-	return k_calloc(1, size);
+	return esp_os_calloc(1, size);
 }
 
 void *xEventGroupCreate(void)
@@ -548,7 +456,7 @@ uint32_t xEventGroupClearBits(void *ptr, uint32_t data)
 
 void task_delay(uint32_t ticks)
 {
-	k_sleep(K_TICKS(ticks));
+	esp_os_sleep_ticks(ticks);
 }
 
 uint32_t esp_get_free_heap_size(void)
@@ -864,7 +772,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
 	._set_isr = set_isr_wrapper,
 	._ints_on = intr_on,
 	._ints_off = intr_off,
-	._is_from_isr = k_is_in_isr,
+	._is_from_isr = esp_os_is_in_isr,
 	._spin_lock_create = esp_coex_common_spin_lock_create_wrapper,
 	._spin_lock_delete = esp_wifi_free,
 	._wifi_int_disable = esp_coex_common_int_disable_wrapper,
@@ -898,7 +806,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
 	._task_delete = task_delete_wrapper,
 	._task_delay = task_delay,
 	._task_ms_to_tick = task_ms_to_tick_wrapper,
-	._task_get_current_task = (void *(*)(void))k_current_get,
+	._task_get_current_task = esp_os_thread_current,
 	._task_get_max_priority = task_get_max_priority_wrapper,
 	._malloc = wifi_malloc,
 	._free = esp_wifi_free,
@@ -942,7 +850,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
 	._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
 	._log_write = esp_log_write_wrapper,
 	._log_writev = esp_log_writev_wrapper,
-	._log_timestamp = k_uptime_get_32,
+	._log_timestamp = esp_os_uptime_ms32,
 	._malloc_internal = esp_coex_common_malloc_internal_wrapper,
 	._realloc_internal = realloc_internal_wrapper,
 	._calloc_internal = calloc_internal_wrapper,

--- a/components/spi_flash/cache_utils.c
+++ b/components/spi_flash/cache_utils.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdlib.h>
+#include <esp_os.h>
 #include <assert.h>
 #include <string.h>
 #include <stdio.h>
@@ -43,7 +44,7 @@ static esp_os_spinlock_t s_intr_saved_state = ESP_OS_SPINLOCK_INIT;
 static uint32_t s_flash_op_cache_state[2];
 
 #ifndef CONFIG_MCUBOOT
-K_MUTEX_DEFINE(s_flash_op_mutex);
+ESP_OS_MUTEX_DEFINE(s_flash_op_mutex);
 
 void spi_flash_init_lock(void)
 {
@@ -51,12 +52,12 @@ void spi_flash_init_lock(void)
 
 void spi_flash_op_lock(void)
 {
-    k_mutex_lock(&s_flash_op_mutex, K_FOREVER);
+    esp_os_mutex_lock(s_flash_op_mutex, ESP_OS_FOREVER);
 }
 
 void spi_flash_op_unlock(void)
 {
-    k_mutex_unlock(&s_flash_op_mutex);
+    esp_os_mutex_unlock(s_flash_op_mutex);
 }
 #endif /* !CONFIG_MCUBOOT */
 

--- a/components/spi_flash/flash_mmap.c
+++ b/components/spi_flash/flash_mmap.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdlib.h>
+#include <esp_os.h>
 #include <assert.h>
 #include <string.h>
 #include <stdio.h>
@@ -119,10 +120,10 @@ esp_err_t spi_flash_mmap(size_t src_addr, size_t size, spi_flash_mmap_memory_t m
 
 err:
     if (vaddr_list) {
-        k_free(vaddr_list);
+        esp_os_free(vaddr_list);
     }
     if (block) {
-        k_free(block);
+        esp_os_free(block);
     }
     return ret;
 }
@@ -191,7 +192,7 @@ esp_err_t spi_flash_mmap_pages(const int *pages, size_t page_count, spi_flash_mm
     int successful_cnt = 0;
 
     int block_num = s_find_non_contiguous_block_nums(pages, page_count);
-    int (*paddr_blocks)[2] = k_calloc(block_num, sizeof(int[2]));
+    int (*paddr_blocks)[2] = esp_os_calloc(block_num, sizeof(int[2]));
     if (!paddr_blocks) {
         return ESP_ERR_NO_MEM;
     }
@@ -242,7 +243,7 @@ esp_err_t spi_flash_mmap_pages(const int *pages, size_t page_count, spi_flash_mm
     *out_ptr = (void *)vaddr_list[0];
     *out_handle = (uint32_t)block;
 
-    k_free(paddr_blocks);
+    esp_os_free(paddr_blocks);
     return ESP_OK;
 
 err:
@@ -250,12 +251,12 @@ err:
         esp_mmu_unmap((void *)vaddr_list[i]);
     }
     if (vaddr_list) {
-        k_free(vaddr_list);
+        esp_os_free(vaddr_list);
     }
     if (block) {
-        k_free(block);
+        esp_os_free(block);
     }
-    k_free(paddr_blocks);
+    esp_os_free(paddr_blocks);
     return ret;
 }
 
@@ -272,8 +273,8 @@ void spi_flash_munmap(spi_flash_mmap_handle_t handle)
         }
     }
 
-    k_free(block->vaddr_list);
-    k_free(block);
+    esp_os_free(block->vaddr_list);
+    esp_os_free(block);
 }
 
 

--- a/components/spi_flash/spi_flash_os_func_app.c
+++ b/components/spi_flash/spi_flash_os_func_app.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdarg.h>
+#include <esp_os.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include "esp_attr.h"
@@ -31,7 +32,7 @@
 static const char TAG[] __attribute__((unused)) = "spi_flash";
 
 #if SPI_FLASH_CACHE_NO_DISABLE
-K_MUTEX_DEFINE(s_spi1_flash_mutex);
+ESP_OS_MUTEX_DEFINE(s_spi1_flash_mutex);
 #endif  //  #if SPI_FLASH_CACHE_NO_DISABLE
 
 /*
@@ -128,7 +129,7 @@ static IRAM_ATTR esp_err_t spi1_start(void *arg, uint32_t flags)
     //use the lock to disable the cache and interrupts before using the SPI bus
     ret = acquire_spi_bus_lock(arg);
 #elif SPI_FLASH_CACHE_NO_DISABLE
-    k_mutex_lock(&s_spi1_flash_mutex, K_FOREVER);
+    esp_os_mutex_lock(s_spi1_flash_mutex, ESP_OS_FOREVER);
 #else
     //directly disable the cache and interrupts when lock is not used
     cache_disable(NULL);
@@ -163,7 +164,7 @@ static IRAM_ATTR esp_err_t spi1_end(void *arg)
 #if CONFIG_SPI_FLASH_SHARE_SPI1_BUS
     ret = release_spi_bus_lock(arg);
 #elif SPI_FLASH_CACHE_NO_DISABLE
-    k_mutex_unlock(&s_spi1_flash_mutex);
+    esp_os_mutex_unlock(s_spi1_flash_mutex);
 #else
     cache_enable(NULL);
 #endif
@@ -190,14 +191,14 @@ static esp_err_t spi_flash_os_check_yield(void *arg, uint32_t chip_status, uint3
 
 static esp_err_t spi_flash_os_yield(void *arg, uint32_t* out_status)
 {
-    /* k_sleep requires an active thread context. Skip the yield if the
+    /* Sleeping requires an active thread context. Skip the yield if the
      * kernel is not yet running (e.g. early boot flash erase recovery).
      */
-    if (!k_is_pre_kernel()) {
+    if (!esp_os_is_pre_kernel()) {
 #ifdef CONFIG_SPI_FLASH_ERASE_YIELD_TICKS
-        k_sleep(K_TICKS(CONFIG_SPI_FLASH_ERASE_YIELD_TICKS));
+        esp_os_sleep_ticks(CONFIG_SPI_FLASH_ERASE_YIELD_TICKS);
 #else
-        k_sleep(K_MSEC(1));
+        esp_os_sleep_ms(1);
 #endif
     }
     on_spi_yielded((app_func_arg_t*)arg);
@@ -222,7 +223,7 @@ static void* get_buffer_malloc(void* arg, size_t reqest_size, size_t* out_size)
     size_t read_chunk_size = (reqest_size + 3) & ~3;
 
     while (ret == NULL && read_chunk_size >= 64) {
-        ret = k_malloc(read_chunk_size);
+        ret = esp_os_malloc(read_chunk_size);
         if (ret == NULL) {
             read_chunk_size = (read_chunk_size / 2) & ~3;
         }
@@ -235,7 +236,7 @@ static void* get_buffer_malloc(void* arg, size_t reqest_size, size_t* out_size)
 
 static void release_buffer_malloc(void* arg, void *temp_buf)
 {
-    k_free(temp_buf);
+    esp_os_free(temp_buf);
 }
 
 #ifndef __ZEPHYR__
@@ -326,7 +327,7 @@ esp_err_t esp_flash_init_os_functions(esp_flash_t *chip, int host_id, spi_bus_lo
         return ESP_ERR_INVALID_ARG;
     }
 
-    chip->os_func_data = k_malloc(sizeof(app_func_arg_t));
+    chip->os_func_data = esp_os_malloc(sizeof(app_func_arg_t));
     if (chip->os_func_data == NULL) {
         return ESP_ERR_NO_MEM;
     }
@@ -361,7 +362,7 @@ esp_err_t esp_flash_deinit_os_functions(esp_flash_t* chip, spi_bus_lock_dev_hand
     if (chip->os_func_data) {
         // SPI bus lock is possibly not used on SPI1 bus
         *out_dev_handle = ((app_func_arg_t*)chip->os_func_data)->dev_lock;
-        k_free(chip->os_func_data);
+        esp_os_free(chip->os_func_data);
     }
     chip->os_func = NULL;
     chip->os_func_data = NULL;

--- a/components/wpa_supplicant/port/eloop.c
+++ b/components/wpa_supplicant/port/eloop.c
@@ -20,6 +20,7 @@
 #include "esp_wifi_driver.h"
 #include "rom/ets_sys.h"
 #include <zephyr/sys/atomic.h>
+#include <esp_os.h>
 #include <stdint.h>
 
 bool current_task_is_wifi_task(void);
@@ -65,7 +66,7 @@ static atomic_t eloop_lifecycle_busy = ATOMIC_INIT(0);
 static void eloop_lifecycle_lock(void)
 {
     while (!atomic_cas(&eloop_lifecycle_busy, 0, 1)) {
-        k_msleep(1);
+        esp_os_sleep_ms(1);
     }
 }
 
@@ -951,7 +952,7 @@ void eloop_destroy(void)
                        (unsigned int)atomic_get(&eloop.dispatch_count), wait_warn_loops * wait_step_ms);
             wait_loops = 0;
         }
-        k_msleep(wait_step_ms);
+        esp_os_sleep_ms(wait_step_ms);
     }
 
 #ifdef ELOOP_DEBUG

--- a/components/wpa_supplicant/port/os_xtensa.c
+++ b/components/wpa_supplicant/port/os_xtensa.c
@@ -23,6 +23,7 @@
  */
 
 #include "os.h"
+#include <esp_os.h>
 #include <stdlib.h>
 #include "esp_system.h"
 #include "utils/common.h"
@@ -35,9 +36,9 @@ int os_get_time(struct os_time *t)
 		return -1;
 	}
 
-	int64_t now = k_uptime_ticks();
+	int64_t now = esp_os_uptime_ticks();
 	t->sec = now / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-	t->usec = k_ticks_to_us_floor64(now);
+	t->usec = esp_os_ticks_to_us(now);
 
 	return 0;
 }
@@ -56,17 +57,17 @@ int os_get_random(unsigned char *buf, size_t len)
 void os_sleep(os_time_t sec, os_time_t usec)
 {
     if (sec) {
-        k_sleep(K_SECONDS(sec));
+        esp_os_sleep_sec(sec);
     }
     if (usec) {
-        k_sleep(K_USEC(usec));
+        esp_os_sleep_us(usec);
     }
 }
 
 char *z_strdup(const char *s)
 {
     size_t size = strlen(s) + 1;
-    char *p = k_malloc(size);
+    char *p = esp_os_malloc(size);
     if (p) {
         memcpy(p, s, size);
     }

--- a/zephyr/common/include/esp_critical_section.h
+++ b/zephyr/common/include/esp_critical_section.h
@@ -42,10 +42,9 @@
 
 #pragma once
 
-#include <zephyr/kernel.h>
-#include <zephyr/irq.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
+#include <esp_os.h>
 #include "esp_cpu.h"
 
 #ifdef __cplusplus
@@ -71,7 +70,7 @@ typedef struct {
 
 static ALWAYS_INLINE void esp_critical_section_enter(esp_critical_section_t *l)
 {
-    unsigned int flags = arch_irq_lock();
+    unsigned int flags = esp_os_arch_irq_lock();
 
 #ifdef CONFIG_SMP
     atomic_val_t me = (atomic_val_t)esp_cpu_get_core_id();
@@ -98,7 +97,7 @@ static ALWAYS_INLINE void esp_critical_section_enter(esp_critical_section_t *l)
      */
     while (!atomic_cas(&l->owner_cpu, ESP_CRITICAL_SECTION_UNOWNED, me)) {
         /* Busy-wait. Interrupts are off on this CPU; the holding
-         * CPU will release soon. arch_spin_relax() is a no-op on
+         * CPU will release soon. A CPU relax hint is a no-op on
          * current hal_espressif targets, so it is omitted here.
          */
     }
@@ -125,7 +124,7 @@ static ALWAYS_INLINE void esp_critical_section_exit(esp_critical_section_t *l)
      */
     if (l->count == 0) {
         __ASSERT(false, "esp_critical_section_exit: unpaired exit on %p", l);
-        k_panic();
+        esp_os_panic();
         return;
     }
 
@@ -139,11 +138,11 @@ static ALWAYS_INLINE void esp_critical_section_exit(esp_critical_section_t *l)
          * writes we made while holding the lock.
          */
         atomic_set(&l->owner_cpu, ESP_CRITICAL_SECTION_UNOWNED);
-        arch_irq_unlock(flags);
+        esp_os_arch_irq_unlock(flags);
     }
 #else
     if (--l->count == 0) {
-        arch_irq_unlock(l->saved_irq_key);
+        esp_os_arch_irq_unlock(l->saved_irq_key);
     }
 #endif
 }

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -4,7 +4,7 @@ package-managers:
     requirement-files:
       - zephyr/requirements.txt
 build:
-  cmake: zephyr
+  cmake-ext: True
   kconfig: zephyr/Kconfig
   settings:
     dts_root: .

--- a/zephyr/port/heap/heap_caps_zephyr.c
+++ b/zephyr/port/heap/heap_caps_zephyr.c
@@ -7,10 +7,10 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <zephyr/kernel.h>
 #include <zephyr/sys/math_extras.h>
 #include <esp_attr.h>
 #include <esp_heap_caps.h>
+#include <esp_os.h>
 
 static esp_alloc_failed_hook_t alloc_failed_callback;
 
@@ -42,7 +42,7 @@ Routine to allocate a bit of memory with certain capabilities. caps is a bitfiel
 static void *heap_caps_malloc_base( size_t size, uint32_t caps)
 {
 
-    void *ptr = k_malloc(size);
+    void *ptr = esp_os_malloc(size);
 
     if (!ptr && size > 0) {
         heap_caps_alloc_failed(size, caps, __func__);
@@ -75,7 +75,7 @@ void *heap_caps_malloc_prefer( size_t size, size_t num, ... )
 
 static void *heap_caps_realloc_base( void *ptr, size_t size, uint32_t caps)
 {
-    ptr = k_realloc(ptr, size);
+    ptr = esp_os_realloc(ptr, size);
 
     if (ptr == NULL && size > 0) {
         heap_caps_alloc_failed(size, caps, __func__);
@@ -101,7 +101,7 @@ void *heap_caps_realloc_prefer( void *ptr, size_t size, size_t num, ... )
 
 void heap_caps_free( void *ptr)
 {
-    k_free(ptr);
+    esp_os_free(ptr);
 }
 
 static void *heap_caps_calloc_base( size_t n, size_t size, uint32_t caps)
@@ -112,7 +112,7 @@ static void *heap_caps_calloc_base( size_t n, size_t size, uint32_t caps)
         return NULL;
     }
 
-    return k_calloc(n, size);
+    return esp_os_calloc(n, size);
 }
 
 void *heap_caps_calloc( size_t n, size_t size, uint32_t caps)
@@ -198,7 +198,7 @@ size_t heap_caps_get_allocated_size( void *ptr )
 
 void *heap_caps_aligned_alloc(size_t alignment, size_t size, uint32_t caps)
 {
-    void *ptr = k_aligned_alloc(alignment, size);
+    void *ptr = esp_os_aligned_alloc(alignment, size);
 
     if (!ptr && size > 0) {
         heap_caps_alloc_failed(size, caps, __func__);

--- a/zephyr/port/include/esp_heap_adapter.h
+++ b/zephyr/port/include/esp_heap_adapter.h
@@ -6,21 +6,23 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
-#include <zephyr/kernel.h>
 #include <zephyr/multi_heap/shared_multi_heap.h>
+#include <esp_os.h>
 
 /* Select heap to be used for WiFi adapter and WPA supplicant */
 #if defined(CONFIG_ESP_WIFI_HEAP_SYSTEM)
 
-#define esp_wifi_malloc_func(_size)         k_malloc(_size)
-#define esp_wifi_calloc_func(_nmemb, _size) k_calloc(_nmemb, _size)
-#define esp_wifi_free_func(_mem)            k_free(_mem)
+#define esp_wifi_malloc_func(_size)         esp_os_malloc(_size)
+#define esp_wifi_calloc_func(_nmemb, _size) esp_os_calloc(_nmemb, _size)
+#define esp_wifi_free_func(_mem)            esp_os_free(_mem)
 
-#define os_wpa_malloc_func(_size)         k_malloc(_size)
-#define os_wpa_realloc_func(_ptr, _size)  k_realloc(_ptr, _size)
-#define os_wpa_calloc_func(_nmemb, _size) k_calloc(_nmemb, _size)
-#define os_wpa_free_func(_mem)            k_free(_mem)
+#define os_wpa_malloc_func(_size)         esp_os_malloc(_size)
+#define os_wpa_realloc_func(_ptr, _size)  esp_os_realloc(_ptr, _size)
+#define os_wpa_calloc_func(_nmemb, _size) esp_os_calloc(_nmemb, _size)
+#define os_wpa_free_func(_mem)            esp_os_free(_mem)
 
 #elif defined(CONFIG_ESP_WIFI_HEAP_SPIRAM)
 
@@ -43,7 +45,7 @@ static inline void* esp_wifi_calloc_func(size_t _nmemb, size_t _size)
 static inline void esp_wifi_free_func(void *_mem)
 {
 	if (esp_ptr_in_dram(_mem)) {
-		k_free(_mem);
+		esp_os_free(_mem);
 	} else {
 		shared_multi_heap_free(_mem);
 	}
@@ -91,10 +93,10 @@ static inline void os_wpa_free_func(void *_mem)
 /* Select heap to be used for BLE adapter */
 #if defined(CONFIG_ESP_BT_HEAP_SYSTEM)
 
-#define esp_bt_malloc_func(_size) k_malloc(_size)
-#define esp_bt_calloc_func(_nmemb, _size) k_calloc(_nmemb, _size)
-#define esp_bt_realloc_func(_ptr, _size) k_realloc(_ptr, _size)
-#define esp_bt_free_func(_mem)    k_free(_mem)
+#define esp_bt_malloc_func(_size) esp_os_malloc(_size)
+#define esp_bt_calloc_func(_nmemb, _size) esp_os_calloc(_nmemb, _size)
+#define esp_bt_realloc_func(_ptr, _size) esp_os_realloc(_ptr, _size)
+#define esp_bt_free_func(_mem)    esp_os_free(_mem)
 
 #elif defined(CONFIG_ESP_BT_HEAP_SPIRAM)
 


### PR DESCRIPTION
Replace every Wi-Fi, coex, Bluetooth controller, NimBLE porting, esp_timer, supplicant port, heap binding and HAL internal direct Zephyr kernel call with the esp_os glue, so no source references a kernel object directly. Thread stacks are created dynamically, matching how the controllers expect the OS to own task stack memory, so the static stack definitions are removed.

The glue itself lives in the Zephyr tree under
modules/hal_espressif/os_wrapper, alongside the other vendor OS wrappers. Switch the module to an external cmake so that tree-side entry point builds the glue, while the HAL Kconfig keeps the standard module entry to avoid a recursive source at repo root.