### PR TITLE
wifi: fix wpa2 tkip crash caused by rom hmac_md5

### DIFF
--- a/components/esp_rom/esp32/ld/esp32.rom.syscalls.ld
+++ b/components/esp_rom/esp32/ld/esp32.rom.syscalls.ld
@@ -61,6 +61,11 @@ PROVIDE ( _write_r = 0x4000bd70 );
 close = 0x40001778;
 open = 0x4000178c;
 read = 0x400017dc;
-sbrk = 0x400017f4;
+/* The ROM implementations below route through
+ * syscall_table_ptr, which this port never installs, and
+ * would fault on a NULL pointer if a libc build ever
+ * referenced them. Keep the compiled libc versions instead.
+ */
+/* sbrk = 0x400017f4; */
 times = 0x40001808;
 write = 0x4000181c;

--- a/components/esp_rom/esp32c2/ld/esp32c2.rom.libc.ld
+++ b/components/esp_rom/esp32c2/ld/esp32c2.rom.libc.ld
@@ -8,7 +8,12 @@ memset = 0x40000488;
 strlen = 0x400004a8;
 strstr = 0x400004ac;
 bzero = 0x400004b0;
-sbrk = 0x400004b8;
+/* The ROM implementations below route through
+ * syscall_table_ptr, which this port never installs, and
+ * would fault on a NULL pointer if a libc build ever
+ * referenced them. Keep the compiled libc versions instead.
+ */
+/* sbrk = 0x400004b8; */
 isascii = 0x400004c4;
 isblank = 0x400004c8;
 iscntrl = 0x400004cc;

--- a/components/esp_rom/esp32c2/ld/esp32c2.rom.newlib.ld
+++ b/components/esp_rom/esp32c2/ld/esp32c2.rom.newlib.ld
@@ -40,7 +40,8 @@
 /* _isatty_r = 0x400004b4; */
 /* __smakebuf_r = 0x400005a0; */
 /* __swhatbuf_r = 0x400005a4; */
-__swbuf = 0x400005ac;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swbuf = 0x400005ac; */
 /* Zephyr: reentrant ROM call, provided by the selected libc */
 /* __swsetup_r = 0x400005b0; */
 toupper = 0x400004ec;

--- a/components/esp_rom/esp32c3/ld/esp32c3.rom.libc.ld
+++ b/components/esp_rom/esp32c3/ld/esp32c3.rom.libc.ld
@@ -8,7 +8,12 @@ memset = 0x40000354;
 strlen = 0x40000374;
 strstr = 0x40000378;
 bzero = 0x4000037c;
-sbrk = 0x40000384;
+/* The ROM implementation routes through syscall_table_ptr,
+ * which this port never installs, and would fault on a NULL
+ * pointer if a libc build ever referenced it. Keep the
+ * compiled libc version instead.
+ * sbrk = 0x40000384;
+ */
 isascii = 0x40000390;
 isblank = 0x40000394;
 iscntrl = 0x40000398;

--- a/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld
+++ b/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld
@@ -36,7 +36,12 @@
 /* __swbuf_r    = 0x40000474; */
 
 /* Functions */
-__swbuf = 0x40000478;
+/* The ROM implementation routes through syscall_table_ptr,
+ * which this port never installs, and would fault on a NULL
+ * pointer if a libc build ever referenced it. Keep the
+ * compiled libc version instead.
+ * __swbuf = 0x40000478;
+ */
 toupper = 0x400003b8;
 tolower = 0x400003bc;
 isalnum = 0x40000388;

--- a/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld
+++ b/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld
@@ -50,5 +50,11 @@ strcoll = 0x400003e8;
 strlwr = 0x400003f4;
 strncasecmp = 0x400003f8;
 strupr = 0x40000418;
-hmac_md5_vector = 0x40000620;
-hmac_md5 = 0x40000624;
+/* The ROM hmac_md5 implementations call the ROM malloc, which
+ * dispatches through syscall_table_ptr. That table is never
+ * installed in this port, so any call faults on a NULL pointer.
+ * The supplicant builds its own hmac_md5/hmac_md5_vector from
+ * src/crypto/md5.c, which must win the link instead.
+ * hmac_md5_vector = 0x40000620;
+ * hmac_md5 = 0x40000624;
+ */

--- a/components/esp_rom/esp32c5/ld/esp32c5.rom.libc.ld
+++ b/components/esp_rom/esp32c5/ld/esp32c5.rom.libc.ld
@@ -27,7 +27,12 @@ memset = 0x400004b8;
 strlen = 0x400004d8;
 strstr = 0x400004dc;
 bzero = 0x400004e0;
