### PR TITLE
esp_supplicant: add STA PMKSA cache export and staging API

### DIFF
--- a/components/wpa_supplicant/CMakeLists.txt
+++ b/components/wpa_supplicant/CMakeLists.txt
@@ -86,6 +86,7 @@ set(esp_srcs "esp_supplicant/src/esp_eap_client.c"
     "esp_supplicant/src/esp_wps.c"
     "esp_supplicant/src/esp_wpa3.c"
     "esp_supplicant/src/esp_owe.c"
+    "esp_supplicant/src/esp_wifi_sta_pmksa_cache.c"
     "esp_supplicant/src/esp_nan_supplicant.c")
 if(CONFIG_ESP_WIFI_SOFTAP_SUPPORT)
     set(esp_srcs ${esp_srcs} "esp_supplicant/src/esp_hostap.c")

--- a/components/wpa_supplicant/esp_supplicant/include/esp_wifi_sta_pmksa_cache.h
+++ b/components/wpa_supplicant/esp_supplicant/include/esp_wifi_sta_pmksa_cache.h
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ESP_WIFI_STA_PMKSA_CACHE_H
+#define ESP_WIFI_STA_PMKSA_CACHE_H
+
+#include <stdint.h>
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ESP_WIFI_STA_PMKSA_MAC_LEN   6U
+#define ESP_WIFI_STA_PMKSA_PMKID_LEN 16U
+#define ESP_WIFI_STA_PMKSA_PMK_LEN   32U
+
+/* Policy limit for imported PMKSA lifetimes. */
+#define ESP_WIFI_STA_PMKSA_MAX_LIFETIME_S 43200U
+
+#define ESP_WIFI_STA_PMKSA_AKM_802_1X        0x000FAC01U /* 00-0F-AC:1 */
+#define ESP_WIFI_STA_PMKSA_AKM_802_1X_SHA256 0x000FAC05U /* 00-0F-AC:5 */
+
+/**
+ * @brief RSN PMKSA record.
+ *
+ * @a pmk is secret. Protect persisted records and wipe caller-owned copies.
+ * This structure is not a stable serialized storage format.
+ */
+typedef struct {
+    uint8_t bssid[ESP_WIFI_STA_PMKSA_MAC_LEN];    /**< Authenticator address. */
+    uint8_t sta_addr[ESP_WIFI_STA_PMKSA_MAC_LEN]; /**< Station address. */
+    uint8_t pmkid[ESP_WIFI_STA_PMKSA_PMKID_LEN];
+    uint8_t pmk[ESP_WIFI_STA_PMKSA_PMK_LEN];
+    uint8_t pmk_len;                 /**< Must be ESP_WIFI_STA_PMKSA_PMK_LEN. */
+    uint32_t akm_suite;              /**< IEEE 802.11 AKM suite selector. */
+    uint32_t expiration_remaining_s; /**< Non-zero, at most the max above. */
+    uint32_t reauth_remaining_s;     /**< At most expiration_remaining_s. */
+} esp_wifi_sta_pmksa_cache_entry_t;
+
+/*
+ * Not synchronized against the Wi-Fi task: stage before connecting, export
+ * while associated, clear while disconnected.
+ */
+
+/**
+ * @brief Export the PMKSA in use, lifetimes relative to now and capped.
+ *
+ * @param[out] entry Always zeroed; populated only on success.
+ * @return ESP_OK, ESP_ERR_INVALID_ARG, ESP_ERR_NOT_FOUND, ESP_ERR_NOT_SUPPORTED
+ *         for an out-of-scope AKM or PMK length, or ESP_ERR_INVALID_STATE.
+ */
+esp_err_t esp_wifi_sta_pmksa_cache_export(esp_wifi_sta_pmksa_cache_entry_t *entry);
+
+/**
+ * @brief Stage a record for the next association to its BSSID.
+ *
+ * Discarded if the station address or AKM mismatch. A non-expired record is
+ * kept if another BSSID is attempted. Replaces any previous record and evicts
+ * the entry it installed.
+ * The caller must deduct time elapsed while the record was stored from the
+ * remaining lifetimes before staging. A matching-BSSID attempt consumes the
+ * staged record except when entry allocation fails, which leaves it for retry.
+ *
+ * @param[in] entry Record to stage.
+ * @return ESP_OK or ESP_ERR_INVALID_ARG if the record is malformed.
+ */
+esp_err_t esp_wifi_sta_pmksa_cache_stage(const esp_wifi_sta_pmksa_cache_entry_t *entry);
+
+/** @brief Discard the staged record and flush every station PMKSA. @return ESP_OK */
+esp_err_t esp_wifi_sta_pmksa_cache_clear(void);
+
+/**
+ * @brief Discard staged and externally installed station PMKSA state.
+ *
+ * Supplicant-learned entries are preserved. An externally installed entry that
+ * is in use is also preserved; call this again once disconnected to remove it.
+ *
+ * @return ESP_OK
+ */
+esp_err_t esp_wifi_sta_pmksa_cache_clear_external(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESP_WIFI_STA_PMKSA_CACHE_H */

--- a/components/wpa_supplicant/esp_supplicant/src/esp_wifi_sta_pmksa_cache.c
+++ b/components/wpa_supplicant/esp_supplicant/src/esp_wifi_sta_pmksa_cache.c
@@ -1,0 +1,328 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "utils/includes.h"
+#include "utils/common.h"
+#include "common/defs.h"
+
+#include "esp_wifi_sta_pmksa_cache.h"
+#include "esp_wifi_sta_pmksa_cache_i.h"
+#include "rsn_supp/wpa.h"
+#include "rsn_supp/wpa_i.h"
+#include "rsn_supp/pmksa_cache.h"
+
+/* Record awaiting installation on the next association attempt. */
+static esp_wifi_sta_pmksa_cache_entry_t s_staged;
+static bool s_staged_valid;
+static os_time_t s_staged_expiration;
+static os_time_t s_staged_reauth_time;
+
+/* Lets a retry of the same association reuse the entry already installed. */
+static struct {
+    u8 bssid[ETH_ALEN];
+    u8 spa[ETH_ALEN];
+    u8 pmkid[PMKID_LEN];
+    unsigned int akmp;
+    bool valid;
+} s_installed;
+
+static void pmksa_staged_clear(void)
+{
+    forced_memzero(&s_staged, sizeof(s_staged));
+    s_staged_valid = false;
+    s_staged_expiration = 0;
+    s_staged_reauth_time = 0;
+}
+
+/*
+ * Drop the entry installed by this module, if it is still cached. Returns false
+ * if that entry is in use, leaving it installed and still tracked.
+ */
+static bool pmksa_installed_try_remove(void)
+{
+    struct wpa_sm *sm = &gWpaSm;
+    struct rsn_pmksa_cache_entry *entry;
+
+    if (s_installed.valid && sm->pmksa != NULL) {
+        /* pmksa_cache_get() cannot match on AKM, so check it here. */
+        entry = pmksa_cache_get(sm->pmksa, s_installed.bssid, s_installed.spa,
+                                s_installed.pmkid, NULL);
+        if (entry != NULL && entry->akmp == (int)s_installed.akmp) {
+            if (pmksa_cache_get_current(sm) == entry) {
+                return false;
+            }
+            pmksa_cache_remove(sm->pmksa, entry);
+        }
+    }
+
+    os_memset(&s_installed, 0, sizeof(s_installed));
+
+    return true;
+}
+
+/* An individual, non-zero MAC address. */
+static bool pmksa_addr_is_valid(const u8 *addr)
+{
+    static const u8 zero[ETH_ALEN] = { 0 };
+
+    return (addr[0] & 0x01) == 0 && os_memcmp(addr, zero, ETH_ALEN) != 0;
+}
+
+/* Returns the matching WPA_KEY_MGMT_* value, or 0 if out of scope here. */
+static unsigned int pmksa_akm_suite_to_akmp(uint32_t akm_suite)
+{
+    switch (akm_suite) {
+    case ESP_WIFI_STA_PMKSA_AKM_802_1X:
+        return WPA_KEY_MGMT_IEEE8021X;
+    case ESP_WIFI_STA_PMKSA_AKM_802_1X_SHA256:
+        return WPA_KEY_MGMT_IEEE8021X_SHA256;
+    default:
+        return 0;
+    }
+}
+
+static uint32_t pmksa_akmp_to_akm_suite(int akmp)
+{
+    switch (akmp) {
+    case WPA_KEY_MGMT_IEEE8021X:
+        return ESP_WIFI_STA_PMKSA_AKM_802_1X;
+    case WPA_KEY_MGMT_IEEE8021X_SHA256:
+        return ESP_WIFI_STA_PMKSA_AKM_802_1X_SHA256;
+    default:
+        return 0;
+    }
+}
+
+/* Seconds from now until t, clamped to [0, cap]. */
+static uint32_t pmksa_remaining_s(os_time_t t, os_time_t now, uint32_t cap)
+{
+    os_time_t delta;
+
+    if (t <= now) {
+        return 0;
+    }
+
+    delta = t - now;
+
+    return (delta > (os_time_t)cap) ? cap : (uint32_t)delta;
+}
+
+esp_err_t esp_wifi_sta_pmksa_cache_export(esp_wifi_sta_pmksa_cache_entry_t *entry)
+{
+    struct wpa_sm *sm = &gWpaSm;
+    struct rsn_pmksa_cache_entry *current;
+    struct os_reltime now;
+    uint32_t akm_suite;
+    uint32_t expiration_s;
+
+    if (entry == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    os_memset(entry, 0, sizeof(*entry));
+
+    current = pmksa_cache_get_current(sm);
+    if (current == NULL) {
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    if (current->pmk_len != ESP_WIFI_STA_PMKSA_PMK_LEN) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    akm_suite = pmksa_akmp_to_akm_suite(current->akmp);
+    if (akm_suite == 0) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    /* Without both addresses the PMKID cannot be re-derived or re-bound. */
+    if (!pmksa_addr_is_valid(current->aa) || !pmksa_addr_is_valid(current->spa)) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    os_get_reltime(&now);
+
+    expiration_s = pmksa_remaining_s(current->expiration, now.sec,
+                                     ESP_WIFI_STA_PMKSA_MAX_LIFETIME_S);
+    if (expiration_s == 0) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    os_memcpy(entry->bssid, current->aa, ETH_ALEN);
+    os_memcpy(entry->sta_addr, current->spa, ETH_ALEN);
+    os_memcpy(entry->pmkid, current->pmkid, PMKID_LEN);
+    os_memcpy(entry->pmk, current->pmk, ESP_WIFI_STA_PMKSA_PMK_LEN);
+    entry->pmk_len = ESP_WIFI_STA_PMKSA_PMK_LEN;
+    entry->akm_suite = akm_suite;
+    entry->expiration_remaining_s = expiration_s;
+    entry->reauth_remaining_s = pmksa_remaining_s(current->reauth_time, now.sec,
+                                                 expiration_s);
+
+    return ESP_OK;
+}
+
+esp_err_t esp_wifi_sta_pmksa_cache_stage(const esp_wifi_sta_pmksa_cache_entry_t *entry)
+{
+    struct os_reltime now;
+
+    if (entry == NULL ||
+        entry->pmk_len != ESP_WIFI_STA_PMKSA_PMK_LEN ||
+        pmksa_akm_suite_to_akmp(entry->akm_suite) == 0 ||
+        !pmksa_addr_is_valid(entry->bssid) ||
+        !pmksa_addr_is_valid(entry->sta_addr) ||
+        entry->expiration_remaining_s == 0 ||
+        entry->expiration_remaining_s > ESP_WIFI_STA_PMKSA_MAX_LIFETIME_S ||
+        entry->reauth_remaining_s > entry->expiration_remaining_s) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    os_get_reltime(&now);
+
+    pmksa_staged_clear();
+    os_memcpy(&s_staged, entry, sizeof(s_staged));
+    s_staged_expiration = now.sec + entry->expiration_remaining_s;
+    s_staged_reauth_time = now.sec + entry->reauth_remaining_s;
+    s_staged_valid = true;
+
+    /*
+     * Evict now rather than leaving it live until the replacement installs, and
+     * stop tracking it either way so it cannot shadow the record just staged.
+     */
+    if (!pmksa_installed_try_remove()) {
+        os_memset(&s_installed, 0, sizeof(s_installed));
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t esp_wifi_sta_pmksa_cache_clear_external(void)
+{
+    pmksa_staged_clear();
+    /* Keep tracking an in-use entry so a later call can still remove it. */
+    (void)pmksa_installed_try_remove();
+
+    return ESP_OK;
+}
+
+esp_err_t esp_wifi_sta_pmksa_cache_clear(void)
+{
+    struct wpa_sm *sm = &gWpaSm;
+
+    pmksa_staged_clear();
+    os_memset(&s_installed, 0, sizeof(s_installed));
+
+    /* Flush all, not just ours: credentials may have changed. */
+    if (sm->pmksa != NULL) {
+        pmksa_cache_flush(sm->pmksa, NULL, NULL, 0);
+        pmksa_cache_clear_current(sm);
+    }
+
+    return ESP_OK;
+}
+
+void esp_wifi_sta_pmksa_cache_deinit(void)
+{
+    /* The cache is being torn down, so only drop state held here. */
+    pmksa_staged_clear();
+    os_memset(&s_installed, 0, sizeof(s_installed));
+}
+
+bool esp_wifi_sta_pmksa_cache_install(struct wpa_sm *sm, const u8 *bssid)
+{
+    struct rsn_pmksa_cache_entry *entry;
+    struct rsn_pmksa_cache_entry *existing;
+    struct os_reltime now;
+    unsigned int akmp;
+
+    if (sm == NULL || bssid == NULL || sm->pmksa == NULL) {
+        return false;
+    }
+
+    /* Retry of an association this module already installed an entry for. */
+    if (s_installed.valid &&
+        os_memcmp(s_installed.bssid, bssid, ETH_ALEN) == 0 &&
+        os_memcmp(s_installed.spa, sm->own_addr, ETH_ALEN) == 0 &&
+        s_installed.akmp == sm->key_mgmt) {
+        /* Match on PMKID and AKM so only our installed entry is reused. */
+        entry = pmksa_cache_get(sm->pmksa, bssid, sm->own_addr,
+                                s_installed.pmkid, NULL);
+        if (entry != NULL && entry->akmp == (int)s_installed.akmp) {
+            return true;
+        }
+        os_memset(&s_installed, 0, sizeof(s_installed));
+    }
+
+    if (!s_staged_valid) {
+        return false;
+    }
+
+    os_get_reltime(&now);
+
+    if (s_staged_expiration <= now.sec) {
+        pmksa_staged_clear();
+        return false;
+    }
+
+    /* Another AP: keep it staged for the BSSID it was meant for. */
+    if (os_memcmp(s_staged.bssid, bssid, ETH_ALEN) != 0) {
+        return false;
+    }
+
+    /* A station or AKM mismatch is permanent, so drop the record. */
+    akmp = pmksa_akm_suite_to_akmp(s_staged.akm_suite);
+    if (akmp != sm->key_mgmt ||
+        os_memcmp(s_staged.sta_addr, sm->own_addr, ETH_ALEN) != 0) {
+        wpa_printf(MSG_DEBUG, "RSN: staged PMKSA does not match this station");
+        pmksa_staged_clear();
+        return false;
+    }
+
+    entry = os_zalloc(sizeof(*entry));
+    if (entry == NULL) {
+        return false;
+    }
+
+    os_memcpy(entry->aa, s_staged.bssid, ETH_ALEN);
+    os_memcpy(entry->spa, sm->own_addr, ETH_ALEN);
+    os_memcpy(entry->pmkid, s_staged.pmkid, PMKID_LEN);
+    os_memcpy(entry->pmk, s_staged.pmk, ESP_WIFI_STA_PMKSA_PMK_LEN);
+    entry->pmk_len = ESP_WIFI_STA_PMKSA_PMK_LEN;
+    entry->akmp = (int)akmp;
+    entry->network_ctx = sm->network_ctx;
+    entry->expiration = s_staged_expiration;
+    entry->reauth_time = s_staged_reauth_time;
+
+    /*
+     * pmksa_cache_add_entry() reuses an identical entry without updating its
+     * lifetime or metadata. Remove only that case before adding this record.
+     */
+    existing = pmksa_cache_get(sm->pmksa, bssid, NULL, NULL, NULL);
+    if (existing != NULL &&
+        existing->pmk_len == entry->pmk_len &&
+        os_memcmp_const(existing->pmk, entry->pmk, entry->pmk_len) == 0 &&
+        os_memcmp_const(existing->pmkid, entry->pmkid, PMKID_LEN) == 0) {
+        if (pmksa_cache_get_current(sm) == existing) {
+            pmksa_cache_clear_current(sm);
+        }
+        pmksa_cache_remove(sm->pmksa, existing);
+    }
+
+    /* Takes ownership of entry. */
+    if (pmksa_cache_add_entry(sm->pmksa, entry) == NULL) {
+        pmksa_staged_clear();
+        return false;
+    }
+
+    os_memcpy(s_installed.bssid, s_staged.bssid, ETH_ALEN);
+    os_memcpy(s_installed.spa, sm->own_addr, ETH_ALEN);
+    os_memcpy(s_installed.pmkid, s_staged.pmkid, PMKID_LEN);
+    s_installed.akmp = akmp;
+    s_installed.valid = true;
+
+    pmksa_staged_clear();
+
+    return true;
+}

--- a/components/wpa_supplicant/esp_supplicant/src/esp_wifi_sta_pmksa_cache_i.h
+++ b/components/wpa_supplicant/esp_supplicant/src/esp_wifi_sta_pmksa_cache_i.h
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ESP_WIFI_STA_PMKSA_CACHE_I_H
+#define ESP_WIFI_STA_PMKSA_CACHE_I_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+struct wpa_sm;
+
+/*
+ * Install a staged PMKSA, or report one installed on an earlier attempt. Called
+ * from wpa_set_bss(); true enables PMKSA cache selection for this association.
+ */
+bool esp_wifi_sta_pmksa_cache_install(struct wpa_sm *sm, const uint8_t *bssid);
+
+/*
+ * Wipe the staged record and drop tracking. Called from wpa_sm_deinit() so no
+ * key material outlives the supplicant.
+ */
+void esp_wifi_sta_pmksa_cache_deinit(void);
+
+#endif /* ESP_WIFI_STA_PMKSA_CACHE_I_H */

--- a/components/wpa_supplicant/src/rsn_supp/wpa.c
+++ b/components/wpa_supplicant/src/rsn_supp/wpa.c
@@ -37,6 +37,7 @@
 #include "common/sae.h"
 #include "esp_eap_client_i.h"
 #include "esp_wpa3_i.h"
+#include "esp_wifi_sta_pmksa_cache_i.h"
 #include "eap_peer/eap.h"
 
 /**
@@ -2439,6 +2440,7 @@ bool wpa_sm_init(void)
 void wpa_sm_deinit(void)
 {
     struct wpa_sm *sm = &gWpaSm;
+    esp_wifi_sta_pmksa_cache_deinit();
     pmksa_cache_deinit(sm->pmksa);
     sm->pmksa = NULL;
     os_free(sm->assoc_rsnxe);
@@ -2685,6 +2687,9 @@ int wpa_set_bss(uint8_t *macddr, uint8_t *bssid, uint8_t pairwise_cipher, uint8_
     sm->renew_snonce = 1;
     memcpy(sm->own_addr, macddr, ETH_ALEN);
     memcpy(sm->bssid, bssid, ETH_ALEN);
+    if (esp_wifi_sta_pmksa_cache_install(sm, bssid)) {
+        use_pmk_cache = true;
+    }
     sm->ap_notify_completed_rsne = esp_wifi_sta_is_ap_notify_completed_rsne_internal();
     sm->use_ext_key_id = (sm->proto == WPA_PROTO_WPA);
     sm->sae_pwe = esp_wifi_get_config_sae_pwe_h2e_internal(WIFI_IF_STA);

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -590,6 +590,7 @@ if(CONFIG_SOC_SERIES_ESP32)
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wps.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wpa3.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_owe.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wifi_sta_pmksa_cache.c"
       )
     if(CONFIG_ESP32_WIFI_SOFTAP_SUPPORT)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -548,6 +548,7 @@ if(CONFIG_SOC_SERIES_ESP32C2)
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wps.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wpa3.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_owe.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wifi_sta_pmksa_cache.c"
       )
     if(CONFIG_ESP32_WIFI_SOFTAP_SUPPORT)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -579,6 +579,7 @@ if(CONFIG_SOC_SERIES_ESP32C3)
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wps.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wpa3.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_owe.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wifi_sta_pmksa_cache.c"
       )
     if(CONFIG_ESP32_WIFI_SOFTAP_SUPPORT)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")

--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -741,6 +741,7 @@ if(CONFIG_SOC_SERIES_ESP32C5)
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wps.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wpa3.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_owe.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wifi_sta_pmksa_cache.c"
       )
     if(CONFIG_ESP32_WIFI_SOFTAP_SUPPORT)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -709,6 +709,7 @@ if(CONFIG_SOC_SERIES_ESP32C6)
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wps.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wpa3.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_owe.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wifi_sta_pmksa_cache.c"
       )
     if(CONFIG_ESP32_WIFI_SOFTAP_SUPPORT)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -542,6 +542,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wps.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wpa3.c"
         "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_owe.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wifi_sta_pmksa_cache.c"
         )
     if(CONFIG_ESP32_WIFI_SOFTAP_SUPPORT)
         set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -648,6 +648,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wps.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wpa3.c"
       "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_owe.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wifi_sta_pmksa_cache.c"
       )
 
     if(CONFIG_ESP32_WIFI_SOFTAP_SUPPORT)


### PR DESCRIPTION
### Summary

- Adds APIs to export, stage, and clear a station PMKSA entry, allowing applications to retain enterprise Wi-Fi session state across resets.
- Staged entries are installed once the target BSSID and AKM are known. Lifetimes continue aging while staged, and cached entries are validated before reuse.
- The application owns secure persistence and must account for elapsed time before staging.

### Follow-up

- This provides the ESP32 implementation needed for a subsequent Zephyr PR that will expose persistent PMKSA caching through the common Wi-Fi management layer and integrate supporting drivers.

### Testing

- Validated PMKSA export and reuse across ESP32-C6 resets with enterprise Wi-Fi. Zephyr ESP32-C6 compilation passes.

### Current limitations

- `export()` could theoretically race with internal PMKSA removal since these APIs are not synchronized with the WiFi task.
  - `export()` obtains a pointer to the current PMKSA, but that entry is owned by the supplicant task. A mutex inside this module would not solve the pointer race because native PMKSA code would never acquire that mutex.
- Only 802.1X and 802.1X-SHA256 AKMs with 32-byte PMKs are supported.
- **Only one PMKSA record can be staged at a time, and it is bound to its BSSID, station address, and AKM.**
  - A future PR will add support for multiple record storage and bring the `esp_supplicant` up to parity with `hostap`.
- Imported lifetimes are capped at 12 hours. Applications must subtract time elapsed across reset before staging.
- The exported structure contains secret PMK material and is not a stable serialized storage format. Secure storage and wiping remain application responsibilities.