### PR TITLE
pincfg: fix esp32 and esp32p4 pin config inputs

### DIFF
--- a/zephyr/port/pincfgs/esp32.yml
+++ b/zephyr/port/pincfgs/esp32.yml
@@ -39,12 +39,6 @@ uart1:
   cts:
     sigi: u1cts_in
     gpio: [[0, 23], [25, 27], [32, 39]]
-  dtr:
-    sigo: u1dtr_out
-    gpio: [[0, 23], [25, 27], [32, 39]]
-  dsr:
-    sigi: u1dsr_in
-    gpio: [[0, 23], [25, 27], [32, 39]]
 
 uart2:
   tx:

--- a/zephyr/port/pincfgs/esp32p4.yml
+++ b/zephyr/port/pincfgs/esp32p4.yml
@@ -312,26 +312,26 @@ i2s1:
 
 twai0:
   tx:
-    sigo: twai0_tx_out
+    sigo: twai0_tx
     gpio: [[0, 54]]
   rx:
-    sigi: twai0_rx_in
+    sigi: twai0_rx
     gpio: [[0, 54]]
 
 twai1:
   tx:
-    sigo: twai1_tx_out
+    sigo: twai1_tx
     gpio: [[0, 54]]
   rx:
-    sigi: twai1_rx_in
+    sigi: twai1_rx
     gpio: [[0, 54]]
 
 twai2:
   tx:
-    sigo: twai2_tx_out
+    sigo: twai2_tx
     gpio: [[0, 54]]
   rx:
-    sigi: twai2_rx_in
+    sigi: twai2_rx
     gpio: [[0, 54]]
 
 smi:

--- a/zephyr/port/pincfgs/esp32p4.yml
+++ b/zephyr/port/pincfgs/esp32p4.yml
@@ -254,6 +254,53 @@ mcpwm0:
     sigi: pwm0_cap2_in
     gpio: [[0, 54]]
 
+mcpwm1:
+  out0a:
+    sigo: pwm1_ch0_a_out
+    gpio: [[0, 54]]
+  out0b:
+    sigo: pwm1_ch0_b_out
+    gpio: [[0, 54]]
+  out1a:
+    sigo: pwm1_ch1_a_out
+    gpio: [[0, 54]]
+  out1b:
+    sigo: pwm1_ch1_b_out
+    gpio: [[0, 54]]
+  out2a:
+    sigo: pwm1_ch2_a_out
+    gpio: [[0, 54]]
+  out2b:
+    sigo: pwm1_ch2_b_out
+    gpio: [[0, 54]]
+  sync0:
+    sigi: pwm1_sync0_in
+    gpio: [[0, 54]]
+  sync1:
+    sigi: pwm1_sync1_in
+    gpio: [[0, 54]]
+  sync2:
+    sigi: pwm1_sync2_in
+    gpio: [[0, 54]]
+  fault0:
+    sigi: pwm1_f0_in
+    gpio: [[0, 54]]
+  fault1:
+    sigi: pwm1_f1_in
+    gpio: [[0, 54]]
+  fault2:
+    sigi: pwm1_f2_in
+    gpio: [[0, 54]]
+  cap0:
+    sigi: pwm1_cap0_in
+    gpio: [[0, 54]]
+  cap1:
+    sigi: pwm1_cap1_in
+    gpio: [[0, 54]]
+  cap2:
+    sigi: pwm1_cap2_in
+    gpio: [[0, 54]]
+
 i2s0:
   o_bck:
     sigo: i2s0_o_bck_out


### PR DESCRIPTION
Fixes the pin config inputs used to generate the Zephyr pinctrl
headers:

- esp32: drop the uart1 dtr and dsr entries. The gpio signal map
  only exposes dtr and dsr on uart0, so these generated pinmux
  macros referenced signals that do not exist.
- esp32p4: fix the twai signal names. The entries referenced
  twai_tx_out and twai_rx_in, while the signal map defines
  twai_tx and twai_rx, so every twai pinmux failed devicetree
  preprocessing.
- esp32p4: add the mcpwm1 group, which was missing entirely.