-sbrk = 0x400004e8;
+/* The ROM implementations below route through
+ * syscall_table_ptr, which this port never installs, and
+ * would fault on a NULL pointer if a libc build ever
+ * referenced them. Keep the compiled libc versions instead.
+ */
+/* sbrk = 0x400004e8; */
 isascii = 0x400004f4;
 isblank = 0x400004f8;
 iscntrl = 0x400004fc;

--- a/components/esp_rom/esp32c5/ld/esp32c5.rom.newlib.ld
+++ b/components/esp_rom/esp32c5/ld/esp32c5.rom.newlib.ld
@@ -38,7 +38,8 @@
 /* _isatty_r = 0x400004e4; */
 /* __smakebuf_r = 0x400005d0; */
 /* __swhatbuf_r = 0x400005d4; */
-__swbuf = 0x400005dc;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swbuf = 0x400005dc; */
 /* Zephyr: reentrant ROM call, provided by the selected libc */
 /* __swsetup_r = 0x400005e0; */
 toupper = 0x4000051c;

--- a/components/esp_rom/esp32c6/ld/esp32c6.rom.libc.ld
+++ b/components/esp_rom/esp32c6/ld/esp32c6.rom.libc.ld
@@ -13,7 +13,12 @@ memset = 0x400004a8;
 strlen = 0x400004c8;
 strstr = 0x400004cc;
 bzero = 0x400004d0;
-sbrk = 0x400004d8;
+/* The ROM implementations below route through
+ * syscall_table_ptr, which this port never installs, and
+ * would fault on a NULL pointer if a libc build ever
+ * referenced them. Keep the compiled libc versions instead.
+ */
+/* sbrk = 0x400004d8; */
 isascii = 0x400004e4;
 isblank = 0x400004e8;
 iscntrl = 0x400004ec;

--- a/components/esp_rom/esp32c6/ld/esp32c6.rom.newlib.ld
+++ b/components/esp_rom/esp32c6/ld/esp32c6.rom.newlib.ld
@@ -40,7 +40,8 @@
 /* _isatty_r = 0x400004d4; */
 /* __smakebuf_r = 0x400005c0; */
 /* __swhatbuf_r = 0x400005c4; */
-__swbuf = 0x400005cc;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swbuf = 0x400005cc; */
 /* Zephyr: reentrant ROM call, provided by the selected libc */
 /* __swsetup_r = 0x400005d0; */
 toupper = 0x4000050c;

--- a/components/esp_rom/esp32h2/ld/esp32h2.rom.libc.ld
+++ b/components/esp_rom/esp32h2/ld/esp32h2.rom.libc.ld
@@ -8,7 +8,12 @@ memset = 0x400004a0;
 strlen = 0x400004c0;
 strstr = 0x400004c4;
 bzero = 0x400004c8;
-sbrk = 0x400004d0;
+/* The ROM implementations below route through
+ * syscall_table_ptr, which this port never installs, and
+ * would fault on a NULL pointer if a libc build ever
+ * referenced them. Keep the compiled libc versions instead.
+ */
+/* sbrk = 0x400004d0; */
 isascii = 0x400004dc;
 isblank = 0x400004e0;
 iscntrl = 0x400004e4;

--- a/components/esp_rom/esp32h2/ld/esp32h2.rom.newlib.ld
+++ b/components/esp_rom/esp32h2/ld/esp32h2.rom.newlib.ld
@@ -43,7 +43,8 @@
 /* Zephyr: reentrant ROM call, provided by the selected libc */
 /* __swbuf_r = 0x400005c0; */
 
-__swbuf = 0x400005c4;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swbuf = 0x400005c4; */
 /* Zephyr: reentrant ROM call, provided by the selected libc */
 /* __swsetup_r = 0x400005c8; */
 toupper = 0x40000504;

--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.libc.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.libc.ld
@@ -8,7 +8,12 @@ memset = 0x4fc00268;
 strlen = 0x4fc00288;
 strstr = 0x4fc0028c;
 bzero = 0x4fc00290;
-sbrk = 0x4fc00298;
+/* The ROM implementations below route through
+ * syscall_table_ptr, which this port never installs, and
+ * would fault on a NULL pointer if a libc build ever
+ * referenced them. Keep the compiled libc versions instead.
+ */
+/* sbrk = 0x4fc00298; */
 isascii = 0x4fc002a4;
 isblank = 0x4fc002a8;
 iscntrl = 0x4fc002ac;

--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.newlib.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.eco0_4.newlib.ld
@@ -43,7 +43,8 @@
 /* Zephyr: reentrant ROM call, provided by the selected libc */
 /* __swbuf_r = 0x4fc00388; */
 
