### PR TITLE
fix: enforce minimum 64-byte temp buffer for short PSRAM flash reads

### DIFF
--- a/components/spi_flash/spi_flash_os_func_app.c
+++ b/components/spi_flash/spi_flash_os_func_app.c
@@ -219,7 +219,7 @@ static void* get_buffer_malloc(void* arg, size_t reqest_size, size_t* out_size)
      * use exponential backoff down to a minimum of 64 bytes.
      */
     void* ret = NULL;
-    size_t read_chunk_size = (reqest_size + 3) & ~3;
+    size_t read_chunk_size = MAX((reqest_size + 3) & ~3, 64);
 
     while (ret == NULL && read_chunk_size >= 64) {
         ret = k_malloc(read_chunk_size);


### PR DESCRIPTION
get_buffer_malloc() computed read_chunk_size from the requested read length, so requests below 64 bytes produced a chunk size under 64. The allocation loop only runs while read_chunk_size >= 64, so it never executed, temp_buffer stayed NULL, and esp_flash_read() failed with ESP_ERR_NO_MEM even though heap memory was available.

This broke flash reads into PSRAM-backed buffers under 64 bytes, including ZMS/settings writes from PSRAM-backed thread stacks (e.g. storing Wi-Fi credentials).

Fix: clamp read_chunk_size to a 64-byte floor before entering the loop, so short requests still get an eligible temp buffer.

Fixes zephyrproject-rtos/zephyr#114822