### PR TITLE
esp32s3/p4: add smp support

### DIFF
--- a/components/bt/controller/esp32/bt.c
+++ b/components/bt/controller/esp32/bt.c
@@ -833,11 +833,23 @@ static int32_t IRAM_ATTR queue_recv_from_isr_wrapper(void *queue, void *item, vo
 
 static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t stack_depth, void *param, uint32_t prio, void *task_handle, uint32_t core_id)
 {
+    ARG_UNUSED(core_id);
+
+    /* The controller asserts its task runs on the configured core, so pin it
+     * (create suspended, pin, then start) instead of letting the scheduler
+     * float it.
+     */
     k_tid_t tid = k_thread_create(&bt_task_handle, bt_stack, stack_depth,
                       (k_thread_entry_t)task_func, param, NULL, NULL,
-                      K_PRIO_COOP(prio), K_INHERIT_PERMS, K_NO_WAIT);
+                      K_PRIO_COOP(prio), K_INHERIT_PERMS,
+                      IS_ENABLED(CONFIG_SMP) ? K_FOREVER : K_NO_WAIT);
 
     k_thread_name_set(tid, name);
+
+#if defined(CONFIG_SMP)
+    k_thread_cpu_pin(tid, CONFIG_ESP32_BT_CTLR_PINNED_TO_CORE);
+    k_thread_start(tid);
+#endif
 
     *(int32_t *)task_handle = (int32_t)tid;
 

--- a/components/esp_hw_support/esp_gpio_reserve.c
+++ b/components/esp_hw_support/esp_gpio_reserve.c
@@ -11,28 +11,31 @@
 
 #ifdef __ZEPHYR__
 #include <zephyr/irq.h>
+#include <zephyr/arch/cpu.h>
 
 /*
- * Use interrupt locking instead of Zephyr spinlocks because this code runs
- * during early boot before the kernel is initialized (e.g., PSRAM init).
+ * Use arch_irq_lock instead of irq_lock because this code runs during early
+ * boot before the kernel threading model is up (e.g., PSRAM init). Under SMP,
+ * irq_lock() resolves to z_smp_global_lock() which dereferences _current and
+ * is unsafe pre-kernel.
  */
 static uint64_t s_reserved_pin_mask = ~(SOC_GPIO_VALID_GPIO_MASK);
 
 uint64_t esp_gpio_reserve(uint64_t gpio_mask)
 {
-    unsigned int key = irq_lock();
+    unsigned int key = arch_irq_lock();
     uint64_t prev = s_reserved_pin_mask;
     s_reserved_pin_mask |= gpio_mask;
-    irq_unlock(key);
+    arch_irq_unlock(key);
     return prev;
 }
 
 uint64_t esp_gpio_revoke(uint64_t gpio_mask)
 {
-    unsigned int key = irq_lock();
+    unsigned int key = arch_irq_lock();
     uint64_t prev = s_reserved_pin_mask;
     s_reserved_pin_mask &= ~gpio_mask;
-    irq_unlock(key);
+    arch_irq_unlock(key);
     return prev;
 }
 