-__swbuf = 0x4fc0038c;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swbuf = 0x4fc0038c; */
 /* Zephyr: reentrant ROM call, provided by the selected libc */
 /* __swsetup_r = 0x4fc00390; */
 toupper = 0x4fc002cc;

--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.libc.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.libc.ld
@@ -13,7 +13,12 @@ memset = 0x4fc00268;
 strlen = 0x4fc00288;
 strstr = 0x4fc0028c;
 bzero = 0x4fc00290;
-sbrk = 0x4fc00298;
+/* The ROM implementations below route through
+ * syscall_table_ptr, which this port never installs, and
+ * would fault on a NULL pointer if a libc build ever
+ * referenced them. Keep the compiled libc versions instead.
+ */
+/* sbrk = 0x4fc00298; */
 isalnum = 0x4fc0029c;
 isalpha = 0x4fc002a0;
 isascii = 0x4fc002a4;

--- a/components/esp_rom/esp32p4/ld/esp32p4.rom.newlib.ld
+++ b/components/esp_rom/esp32p4/ld/esp32p4.rom.newlib.ld
@@ -40,6 +40,7 @@
 /* _isatty_r = 0x4fc00294; */
 /* __smakebuf_r = 0x4fc00380; */
 /* __swhatbuf_r = 0x4fc00384; */
-__swbuf = 0x4fc0038c;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swbuf = 0x4fc0038c; */
 /* Zephyr: reentrant ROM call, provided by the selected libc */
 /* __swsetup_r = 0x4fc00390; */

--- a/components/esp_rom/esp32s3/ld/esp32s3.rom.libc.ld
+++ b/components/esp_rom/esp32s3/ld/esp32s3.rom.libc.ld
@@ -15,7 +15,12 @@ strncmp = 0x4000123c;
 strlen = 0x40001248;
 strstr = 0x40001254;
 bzero = 0x40001260;
-sbrk = 0x40001278;
+/* The ROM implementation routes through syscall_table_ptr,
+ * which this port never installs, and would fault on a NULL
+ * pointer if a libc build ever referenced it. Keep the
+ * compiled libc version instead.
+ * sbrk = 0x40001278;
+ */
 isascii = 0x4000129c;
 isblank = 0x400012a8;
 iscntrl = 0x400012b4;

--- a/components/esp_rom/esp32s3/ld/esp32s3.rom.newlib.ld
+++ b/components/esp_rom/esp32s3/ld/esp32s3.rom.newlib.ld
@@ -46,5 +46,11 @@ strcoll = 0x400013a4;
 strlwr = 0x400013c8;
 strncasecmp = 0x400013d4;
 strupr = 0x40001434;
-hmac_md5_vector = 0x40001c80;
-hmac_md5 = 0x40001c8c;
+/* The ROM hmac_md5 implementations call the ROM malloc, which
+ * dispatches through syscall_table_ptr. That table is never
+ * installed in this port, so any call faults on a NULL pointer.
+ * The supplicant builds its own hmac_md5/hmac_md5_vector from
+ * src/crypto/md5.c, which must win the link instead.
+ * hmac_md5_vector = 0x40001c80;
+ * hmac_md5 = 0x40001c8c;
+ */

--- a/components/esp_rom/esp32s3/ld/esp32s3.rom.newlib.ld
+++ b/components/esp_rom/esp32s3/ld/esp32s3.rom.newlib.ld
@@ -32,7 +32,8 @@
 /* _fwalk       = 0x40001518; */
 /* _fwalk_reent = 0x40001524; */
 /* __swbuf_r    = 0x40001548; */
-__swbuf = 0x40001554;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swbuf = 0x40001554; */
 toupper = 0x40001314;
 tolower = 0x40001320;
 isalnum = 0x40001284;

--- a/components/wpa_supplicant/port/os_xtensa.c
+++ b/components/wpa_supplicant/port/os_xtensa.c
@@ -35,9 +35,10 @@ int os_get_time(struct os_time *t)
 		return -1;
 	}
 
-	int64_t now = k_uptime_ticks();
-	t->sec = now / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-	t->usec = k_ticks_to_us_floor64(now);
+	uint64_t now_us = k_ticks_to_us_floor64(k_uptime_ticks());
+
+	t->sec = now_us / USEC_PER_SEC;
+	t->usec = now_us % USEC_PER_SEC;
 
 	return 0;
 }


### PR DESCRIPTION
Stop linking the ROM hmac_md5 (and other syscall-table dependent libc exports), whose internal ROM malloc dereferences the never installed syscall_table_ptr, crashing TKIP connections on ESP32-S3/C3. Also fix os_get_time so supplicant eloop timers (EAPOL retransmissions) actually fire