--- a/components/esp_hw_support/port/esp32s3/esp_cpu_intr.c
+++ b/components/esp_hw_support/port/esp32s3/esp_cpu_intr.c
@@ -22,16 +22,13 @@ typedef struct {
 
 const static intr_desc_t intr_desc_table [SOC_CPU_INTR_NUM] = {
     /* Interrupt 0 reserved for WMAC (Wifi) */
-#if CONFIG_ESP_WIFI_TASK_PINNED_TO_CORE_0
-    [0] = { 1, ESP_CPU_INTR_TYPE_LEVEL,  { ESP_CPU_INTR_DESC_FLAG_RESVD,   0                               } },
-#else
-    [0] = { 1, ESP_CPU_INTR_TYPE_LEVEL,  { 0,                              ESP_CPU_INTR_DESC_FLAG_RESVD    } },
-#endif
-    [1] = { 1, ESP_CPU_INTR_TYPE_LEVEL,  { 0,                              0                               } },
+    [0] = { 1, ESP_CPU_INTR_TYPE_LEVEL,  { ESP_CPU_INTR_DESC_FLAG_RESVD,   ESP_CPU_INTR_DESC_FLAG_RESVD    } },
+    /* Interrupt 1 used by the WiFi blob alongside int 0 */
+    [1] = { 1, ESP_CPU_INTR_TYPE_LEVEL,  { ESP_CPU_INTR_DESC_FLAG_RESVD,   ESP_CPU_INTR_DESC_FLAG_RESVD    } },
     [2] = { 1, ESP_CPU_INTR_TYPE_LEVEL,  { 0,                              0                               } },
     [3] = { 1, ESP_CPU_INTR_TYPE_LEVEL,  { 0,                              0                               } },
     /* Interrupt 4 reserved for WBB */
-    [4] = { 1, ESP_CPU_INTR_TYPE_LEVEL,  { ESP_CPU_INTR_DESC_FLAG_RESVD,   0                               } },
+    [4] = { 1, ESP_CPU_INTR_TYPE_LEVEL,  { ESP_CPU_INTR_DESC_FLAG_RESVD,   ESP_CPU_INTR_DESC_FLAG_RESVD    } },
     [5] = { 1, ESP_CPU_INTR_TYPE_LEVEL,  { 0,                              0                               } },
     [6] = { 1, ESP_CPU_INTR_TYPE_NA,     { ESP_CPU_INTR_DESC_FLAG_SPECIAL, ESP_CPU_INTR_DESC_FLAG_SPECIAL  } },
     [7] = { 1, ESP_CPU_INTR_TYPE_NA,     { ESP_CPU_INTR_DESC_FLAG_SPECIAL, ESP_CPU_INTR_DESC_FLAG_SPECIAL  } },

--- a/components/esp_hw_support/regi2c_ctrl.c
+++ b/components/esp_hw_support/regi2c_ctrl.c
@@ -8,6 +8,7 @@
 #include "esp_attr.h"
 #include <stdint.h>
 #include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/sys/__assert.h>
 #include "esp_private/critical_section.h"
 #include "hal/regi2c_ctrl.h"
@@ -18,9 +19,9 @@ uint8_t regi2c_ctrl_read_reg(uint8_t block, uint8_t host_id, uint8_t reg_add)
 {
     REGI2C_CLOCK_ENABLE();
     int __DECLARE_REGI2C_ATOMIC_ENV __attribute__((unused));
-    unsigned int key = irq_lock();
+    unsigned int key = arch_irq_lock();
     uint8_t value = regi2c_impl_read(block, host_id, reg_add);
-    irq_unlock(key);
+    arch_irq_unlock(key);
     REGI2C_CLOCK_DISABLE();
     return value;
 }
@@ -29,9 +30,9 @@ uint8_t regi2c_ctrl_read_reg_mask(uint8_t block, uint8_t host_id, uint8_t reg_ad
 {
     REGI2C_CLOCK_ENABLE();
     int __DECLARE_REGI2C_ATOMIC_ENV __attribute__((unused));
-    unsigned int key = irq_lock();
+    unsigned int key = arch_irq_lock();
     uint8_t value = regi2c_impl_read_mask(block, host_id, reg_add, msb, lsb);
-    irq_unlock(key);
+    arch_irq_unlock(key);
     REGI2C_CLOCK_DISABLE();
     return value;
 }
@@ -40,9 +41,9 @@ void regi2c_ctrl_write_reg(uint8_t block, uint8_t host_id, uint8_t reg_add, uint
 {
     REGI2C_CLOCK_ENABLE();
     int __DECLARE_REGI2C_ATOMIC_ENV __attribute__((unused));
-    unsigned int key = irq_lock();
+    unsigned int key = arch_irq_lock();
     regi2c_impl_write(block, host_id, reg_add, data);
-    irq_unlock(key);
+    arch_irq_unlock(key);
     REGI2C_CLOCK_DISABLE();
 }
 
@@ -50,9 +51,9 @@ void regi2c_ctrl_write_reg_mask(uint8_t block, uint8_t host_id, uint8_t reg_add,
 {
     REGI2C_CLOCK_ENABLE();
     int __DECLARE_REGI2C_ATOMIC_ENV __attribute__((unused));
-    unsigned int key = irq_lock();
+    unsigned int key = arch_irq_lock();
     regi2c_impl_write_mask(block, host_id, reg_add, msb, lsb, data);
-    irq_unlock(key);
+    arch_irq_unlock(key);
     REGI2C_CLOCK_DISABLE();
 }
 

--- a/components/esp_mm/esp_cache_utils.c
+++ b/components/esp_mm/esp_cache_utils.c
@@ -101,6 +101,11 @@ void esp_cache_freeze_caches_disable_interrupts(void)
      * - disable non-iram interrupt on current core
      * - current core call cache freeze
      * - external access from other cores will hang on cache
+     *
+     * Freezing stalls the other core on its next cache access rather than
+     * faulting it, so unlike the flash-write path this does not need to park
+     * the peer. Keep it that way: parking here would take the pause lock
+     * below s_spinlock and invert the order used by the flash path.
      */
     esp_intr_noniram_disable();
     esp_cache_freeze_ext_mem_cache();

--- a/components/esp_mm/esp_mmu_map.c
+++ b/components/esp_mm/esp_mmu_map.c
@@ -10,6 +10,7 @@
 #include <sys/queue.h>
 #include <inttypes.h>
 #include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
 #include "sdkconfig.h"
 #include "esp_attr.h"
 #include "esp_log.h"
@@ -281,7 +282,7 @@ esp_err_t esp_mmu_map_get_max_consecutive_free_block_size(mmu_mem_caps_t caps, m
     ESP_RETURN_ON_ERROR(s_mem_caps_check(caps), TAG, "invalid caps");
     *out_len = 0;
 
-    unsigned int key = irq_lock();
+    unsigned int key = arch_irq_lock();
     size_t max = 0;
 
     for (int i = 0; i < s_mmu_ctx.num_regions; i++) {
@@ -293,7 +294,7 @@ esp_err_t esp_mmu_map_get_max_consecutive_free_block_size(mmu_mem_caps_t caps, m
     }
 
     *out_len = max;
-    irq_unlock(key);
+    arch_irq_unlock(key);
 
     return ESP_OK;
 }

--- a/components/esp_timer/src/esp_timer.c
+++ b/components/esp_timer/src/esp_timer.c
@@ -613,11 +613,24 @@ static esp_err_t init_timer_task(void)
     } else {
         k_sem_init(&s_timer_semaphore, 0, 1);
 
-        k_thread_create(&s_timer_task, timer_task_stack,
+        /* Pin to the configured core (create suspended, pin, then start) to keep
+         * the timer task on the same core as the Wi-Fi/BLE stacks it serves.
+         */
+        k_tid_t tid = k_thread_create(&s_timer_task, timer_task_stack,
                         CONFIG_ESP32_TIMER_TASK_STACK_SIZE,
                         timer_task, NULL, NULL, NULL,
-                        K_PRIO_PREEMPT(CONFIG_ESP32_TIMER_TASK_PRIO), 0, K_NO_WAIT);
+                        K_PRIO_PREEMPT(CONFIG_ESP32_TIMER_TASK_PRIO), 0,
+                        IS_ENABLED(CONFIG_SMP) ? K_FOREVER : K_NO_WAIT);
         k_thread_name_set(&s_timer_task, "esp_timer");
+
+#if defined(CONFIG_SMP)
+#ifdef CONFIG_SCHED_CPU_MASK
+        k_thread_cpu_pin(tid, CONFIG_ESP_TIMER_TASK_AFFINITY);
+#endif
+        k_thread_start(tid);
+#else
+        ARG_UNUSED(tid);
+#endif
         s_timer_task_created = true;
     }
     return err;

--- a/components/esp_timer/src/esp_timer.c
+++ b/components/esp_timer/src/esp_timer.c
@@ -613,11 +613,24 @@ static esp_err_t init_timer_task(void)
     } else {
         k_sem_init(&s_timer_semaphore, 0, 1);
 
-        k_thread_create(&s_timer_task, timer_task_stack,
+        /* Pin to the configured core (create suspended, pin, then start) to keep
+         * the timer task on the same core as the Wi-Fi/BLE stacks it serves.
+         */
+        k_tid_t tid = k_thread_create(&s_timer_task, timer_task_stack,
                         CONFIG_ESP32_TIMER_TASK_STACK_SIZE,
                         timer_task, NULL, NULL, NULL,
-                        K_PRIO_PREEMPT(CONFIG_ESP32_TIMER_TASK_PRIO), 0, K_NO_WAIT);
+                        K_PRIO_PREEMPT(CONFIG_ESP32_TIMER_TASK_PRIO), 0,
+                        IS_ENABLED(CONFIG_SMP) ? K_FOREVER : K_NO_WAIT);
         k_thread_name_set(&s_timer_task, "esp_timer");
+
+#if defined(CONFIG_SMP)
+#ifdef CONFIG_SCHED_CPU_MASK
+        k_thread_cpu_pin(tid, CONFIG_SOC_ESP32_TIMER_TASK_CORE_ID);
+#endif
+        k_thread_start(tid);
+#else
+        ARG_UNUSED(tid);
+#endif
         s_timer_task_created = true;
     }
     return err;

--- a/components/esp_wifi/esp32s3/esp_adapter.c
+++ b/components/esp_wifi/esp32s3/esp_adapter.c
@@ -464,11 +464,21 @@ static int32_t task_create_pinned_to_core_wrapper(void *task_func, const char *n
 		return 0;
 	}
 
+	/* The blob assumes its task and interrupt share a core, so pin the task to
+	 * the configured core (create suspended, pin, then start) instead of letting
+	 * the scheduler float it.
+	 */
 	k_tid_t tid = k_thread_create(&t->thread, t->stack, stack_size,
 				      (k_thread_entry_t)task_func, param, NULL, NULL,
-				      prio, K_INHERIT_PERMS, K_NO_WAIT);
+				      prio, K_INHERIT_PERMS,
+				      IS_ENABLED(CONFIG_SMP) ? K_FOREVER : K_NO_WAIT);
 
 	k_thread_name_set(tid, name);
+
+#if defined(CONFIG_SMP)
+	k_thread_cpu_pin(tid, IS_ENABLED(CONFIG_ESP_WIFI_TASK_PINNED_TO_CORE_1) ? 1 : 0);
+	k_thread_start(tid);
+#endif
 
 	*(int32_t *)task_handle = (int32_t)tid;
 	return 1;

--- a/components/esp_wifi/esp32s3/esp_adapter.c
+++ b/components/esp_wifi/esp32s3/esp_adapter.c
@@ -463,11 +463,21 @@ static int32_t task_create_pinned_to_core_wrapper(void *task_func, const char *n
 		return 0;
 	}
 
+	/* The blob assumes its task and interrupt share a core, so pin the task to
+	 * the configured core (create suspended, pin, then start) instead of letting
+	 * the scheduler float it.
+	 */
 	k_tid_t tid = k_thread_create(&t->thread, t->stack, stack_size,
 				      (k_thread_entry_t)task_func, param, NULL, NULL,
-				      prio, K_INHERIT_PERMS, K_NO_WAIT);
+				      prio, K_INHERIT_PERMS,
+				      IS_ENABLED(CONFIG_SMP) ? K_FOREVER : K_NO_WAIT);
 
 	k_thread_name_set(tid, name);
+
+#if defined(CONFIG_SMP)
+	k_thread_cpu_pin(tid, IS_ENABLED(CONFIG_ESP_WIFI_TASK_PINNED_TO_CORE_1) ? 1 : 0);
+	k_thread_start(tid);
+#endif
 
 	*(int32_t *)task_handle = (int32_t)tid;
 	return 1;

--- a/components/spi_flash/cache_utils.c
+++ b/components/spi_flash/cache_utils.c
@@ -37,6 +37,24 @@
 
 ESP_LOG_ATTR_TAG(TAG, "cache");
 
+#if defined(CONFIG_SMP) && \
+	(defined(CONFIG_SOC_SERIES_ESP32P4) || defined(CONFIG_SOC_SERIES_ESP32S3))
+/*
+ * On SMP SoCs with a cache shared by both cores (ESP32-P4's L2, ESP32-S3's
+ * single cache), suspending it for a flash op is not safe while the other core
+ * runs flash-mapped (XIP) code. soc_mp_pause_others() takes a global pause lock
+ * (the outermost lock, before any flash/cache lock) and parks the other core in
+ * IRAM for the duration. Provided by the SoC's smp support.
+ */
+void soc_mp_pause_others(void);
+void soc_mp_resume_others(void);
+#define SPI_FLASH_PAUSE_OTHERS()    soc_mp_pause_others()
+#define SPI_FLASH_RESUME_OTHERS()   soc_mp_resume_others()
+#else
+#define SPI_FLASH_PAUSE_OTHERS()
+#define SPI_FLASH_RESUME_OTHERS()
+#endif
+
 static esp_os_spinlock_t s_intr_saved_state = ESP_OS_SPINLOCK_INIT;
 
 // Used only on ROM impl. in idf, this param unused, cache status hold by hal
@@ -62,6 +80,13 @@ void spi_flash_op_unlock(void)
 
 void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu(void)
 {
+    /* Park the peer first, so the pause lock is the outermost lock. The locks
+     * taken below are cross-core, and a core that blocks on one of them does so
+     * with interrupts disabled, which would leave it unable to answer the stall
+     * request. A core can never be parked while holding them for the same
+     * reason: they are only ever taken with interrupts already off.
+     */
+    SPI_FLASH_PAUSE_OTHERS();
     esp_os_enter_critical(&s_intr_saved_state);
     esp_intr_noniram_disable();
     spi_flash_disable_cache(0, &s_flash_op_cache_state[0]);
@@ -72,6 +97,7 @@ void IRAM_ATTR spi_flash_enable_interrupts_caches_and_other_cpu(void)
     spi_flash_restore_cache(0, s_flash_op_cache_state[0]);
     esp_intr_noniram_enable();
     esp_os_exit_critical(&s_intr_saved_state);
+    SPI_FLASH_RESUME_OTHERS();
 }
 
 void IRAM_ATTR spi_flash_disable_interrupts_caches_and_other_cpu_no_os(void)

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -245,14 +245,14 @@ config ESP_TIMER_IMPL_SYSTIMER
 	default y
 	depends on !SOC_SERIES_ESP32
 
-menu "Wi-Fi config"
-
 choice ESP_WIFI_TASK_CORE_ID
-	prompt "WiFi Task Core ID"
+	prompt "WiFi task CPU core affinity"
 	depends on SOC_SERIES_ESP32S3
 	default ESP_WIFI_TASK_PINNED_TO_CORE_0
 	help
-	  Pinned WiFi task to core 0 or core 1.
+	  Pin the WiFi task to a specific CPU core to ensure it and the WiFi
+	  interrupt handler run on the same core. This is required because the
+	  WiFi blob assumes task and interrupt share a core.
 
 config ESP_WIFI_TASK_PINNED_TO_CORE_0
 	bool "Core 0"
@@ -262,13 +262,14 @@ config ESP_WIFI_TASK_PINNED_TO_CORE_1
 
 endchoice # ESP_WIFI_TASK_CORE_ID
 
-endmenu # Wi-Fi config
-
 if BT_ESP32
 
 config ESP32_BT_CTLR_PINNED_TO_CORE
-	int
+	int "CPU core for Bluetooth controller task"
 	default 0
+	range 0 1
+	help
+	  Pin the Bluetooth controller task to this CPU core.
 
 endif
 

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -245,23 +245,6 @@ config ESP_TIMER_IMPL_SYSTIMER
 	default y
 	depends on !SOC_SERIES_ESP32
 
-choice ESP_WIFI_TASK_CORE_ID
-	prompt "WiFi task CPU core affinity"
-	depends on SOC_SERIES_ESP32S3
-	default ESP_WIFI_TASK_PINNED_TO_CORE_0
-	help
-	  Pin the WiFi task to a specific CPU core to ensure it and the WiFi
-	  interrupt handler run on the same core. This is required because the
-	  WiFi blob assumes task and interrupt share a core.
-
-config ESP_WIFI_TASK_PINNED_TO_CORE_0
-	bool "Core 0"
-
-config ESP_WIFI_TASK_PINNED_TO_CORE_1
-	bool "Core 1"
-
-endchoice # ESP_WIFI_TASK_CORE_ID
-
 if BT_ESP32
 
 config ESP32_BT_CTLR_PINNED_TO_CORE

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -254,23 +254,6 @@ config ESP_TIMER_IMPL_SYSTIMER
 	default y
 	depends on !SOC_SERIES_ESP32
 
-choice ESP_WIFI_TASK_CORE_ID
-	prompt "WiFi task CPU core affinity"
-	depends on SOC_SERIES_ESP32S3
-	default ESP_WIFI_TASK_PINNED_TO_CORE_0
-	help
-	  Pin the WiFi task to a specific CPU core to ensure it and the WiFi
-	  interrupt handler run on the same core. This is required because the
-	  WiFi blob assumes task and interrupt share a core.
-
-config ESP_WIFI_TASK_PINNED_TO_CORE_0
-	bool "Core 0"
-
-config ESP_WIFI_TASK_PINNED_TO_CORE_1
-	bool "Core 1"
-
-endchoice # ESP_WIFI_TASK_CORE_ID
-
 if BT_ESP32
 
 config ESP32_BT_CTLR_PINNED_TO_CORE

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -254,14 +254,14 @@ config ESP_TIMER_IMPL_SYSTIMER
 	default y
 	depends on !SOC_SERIES_ESP32
 
-menu "Wi-Fi config"
-
 choice ESP_WIFI_TASK_CORE_ID
-	prompt "WiFi Task Core ID"
+	prompt "WiFi task CPU core affinity"
 	depends on SOC_SERIES_ESP32S3
 	default ESP_WIFI_TASK_PINNED_TO_CORE_0
 	help
-	  Pinned WiFi task to core 0 or core 1.
+	  Pin the WiFi task to a specific CPU core to ensure it and the WiFi
+	  interrupt handler run on the same core. This is required because the
+	  WiFi blob assumes task and interrupt share a core.
 
 config ESP_WIFI_TASK_PINNED_TO_CORE_0
 	bool "Core 0"
@@ -271,13 +271,14 @@ config ESP_WIFI_TASK_PINNED_TO_CORE_1
 
 endchoice # ESP_WIFI_TASK_CORE_ID
 
-endmenu # Wi-Fi config
-
 if BT_ESP32
 
 config ESP32_BT_CTLR_PINNED_TO_CORE
-	int
+	int "CPU core for Bluetooth controller task"
 	default 0
+	range 0 1
+	help
+	  Pin the Bluetooth controller task to this CPU core.
 
 endif
 


### PR DESCRIPTION
Add the changes hal_espressif needs to support dual-core SMP on the
ESP32-S3 and ESP32-P4.

Locking primitives are made SMP safe so they exclude the other core
rather than only local interrupts.

The Wi-Fi, Bluetooth and esp_timer tasks are pinned to a fixed core,
since the radio blobs assume their task and interrupt share a core and
the timer task stays with the stacks it serves. Each is created
suspended, pinned, then started.

The Wi-Fi task affinity choice is dropped here because it is now
defined on the Zephyr side, where it also selects the core the Wi-Fi
interrupt is reserved on.

The Wi-Fi blob's interrupt lines (WMAC and WBB) are reserved on both
cores. The interrupt allocator reserves per core, so reserving them on
one core only let the other core's allocator hand the same lines to
the scheduler IPI and the system timer, stalling the secondary core.