### PR TITLE
esp32c61: add initial support

### DIFF
--- a/components/bt/include/esp32c6/include/esp_bt.h
+++ b/components/bt/include/esp32c6/include/esp_bt.h
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 #include "esp_err.h"
 #include "sdkconfig.h"
+#include "esp_task.h"
 
 #include "../../../controller/esp32c6/esp_bt_cfg.h"
 #include "hal/efuse_hal.h"

--- a/components/esp_coex/esp32c61/esp_coex_adapter.c
+++ b/components/esp_coex/esp32c61/esp_coex_adapter.c
@@ -4,23 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
-#include <pthread.h>
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/queue.h"
-#include "freertos/semphr.h"
-#include "freertos/portmacro.h"
-#include "esp_heap_caps.h"
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/irq.h>
+#include <zephyr/logging/log.h>
+
+#if CONFIG_WIFI_ESP32
+LOG_MODULE_REGISTER(esp32_coex_adapter, CONFIG_WIFI_LOG_LEVEL);
+#elif CONFIG_BT_ESP32
+LOG_MODULE_REGISTER(esp32_coex_adapter, CONFIG_BT_LOG_LEVEL);
+#else
+LOG_MODULE_REGISTER(esp32_coex_adapter);
+#endif
+
+#include "esp_attr.h"
 #include "esp_timer.h"
 #include "soc/rtc.h"
+#include "soc/soc_caps.h"
 #include "esp_private/esp_clk.h"
 #include "private/esp_coexist_adapter.h"
+#include "private/esp_coexist_internal.h"
 #include "esp32c61/rom/ets_sys.h"
 #include "private/esp_coexist_debug.h"
 
@@ -39,63 +48,76 @@ bool IRAM_ATTR esp_coex_common_env_is_chip_wrapper(void)
 
 void *esp_coex_common_spin_lock_create_wrapper(void)
 {
-    portMUX_TYPE tmp = portMUX_INITIALIZER_UNLOCKED;
-    void *mux = malloc(sizeof(portMUX_TYPE));
-
-    if (mux) {
-        memcpy(mux, &tmp, sizeof(portMUX_TYPE));
-        return mux;
+    unsigned int *spin_lock = (unsigned int *)k_malloc(sizeof(unsigned int));
+    if (spin_lock == NULL) {
+        LOG_ERR("spin_lock_create_wrapper allocation failed");
+        return NULL;
     }
-    return NULL;
+
+    *spin_lock = 0;
+    return (void *)spin_lock;
 }
 
 uint32_t IRAM_ATTR esp_coex_common_int_disable_wrapper(void *wifi_int_mux)
 {
-    if (xPortInIsrContext()) {
-        portENTER_CRITICAL_ISR(wifi_int_mux);
-    } else {
-        portENTER_CRITICAL(wifi_int_mux);
-    }
+    unsigned int *int_mux = (unsigned int *)wifi_int_mux;
 
+    *int_mux = irq_lock();
     return 0;
 }
 
 void IRAM_ATTR esp_coex_common_int_restore_wrapper(void *wifi_int_mux, uint32_t tmp)
 {
-    if (xPortInIsrContext()) {
-        portEXIT_CRITICAL_ISR(wifi_int_mux);
-    } else {
-        portEXIT_CRITICAL(wifi_int_mux);
-    }
+    unsigned int *key = (unsigned int *)wifi_int_mux;
+
+    irq_unlock(*key);
 }
 
 void IRAM_ATTR esp_coex_common_task_yield_from_isr_wrapper(void)
 {
-    portYIELD_FROM_ISR();
+    k_yield();
 }
 
 void *esp_coex_common_semphr_create_wrapper(uint32_t max, uint32_t init)
 {
-    return (void *)xSemaphoreCreateCounting(max, init);
+    struct k_sem *sem = (struct k_sem *)k_malloc(sizeof(struct k_sem));
+
+    if (sem == NULL) {
+        LOG_ERR("semphr_create_wrapper allocation failed");
+        return NULL;
+    }
+
+    k_sem_init(sem, init, max);
+
+    return (void *)sem;
 }
 
 void esp_coex_common_semphr_delete_wrapper(void *semphr)
 {
-    vSemaphoreDelete(semphr);
+    k_free(semphr);
 }
 
 int32_t esp_coex_common_semphr_take_wrapper(void *semphr, uint32_t block_time_tick)
 {
     if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        return (int32_t)xSemaphoreTake(semphr, portMAX_DELAY);
+        int ret = k_sem_take((struct k_sem *)semphr, K_FOREVER);
+        if (ret == 0) {
+            return 1;
+        }
     } else {
-        return (int32_t)xSemaphoreTake(semphr, block_time_tick);
+        int ret = k_sem_take((struct k_sem *)semphr, K_TICKS(block_time_tick));
+
+        if (ret == 0) {
+            return 1;
+        }
     }
+    return 0;
 }
 
 int32_t esp_coex_common_semphr_give_wrapper(void *semphr)
 {
-    return (int32_t)xSemaphoreGive(semphr);
+    k_sem_give((struct k_sem *)semphr);
+    return 1;
 }
 
 void IRAM_ATTR esp_coex_common_timer_disarm_wrapper(void *timer)
@@ -118,29 +140,49 @@ void IRAM_ATTR esp_coex_common_timer_arm_us_wrapper(void *ptimer, uint32_t us, b
     ets_timer_arm_us(ptimer, us, repeat);
 }
 
-uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
-{
-    /* The bit width of WiFi light sleep clock calibration is 12 while the one of
-     * system is 19. It should shift 19 - 12 = 7.
-    */
-    return (esp_clk_slowclk_cal_get() >> (RTC_CLK_CAL_FRACT - SOC_WIFI_LIGHT_SLEEP_CLK_WIDTH));
-}
-
 void *IRAM_ATTR esp_coex_common_malloc_internal_wrapper(size_t size)
 {
-    return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+    return k_malloc(size);
+}
+
+uint32_t esp_coex_common_clk_slowclk_cal_get_wrapper(void)
+{
+    /* The bit width of Wi-Fi light sleep clock calibration is 12 while the one of
+     * system is 19. It should shift 19 - 12 = 7.
+     */
+    return (esp_clk_slowclk_cal_get() >> (RTC_CLK_CAL_FRACT - SOC_WIFI_LIGHT_SLEEP_CLK_WIDTH));
 }
 
 /* static wrapper */
 
 static int32_t IRAM_ATTR esp_coex_semphr_take_from_isr_wrapper(void *semphr, void *hptw)
 {
-    return (int32_t)xSemaphoreTakeFromISR(semphr, hptw);
+    int *hpt = (int *)hptw;
+    int ret = k_sem_take((struct k_sem *)semphr, K_NO_WAIT);
+
+    if (ret == 0) {
+        if (hpt) {
+            *hpt = 0;
+        }
+        return 1;
+    }
+
+    if (hpt) {
+        *hpt = 0;
+    }
+    return 0;
 }
 
 static int32_t IRAM_ATTR esp_coex_semphr_give_from_isr_wrapper(void *semphr, void *hptw)
 {
-    return (int32_t)xSemaphoreGiveFromISR(semphr, hptw);
+    int *hpt = (int *)hptw;
+
+    k_sem_give((struct k_sem *)semphr);
+
+    if (hpt) {
+        *hpt = 0;
+    }
+    return 1;
 }
 
 static int esp_coexist_debug_matrix_init_wrapper(int evt, int sig, bool rev)
@@ -157,6 +199,11 @@ static IRAM_ATTR int esp_coex_common_xtal_freq_get_wrapper(void)
     return rtc_clk_xtal_freq_get();
 }
 
+int32_t IRAM_ATTR coex_is_in_isr_wrapper(void)
+{
+    return k_is_in_isr();
+}
+
 coex_adapter_funcs_t g_coex_adapter_funcs = {
     ._version = COEX_ADAPTER_VERSION,
     ._task_yield_from_isr = esp_coex_common_task_yield_from_isr_wrapper,
@@ -166,9 +213,9 @@ coex_adapter_funcs_t g_coex_adapter_funcs = {
     ._semphr_give_from_isr = esp_coex_semphr_give_from_isr_wrapper,
     ._semphr_take = esp_coex_common_semphr_take_wrapper,
     ._semphr_give = esp_coex_common_semphr_give_wrapper,
-    ._is_in_isr = xPortInIsrContext,
-    ._malloc_internal =  esp_coex_common_malloc_internal_wrapper,
-    ._free = free,
+    ._is_in_isr = coex_is_in_isr_wrapper,
+    ._malloc_internal = esp_coex_common_malloc_internal_wrapper,
+    ._free = k_free,
     ._esp_timer_get_time = esp_timer_get_time,
     ._env_is_chip = esp_coex_common_env_is_chip_wrapper,
     ._timer_disarm = esp_coex_common_timer_disarm_wrapper,
@@ -179,3 +226,14 @@ coex_adapter_funcs_t g_coex_adapter_funcs = {
     ._xtal_freq_get = esp_coex_common_xtal_freq_get_wrapper,
     ._magic = COEX_ADAPTER_MAGIC,
 };
+
+#if CONFIG_ESP32_SW_COEXIST_ENABLE
+static int esp_coex_adapter_init(void)
+{
+    esp_coex_adapter_register(&g_coex_adapter_funcs);
+    coex_pre_init();
+    return 0;
+}
+
+SYS_INIT(esp_coex_adapter_init, POST_KERNEL, 50);
+#endif

--- a/components/esp_hal_clock/esp32c61/clk_tree_hal.c
+++ b/components/esp_hal_clock/esp32c61/clk_tree_hal.c
@@ -16,7 +16,7 @@ uint32_t clk_hal_soc_root_get_freq_mhz(soc_cpu_clk_src_t cpu_clk_src)
     case SOC_CPU_CLK_SRC_PLL_F160M:
         return CLK_LL_PLL_160M_FREQ_MHZ;
     case SOC_CPU_CLK_SRC_RC_FAST:
-        return SOC_CLK_RC_FAST_FREQ_APPROX / MHZ;
+        return SOC_CLK_RC_FAST_FREQ_APPROX / MHZ(1);
     default:
         // Unknown CPU_CLK mux input
         HAL_ASSERT(false);
@@ -28,14 +28,14 @@ uint32_t clk_hal_cpu_get_freq_hz(void)
 {
     soc_cpu_clk_src_t source = clk_ll_cpu_get_src();
     uint32_t divider = clk_ll_cpu_get_divider();
-    return clk_hal_soc_root_get_freq_mhz(source) * MHZ / divider;
+    return clk_hal_soc_root_get_freq_mhz(source) * MHZ(1) / divider;
 }
 
 static uint32_t clk_hal_ahb_get_freq_hz(void)
 {
     soc_cpu_clk_src_t source = clk_ll_cpu_get_src();
     uint32_t divider = clk_ll_ahb_get_divider();
-    return clk_hal_soc_root_get_freq_mhz(source) * MHZ / divider;
+    return clk_hal_soc_root_get_freq_mhz(source) * MHZ(1) / divider;
 }
 
 uint32_t clk_hal_apb_get_freq_hz(void)

--- a/components/esp_hal_clock/esp32c61/include/hal/clk_tree_ll.h
+++ b/components/esp_hal_clock/esp32c61/include/hal/clk_tree_ll.h
@@ -22,7 +22,13 @@
 #include "esp32c61/rom/rtc.h"
 #include "hal/misc.h"
 
-#define MHZ                 (1000000)
+/* Zephyr's sys/util.h provides a function-like MHZ(x) macro; use the
+ * same form here to avoid a collision with the original object-like
+ * MHZ definition.
+ */
+#ifndef MHZ
+#define MHZ(x)              ((x) * 1000000UL)
+#endif
 
 #define CLK_LL_PLL_80M_FREQ_MHZ    (80)
 #define CLK_LL_PLL_120M_FREQ_MHZ   (120)

--- a/components/esp_hal_dma/esp32c61/include/hal/gdma_ll.h
+++ b/components/esp_hal_dma/esp32c61/include/hal/gdma_ll.h
@@ -18,6 +18,46 @@
 #define GDMA_LL_AHB_BURST_SIZE_ADJUSTABLE 1  // AHB GDMA supports adjustable burst size
 #define GDMA_LL_MAX_BURST_SIZE_PSRAM      32 // PSRAM controller doesn't support burst access with size > 32 bytes
 
+/*
+ * Compatibility aliases: map gdma_ll_* names to the ahb_dma_ll_* API
+ * so that Zephyr drivers written against the v1 GDMA interface compile on
+ * AHB-GDMA-v2 SoCs without source changes.
+ */
+#define GDMA_LL_M2M_FREE_PERIPH_ID_MASK          AHB_DMA_LL_M2M_FREE_PERIPH_ID_MASK
+#define GDMA_LL_RX_EVENT_MASK                     AHB_DMA_LL_RX_EVENT_MASK
+#define GDMA_LL_TX_EVENT_MASK                     AHB_DMA_LL_TX_EVENT_MASK
+#define gdma_ll_force_enable_reg_clock            ahb_dma_ll_force_enable_reg_clock
+#define gdma_ll_rx_clear_interrupt_status          ahb_dma_ll_rx_clear_interrupt_status
+#define gdma_ll_rx_connect_to_mem                  ahb_dma_ll_rx_connect_to_mem
+#define gdma_ll_rx_connect_to_periph               ahb_dma_ll_rx_connect_to_periph
+#define gdma_ll_rx_enable_data_burst               ahb_dma_ll_rx_enable_data_burst
+#define gdma_ll_rx_enable_descriptor_burst         ahb_dma_ll_rx_enable_descriptor_burst
+#define gdma_ll_rx_enable_interrupt                ahb_dma_ll_rx_enable_interrupt
+#define gdma_ll_rx_enable_owner_check              ahb_dma_ll_rx_enable_owner_check
+#define gdma_ll_rx_get_interrupt_status            ahb_dma_ll_rx_get_interrupt_status
+#define gdma_ll_rx_get_interrupt_status_reg        ahb_dma_ll_rx_get_interrupt_status_reg
+#define gdma_ll_rx_get_prefetched_desc_addr        ahb_dma_ll_rx_get_prefetched_desc_addr
+#define gdma_ll_rx_get_success_eof_desc_addr       ahb_dma_ll_rx_get_success_eof_desc_addr
+#define gdma_ll_rx_is_desc_fsm_idle                ahb_dma_ll_rx_is_desc_fsm_idle
+#define gdma_ll_rx_reset_channel                   ahb_dma_ll_rx_reset_channel
+#define gdma_ll_rx_set_desc_addr                   ahb_dma_ll_rx_set_desc_addr
+#define gdma_ll_rx_start                           ahb_dma_ll_rx_start
+#define gdma_ll_rx_stop                            ahb_dma_ll_rx_stop
+#define gdma_ll_tx_clear_interrupt_status          ahb_dma_ll_tx_clear_interrupt_status
+#define gdma_ll_tx_connect_to_mem                  ahb_dma_ll_tx_connect_to_mem
+#define gdma_ll_tx_connect_to_periph               ahb_dma_ll_tx_connect_to_periph
+#define gdma_ll_tx_enable_data_burst               ahb_dma_ll_tx_enable_data_burst
+#define gdma_ll_tx_enable_descriptor_burst         ahb_dma_ll_tx_enable_descriptor_burst
+#define gdma_ll_tx_enable_interrupt                ahb_dma_ll_tx_enable_interrupt
+#define gdma_ll_tx_get_interrupt_status            ahb_dma_ll_tx_get_interrupt_status
+#define gdma_ll_tx_get_interrupt_status_reg        ahb_dma_ll_tx_get_interrupt_status_reg
+#define gdma_ll_tx_get_prefetched_desc_addr        ahb_dma_ll_tx_get_prefetched_desc_addr
+#define gdma_ll_tx_is_desc_fsm_idle                ahb_dma_ll_tx_is_desc_fsm_idle
+#define gdma_ll_tx_reset_channel                   ahb_dma_ll_tx_reset_channel
+#define gdma_ll_tx_set_desc_addr                   ahb_dma_ll_tx_set_desc_addr
+#define gdma_ll_tx_start                           ahb_dma_ll_tx_start
+#define gdma_ll_tx_stop                            ahb_dma_ll_tx_stop
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/components/esp_hal_i2s/esp32c61/include/hal/i2s_ll.h
+++ b/components/esp_hal_i2s/esp32c61/include/hal/i2s_ll.h
@@ -1372,6 +1372,7 @@ static inline bool i2s_ll_get_etm_rx_threshold_event_status(i2s_dev_t *hw)
     }
 }
 
+#ifndef __ZEPHYR__
 /**
  * @brief Set I2S data destination
  */
@@ -1390,6 +1391,7 @@ static inline bool i2s_ll_is_destination_supported(int port_id, i2s_destination_
     (void)port_id;
     return destination == I2S_DESTINATION_DMA;
 }
+#endif /* __ZEPHYR__ */
 
 /**
  * @brief Check whether I2S PDM mode is supported on the specified port

--- a/components/esp_hal_uart/esp32c61/include/hal/uart_ll.h
+++ b/components/esp_hal_uart/esp32c61/include/hal/uart_ll.h
@@ -1022,6 +1022,18 @@ FORCE_INLINE_ATTR void uart_ll_set_mode_rs485_half_duplex(uart_dev_t *hw)
 }
 
 /**
+ * @brief  Check if the UART is in rs485 half duplex mode.
+ *
+ * @param  hw Beginning address of the peripheral registers.
+ *
+ * @return True if the UART is in rs485 half duplex mode, otherwise false.
+ */
+FORCE_INLINE_ATTR bool uart_ll_is_mode_rs485_half_duplex(uart_dev_t *hw)
+{
+    return hw->rs485_conf_sync.rs485_en && hw->conf0_sync.sw_rts;
+}
+
+/**
  * @brief  Configure the UART work in collision_detect mode.
  *
  * @param  hw Beginning address of the peripheral registers.

--- a/components/esp_hw_support/periph_ctrl.c
+++ b/components/esp_hw_support/periph_ctrl.c
@@ -29,6 +29,8 @@
 #include <zephyr/dt-bindings/clock/esp32c5_clock.h>
 #elif defined(CONFIG_SOC_SERIES_ESP32C6)
 #include <zephyr/dt-bindings/clock/esp32c6_clock.h>
+#elif defined(CONFIG_SOC_SERIES_ESP32C61)
+#include <zephyr/dt-bindings/clock/esp32c61_clock.h>
 #elif defined(CONFIG_SOC_SERIES_ESP32H2)
 #include <zephyr/dt-bindings/clock/esp32h2_clock.h>
 #elif defined(CONFIG_SOC_SERIES_ESP32P4)

--- a/components/esp_hw_support/port/esp32c61/cpu_region_protect.c
+++ b/components/esp_hw_support/port/esp32c61/cpu_region_protect.c
@@ -32,7 +32,7 @@
 #define ALIGN_DOWN_TO_MMU_PAGE_SIZE(addr)  ((addr) & ~((SOC_MMU_PAGE_SIZE) - 1))
 #define ALIGN_UP(addr, align)  (((addr) + (align) - 1) & ~((align) - 1))
 
-static void esp_cpu_configure_invalid_regions(void)
+void esp_cpu_configure_invalid_regions(void)
 {
     const unsigned PMA_NONE                            = PMA_L | PMA_EN;
     __attribute__((unused)) const unsigned PMA_RW      = PMA_L | PMA_EN | PMA_R | PMA_W;

--- a/components/esp_hw_support/port/esp32c61/esp_clk_tree.c
+++ b/components/esp_hw_support/port/esp32c61/esp_clk_tree.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdint.h>
-#include <stdatomic.h>
+#include <zephyr/sys/atomic.h>
 #include "esp_clk_tree.h"
 #include "esp_err.h"
 #include "esp_check.h"
@@ -18,7 +18,7 @@
 
 ESP_LOG_ATTR_TAG(TAG, "esp_clk_tree");
 
-static _Atomic int16_t s_pll_src_cg_ref_cnt[SOC_MOD_CLK_INVALID] = { 0 };
+static atomic_t s_pll_src_cg_ref_cnt[SOC_MOD_CLK_INVALID];
 
 esp_err_t esp_clk_tree_src_get_freq_hz(soc_module_clk_t clk_src, esp_clk_tree_src_freq_precision_t precision,
 uint32_t *freq_value)
@@ -33,19 +33,19 @@ uint32_t *freq_value)
         clk_src_freq = clk_hal_cpu_get_freq_hz();
         break;
     case SOC_MOD_CLK_XTAL:
-        clk_src_freq = clk_hal_xtal_get_freq_mhz() * MHZ;
+        clk_src_freq = clk_hal_xtal_get_freq_mhz() * MHZ(1);
         break;
     case SOC_MOD_CLK_PLL_F80M:
-        clk_src_freq = CLK_LL_PLL_80M_FREQ_MHZ * MHZ;
+        clk_src_freq = CLK_LL_PLL_80M_FREQ_MHZ * MHZ(1);
         break;
     case SOC_MOD_CLK_PLL_F120M:
-        clk_src_freq = CLK_LL_PLL_120M_FREQ_MHZ * MHZ;
+        clk_src_freq = CLK_LL_PLL_120M_FREQ_MHZ * MHZ(1);
         break;
     case SOC_MOD_CLK_PLL_F160M:
-        clk_src_freq = CLK_LL_PLL_160M_FREQ_MHZ * MHZ;
+        clk_src_freq = CLK_LL_PLL_160M_FREQ_MHZ * MHZ(1);
         break;
     case SOC_MOD_CLK_SPLL:
-        clk_src_freq = CLK_LL_PLL_480M_FREQ_MHZ * MHZ;
+        clk_src_freq = CLK_LL_PLL_480M_FREQ_MHZ * MHZ(1);
         break;
     case SOC_MOD_CLK_RTC_SLOW:
         clk_src_freq = esp_clk_tree_lp_slow_get_freq_hz(precision);
@@ -97,14 +97,17 @@ esp_err_t esp_clk_tree_enable_src(soc_module_clk_t clk_src, bool enable)
         // some conditions is legal, e.g. -1 means external clock source
         return ESP_OK;
     }
+    /* Zephyr sys/atomic.h: atomic_add/atomic_sub return the previous
+     * value, matching C11 atomic_fetch_add/sub semantics.
+     */
     int16_t prev_ref_cnt = 0;
     if (enable) {
-        prev_ref_cnt = atomic_fetch_add(&s_pll_src_cg_ref_cnt[clk_src], 1);
+        prev_ref_cnt = atomic_add(&s_pll_src_cg_ref_cnt[clk_src], 1);
     } else {
-        prev_ref_cnt = atomic_fetch_sub(&s_pll_src_cg_ref_cnt[clk_src], 1);
+        prev_ref_cnt = atomic_sub(&s_pll_src_cg_ref_cnt[clk_src], 1);
         if (prev_ref_cnt <= 0) {
             ESP_EARLY_LOGW(TAG, "soc_module_clk_t %d disabled multiple times!!", clk_src);
-            atomic_store(&s_pll_src_cg_ref_cnt[clk_src], 0);
+            atomic_set(&s_pll_src_cg_ref_cnt[clk_src], 0);
             return ESP_OK;
         }
     }

--- a/components/esp_hw_support/port/esp32c61/include/soc/rtc.h
+++ b/components/esp_hw_support/port/esp32c61/include/soc/rtc.h
@@ -47,7 +47,9 @@ extern "C" {
  * - rtc_time: reading RTC counter, conversion between counter values and time
  */
 
-#define MHZ (1000000)
+#ifndef MHZ
+#define MHZ(x) ((x) * 1000000UL)
+#endif
 
 #define OTHER_BLOCKS_POWERUP        1
 #define OTHER_BLOCKS_WAIT           1

--- a/components/esp_hw_support/port/esp32c61/ocode_init.c
+++ b/components/esp_hw_support/port/esp32c61/ocode_init.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdint.h>
+#include "esp_attr.h"
 #include "soc/soc.h"
 #include "soc/rtc.h"
 #include "soc/regi2c_dig_reg.h"

--- a/components/esp_hw_support/port/esp32c61/rtc_clk.c
+++ b/components/esp_hw_support/port/esp32c61/rtc_clk.c
@@ -389,7 +389,7 @@ static uint32_t rtc_clk_ahb_freq_get(void)
 
 uint32_t rtc_clk_apb_freq_get(void)
 {
-    return rtc_clk_ahb_freq_get() / clk_ll_apb_get_divider() * MHZ;
+    return rtc_clk_ahb_freq_get() / clk_ll_apb_get_divider() * MHZ(1);
 }
 
 void rtc_dig_clk8m_enable(void)

--- a/components/esp_hw_support/port/esp32c61/rtc_time.c
+++ b/components/esp_hw_support/port/esp32c61/rtc_time.c
@@ -98,7 +98,7 @@ static uint32_t rtc_clk_cal_internal(soc_clk_freq_calculation_src_t cal_clk_sel,
     } else {
         expected_freq = SOC_CLK_RC_SLOW_FREQ_APPROX;
     }
-    uint32_t us_time_estimate = (uint32_t) (((uint64_t) slowclk_cycles) * MHZ / expected_freq);
+    uint32_t us_time_estimate = (uint32_t) (((uint64_t) slowclk_cycles) * MHZ(1) / expected_freq);
     /* Start calibration */
     CLEAR_PERI_REG_MASK(TIMG_RTCCALICFG_REG(0), TIMG_RTC_CALI_START);
     SET_PERI_REG_MASK(TIMG_RTCCALICFG_REG(0), TIMG_RTC_CALI_START);
@@ -202,7 +202,7 @@ uint32_t rtc_clk_freq_to_period(uint32_t) __attribute__((alias("rtc_clk_freq_cal
 
 /// @brief if the calibration is used, we need to enable the timer group0 first
 
-static void enable_timer_group0_for_calibration(void)
+static void __attribute__((unused)) enable_timer_group0_for_calibration(void)
 {
 #ifndef BOOTLOADER_BUILD
     PERIPH_RCC_ACQUIRE_ATOMIC(PERIPH_TIMG0_MODULE, ref_count) {

--- a/components/esp_hw_support/port/esp32c61/sar_periph_ctrl.c
+++ b/components/esp_hw_support/port/esp32c61/sar_periph_ctrl.c
@@ -15,9 +15,9 @@
  */
 
 #include <sys/lock.h>
+#include <zephyr/kernel.h>
 #include "sdkconfig.h"
 #include "esp_log.h"
-#include "freertos/FreeRTOS.h"
 #include "esp_private/sar_periph_ctrl.h"
 #include "esp_private/regi2c_ctrl.h"
 #include "esp_private/esp_modem_clock.h"
@@ -28,8 +28,8 @@
 #include "hal/temperature_sensor_ll.h"
 
 ESP_LOG_ATTR_TAG(TAG, "sar_periph_ctrl");
-extern portMUX_TYPE rtc_spinlock;
-static _lock_t adc_reset_lock;
+extern esp_os_spinlock_t rtc_spinlock;
+K_MUTEX_DEFINE(adc_reset_lock);
 
 void sar_periph_ctrl_init(void)
 {
@@ -150,10 +150,10 @@ void sar_periph_ctrl_adc_reset(void)
 
 void adc_reset_lock_acquire(void)
 {
-    _lock_acquire(&adc_reset_lock);
+    k_mutex_lock(&adc_reset_lock, K_FOREVER);
 }
 
 void adc_reset_lock_release(void)
 {
-    _lock_release(&adc_reset_lock);
+    k_mutex_unlock(&adc_reset_lock);
 }

--- a/components/esp_rom/esp32c61/include/esp32c61/rom/uart.h
+++ b/components/esp_rom/esp32c61/include/esp32c61/rom/uart.h
@@ -113,6 +113,10 @@ typedef enum {
     XON_XOFF_CTRL
 } UartFlowCtrl;
 
+/* Undef EMPTY if defined by Zephyr util_macro.h */
+#ifdef EMPTY
+#undef EMPTY
+#endif
 typedef enum {
     EMPTY,
     UNDER_WRITE,

--- a/components/esp_rom/esp32c61/ld/esp32c61.rom.libc.ld
+++ b/components/esp_rom/esp32c61/ld/esp32c61.rom.libc.ld
@@ -8,7 +8,12 @@ memset = 0x400004b8;
 strlen = 0x400004d8;
 strstr = 0x400004dc;
 bzero = 0x400004e0;
-sbrk = 0x400004e8;
+/* The ROM implementations below route through
+ * syscall_table_ptr, which this port never installs, and
+ * would fault on a NULL pointer if a libc build ever
+ * referenced them. Keep the compiled libc versions instead.
+ */
+/* sbrk = 0x400004e8; */
 isascii = 0x400004f4;
 isblank = 0x400004f8;
 iscntrl = 0x400004fc;
@@ -31,8 +36,9 @@ strrchr = 0x4000056c;
 strsep = 0x40000570;
 strspn = 0x40000574;
 strtok_r = 0x40000578;
-longjmp = 0x40000580;
-setjmp = 0x40000584;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* longjmp = 0x40000580; */
+/* setjmp  = 0x40000584; */
 abs = 0x40000588;
 div = 0x4000058c;
 labs = 0x40000590;

--- a/components/esp_rom/esp32c61/ld/esp32c61.rom.newlib.ld
+++ b/components/esp_rom/esp32c61/ld/esp32c61.rom.newlib.ld
@@ -19,26 +19,31 @@
  Group newlib
  ***************************************/
 
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* strdup       = 0x40000540; */
+/* strndup      = 0x40000564; */
+/* rand         = 0x400005a0; */
+/* srand        = 0x400005a4; */
+/* rand_r       = 0x4000059c; */
+/* atoi         = 0x400005b0; */
+/* atol         = 0x400005b4; */
+/* strtol       = 0x400005b8; */
+/* strtoul      = 0x400005bc; */
+/* fflush       = 0x400005c0; */
+/* _fflush_r    = 0x400005c4; */
+/* _fwalk       = 0x400005c8; */
+/* _fwalk_reent = 0x400005cc; */
+/* __swbuf_r    = 0x400005d8; */
+
 /* Functions */
-_isatty_r = 0x400004e4;
-strdup = 0x40000540;
-strndup = 0x40000564;
-rand_r = 0x4000059c;
-rand = 0x400005a0;
-srand = 0x400005a4;
-atoi = 0x400005b0;
-atol = 0x400005b4;
-strtol = 0x400005b8;
-strtoul = 0x400005bc;
-fflush = 0x400005c0;
-_fflush_r = 0x400005c4;
-_fwalk = 0x400005c8;
-_fwalk_reent = 0x400005cc;
-__smakebuf_r = 0x400005d0;
-__swhatbuf_r = 0x400005d4;
-__swbuf_r = 0x400005d8;
-__swbuf = 0x400005dc;
-__swsetup_r = 0x400005e0;
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* _isatty_r = 0x400004e4; */
+/* __smakebuf_r = 0x400005d0; */
+/* __swhatbuf_r = 0x400005d4; */
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swbuf = 0x400005dc; */
+/* Zephyr: reentrant ROM call, provided by the selected libc */
+/* __swsetup_r = 0x400005e0; */
 toupper = 0x4000051c;
 tolower = 0x40000520;
 isalnum = 0x400004ec;

--- a/components/esp_system/port/soc/esp32c61/clk.c
+++ b/components/esp_system/port/soc/esp32c61/clk.c
@@ -34,15 +34,13 @@
  */
 #define SLOW_CLK_CAL_CYCLES     CONFIG_CLOCK_CONTROL_ESP32_RTC_CLK_CAL_CYCLES
 
-#define MHZ (1000000)
-
 static void select_rtc_slow_clk(soc_rtc_slow_clk_src_t rtc_slow_clk_src);
 
 ESP_LOG_ATTR_TAG(TAG, "clk");
 
 void esp_rtc_init(void)
 {
-#if !CONFIG_IDF_ENV_FPGA
+#if !CONFIG_IDF_ENV_FPGA && !CONFIG_MCUBOOT
     pmu_init();
 #endif
 }

--- a/components/esp_system/port/soc/esp32c61/reset_reason.c
+++ b/components/esp_system/port/soc/esp32c61/reset_reason.c
@@ -68,7 +68,7 @@ static esp_reset_reason_t get_reset_reason(soc_reset_reason_t rtc_reset_reason, 
     }
 }
 
-static void esp_reset_reason_init(void)
+void esp_reset_reason_init(void)
 {
     esp_reset_reason_t hint = esp_reset_reason_get_hint();
     s_reset_reason = get_reset_reason(esp_rom_get_reset_reason(PRO_CPU_NUM), hint);

--- a/components/esp_wifi/esp32c61/esp_adapter.c
+++ b/components/esp_wifi/esp32c61/esp_adapter.c
@@ -4,30 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
-#include <pthread.h>
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/queue.h"
-#include "freertos/semphr.h"
-#include "freertos/event_groups.h"
-#include "freertos/portmacro.h"
-#include "riscv/interrupt.h"
+#include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/random/random.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(esp32c61_wifi_adapter, CONFIG_WIFI_LOG_LEVEL);
+
+#include <riscv/interrupt.h>
+
 #include "esp_types.h"
 #include "esp_random.h"
 #include "esp_mac.h"
-#include "esp_task.h"
-#include "esp_intr_alloc.h"
+#include "esp_efuse.h"
+#include "esp_efuse_table.h"
 #include "esp_attr.h"
-#include "esp_log.h"
-#include "esp_event.h"
-#include "esp_heap_caps.h"
 #include "esp_timer.h"
+#include "esp_heap_caps.h"
+#include "esp_system.h"
 #include "esp_private/esp_modem_clock.h"
 #include "esp_private/wifi_os_adapter.h"
 #include "esp_private/wifi.h"
@@ -42,17 +44,17 @@
 #include "soc/rtc.h"
 #include "esp_private/periph_ctrl.h"
 #include "esp_private/esp_clk.h"
-#include "nvs.h"
-#include "esp_efuse.h"
-#include "esp_efuse_table.h"
 #include "os.h"
-#include "esp_smartconfig.h"
+#include "esp_log.h"
 #ifdef CONFIG_ESP_COEX_ENABLED
 #include "private/esp_coexist_internal.h"
 #endif
+#include "esp_rom_sys.h"
 #include "esp32c61/rom/ets_sys.h"
 #include "private/esp_modem_wrapper.h"
-#include "esp_private/esp_modem_clock.h"
+#include "esp_heap_adapter.h"
+#include "wifi/wifi_event.h"
+#include "zephyr_compat.h"
 
 #if SOC_PM_MODEM_RETENTION_BY_REGDMA
 #include "esp_private/esp_regdma.h"
@@ -61,6 +63,19 @@
 
 #define TAG "esp_adapter"
 
+static void esp_wifi_free(void *mem);
+
+struct wifi_adapter_msgq {
+	struct k_msgq msgq;
+	void *buffer;
+};
+
+struct wifi_task {
+    struct k_thread thread;
+    k_thread_stack_t *stack;
+    struct k_work cleanup_work;
+};
+
 #ifdef CONFIG_PM
 extern void wifi_apb80m_request(void);
 extern void wifi_apb80m_release(void);
@@ -68,88 +83,97 @@ extern void wifi_apb80m_release(void);
 
 IRAM_ATTR void *wifi_malloc(size_t size)
 {
-#if CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP
-    return heap_caps_malloc_prefer(size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL);
-#else
-    return malloc(size);
-#endif
+    void *ptr = esp_wifi_malloc_func(size);
+
+    if (ptr == NULL) {
+        LOG_ERR("memory allocation failed");
+    }
+
+    return ptr;
 }
 
 IRAM_ATTR void *wifi_realloc(void *ptr, size_t size)
 {
-#if CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP
-    return heap_caps_realloc_prefer(ptr, size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL);
-#else
-    return realloc(ptr, size);
-#endif
+    void *p = esp_wifi_realloc_func(ptr, size);
+
+    if (p == NULL) {
+        LOG_ERR("memory allocation failed");
+    }
+
+    return p;
 }
 
 IRAM_ATTR void *wifi_calloc(size_t n, size_t size)
 {
-#if CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP
-    return heap_caps_calloc_prefer(n, size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL);
-#else
-    return calloc(n, size);
-#endif
+    void *ptr = esp_wifi_calloc_func(n, size);
+
+    if (ptr == NULL) {
+        LOG_ERR("memory allocation failed");
+    }
+
+    return ptr;
 }
 
 static void *IRAM_ATTR wifi_zalloc_wrapper(size_t size)
 {
-    void *ptr = wifi_calloc(1, size);
-    return ptr;
+    return wifi_calloc(1, size);
+}
+
+static void esp_wifi_free(void *mem)
+{
+    esp_wifi_free_func(mem);
+}
+
+static void wifi_task_cleanup_work(struct k_work *work)
+{
+    struct wifi_task *t = CONTAINER_OF(work, struct wifi_task, cleanup_work);
+
+    k_thread_join(&t->thread, K_FOREVER);
+    if (t->thread.custom_data) {
+        esp_wifi_free_func(t->thread.custom_data);
+    }
+
+    k_thread_stack_free(t->stack);
+    k_object_release(&t->thread);
+    esp_wifi_free_func(t);
 }
 
 wifi_static_queue_t *wifi_create_queue(int queue_len, int item_size)
 {
     wifi_static_queue_t *queue = NULL;
 
-    queue = (wifi_static_queue_t *)heap_caps_malloc(sizeof(wifi_static_queue_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    queue = (wifi_static_queue_t *)wifi_malloc(sizeof(wifi_static_queue_t));
     if (!queue) {
+        LOG_ERR("msg buffer allocation failed");
         return NULL;
     }
 
-#if CONFIG_SPIRAM_USE_MALLOC
-    /* Wi-Fi still use internal RAM */
-
-    queue->storage = heap_caps_calloc(1, sizeof(StaticQueue_t) + (queue_len * item_size), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-    if (!queue->storage) {
-        goto _error;
+    queue->storage = wifi_malloc(queue_len * item_size);
+    if (queue->storage == NULL) {
+        LOG_ERR("msg buffer allocation failed");
+        esp_wifi_free(queue);
+        return NULL;
     }
 
-    queue->handle = xQueueCreateStatic(queue_len, item_size, ((uint8_t*)(queue->storage)) + sizeof(StaticQueue_t), (StaticQueue_t*)(queue->storage));
-
-    if (!queue->handle) {
-        goto _error;
+    queue->handle = wifi_malloc(sizeof(struct k_msgq));
+    if (queue->handle == NULL) {
+        esp_wifi_free(queue->storage);
+        esp_wifi_free(queue);
+        LOG_ERR("queue handle allocation failed");
+        return NULL;
     }
+
+    k_msgq_init((struct k_msgq *)queue->handle, queue->storage, item_size, queue_len);
 
     return queue;
-
-_error:
-    if (queue) {
-        if (queue->storage) {
-            free(queue->storage);
-        }
-
-        free(queue);
-    }
-
-    return NULL;
-#else
-    queue->handle = xQueueCreate(queue_len, item_size);
-    return queue;
-#endif
 }
 
 void wifi_delete_queue(wifi_static_queue_t *queue)
 {
     if (queue) {
-        vQueueDelete(queue->handle);
-#if CONFIG_SPIRAM_USE_MALLOC
-        if (queue->storage) {
-            free(queue->storage);
-        }
-#endif
-        free(queue);
+        esp_wifi_free(queue->handle);
+        esp_wifi_free(queue->storage);
+        esp_wifi_free(queue);
     }
 }
 
@@ -165,6 +189,8 @@ static void wifi_delete_queue_wrapper(void *queue)
 
 static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source, uint32_t intr_num, int32_t intr_prio)
 {
+    ARG_UNUSED(cpu_no);
+
     esp_rom_route_intr_matrix(cpu_no, intr_source, intr_num);
     esprv_int_set_priority(intr_num, intr_prio);
     esprv_int_set_type(intr_num, INTR_TYPE_LEVEL);
@@ -172,12 +198,15 @@ static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source, uint32_t intr
 
 static void clear_intr_wrapper(uint32_t intr_source, uint32_t intr_num)
 {
-
+    ARG_UNUSED(intr_source);
+    ARG_UNUSED(intr_num);
 }
 
 static void set_isr_wrapper(int32_t n, void *f, void *arg)
 {
-    intr_handler_set(n, (intr_handler_t)f, arg);
+    irq_disable(n);
+    irq_connect_dynamic(n, 0, f, arg, 0);
+    irq_enable(n);
 }
 
 static void enable_intr_wrapper(uint32_t intr_mask)
@@ -192,168 +221,308 @@ static void disable_intr_wrapper(uint32_t intr_mask)
 
 static bool IRAM_ATTR is_from_isr_wrapper(void)
 {
-    return !xPortCanYield();
-}
-
-static void wifi_thread_semphr_free(void *data)
-{
-    SemaphoreHandle_t *sem = (SemaphoreHandle_t *)(data);
-
-    if (sem) {
-        vSemaphoreDelete(sem);
-    }
+    return k_is_in_isr();
 }
 
 static void *wifi_thread_semphr_get_wrapper(void)
 {
-    static bool s_wifi_thread_sem_key_init = false;
-    static pthread_key_t s_wifi_thread_sem_key;
-    SemaphoreHandle_t sem = NULL;
+    struct k_sem *sem = NULL;
 
-    if (s_wifi_thread_sem_key_init == false) {
-        if (0 != pthread_key_create(&s_wifi_thread_sem_key, wifi_thread_semphr_free)) {
+    sem = k_thread_custom_data_get();
+    if (!sem) {
+        sem = (struct k_sem *)wifi_malloc(sizeof(struct k_sem));
+        if (sem == NULL) {
+            LOG_ERR("wifi_thread_semphr_get_wrapper allocation failed");
             return NULL;
         }
-        s_wifi_thread_sem_key_init = true;
+        k_sem_init(sem, 0, 1);
+        k_thread_custom_data_set(sem);
     }
-
-    sem = pthread_getspecific(s_wifi_thread_sem_key);
-    if (!sem) {
-        sem = xSemaphoreCreateCounting(1, 0);
-        if (sem) {
-            pthread_setspecific(s_wifi_thread_sem_key, sem);
-            ESP_LOGV(TAG, "thread sem create: sem=%p", sem);
-        }
-    }
-
-    ESP_LOGV(TAG, "thread sem get: sem=%p", sem);
     return (void *)sem;
 }
 
 static void *recursive_mutex_create_wrapper(void)
 {
-    return (void *)xSemaphoreCreateRecursiveMutex();
+    struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+
+    if (my_mutex == NULL) {
+        LOG_ERR("recursive_mutex_create_wrapper allocation failed");
+        return NULL;
+    }
+
+    k_mutex_init(my_mutex);
+
+    return (void *)my_mutex;
 }
 
 static void *mutex_create_wrapper(void)
 {
-    return (void *)xSemaphoreCreateMutex();
+    struct k_mutex *my_mutex = (struct k_mutex *)wifi_malloc(sizeof(struct k_mutex));
+
+    if (my_mutex == NULL) {
+        LOG_ERR("mutex_create_wrapper allocation failed");
+        return NULL;
+    }
+
+    k_mutex_init(my_mutex);
+
+    return (void *)my_mutex;
 }
 
 static void mutex_delete_wrapper(void *mutex)
 {
-    vSemaphoreDelete(mutex);
+    esp_wifi_free(mutex);
 }
 
 static int32_t IRAM_ATTR mutex_lock_wrapper(void *mutex)
 {
-    return (int32_t)xSemaphoreTakeRecursive(mutex, portMAX_DELAY);
+    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
+
+    k_mutex_lock(my_mutex, K_FOREVER);
+    return 0;
 }
 
 static int32_t IRAM_ATTR mutex_unlock_wrapper(void *mutex)
 {
-    return (int32_t)xSemaphoreGiveRecursive(mutex);
+    struct k_mutex *my_mutex = (struct k_mutex *)mutex;
+
+    k_mutex_unlock(my_mutex);
+    return 0;
 }
 
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 {
-    StaticQueue_t *queue_buffer = heap_caps_malloc_prefer(sizeof(StaticQueue_t) + (queue_len * item_size), 2,
-                                                          MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM,
-                                                          MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL);
-    if (!queue_buffer) {
-        return NULL;
-    }
-    QueueHandle_t queue_handle = xQueueCreateStatic(queue_len, item_size, (uint8_t *)queue_buffer + sizeof(StaticQueue_t),
-                                                    queue_buffer);
-    if (!queue_handle) {
-        free(queue_buffer);
+    struct wifi_adapter_msgq *queue = wifi_malloc(sizeof(*queue));
+
+    if (!queue) {
+        LOG_ERR("queue malloc failed");
         return NULL;
     }
 
-    return (void *)queue_handle;
+    queue->buffer = wifi_malloc(queue_len * item_size);
+    if (!queue->buffer) {
+        LOG_ERR("queue buffer malloc failed");
+        esp_wifi_free(queue);
+        return NULL;
+    }
+
+    k_msgq_init(&queue->msgq, queue->buffer, item_size, queue_len);
+
+    return (void *)queue;
 }
 
-static void queue_delete_wrapper(void *queue)
+static void queue_delete_wrapper(void *handle)
 {
-    if (queue) {
-        StaticQueue_t *queue_buffer = NULL;
-        xQueueGetStaticBuffers(queue, NULL, &queue_buffer);
-        vQueueDelete(queue);
-        if (queue_buffer) {
-            free(queue_buffer);
-        }
+    if (handle) {
+        struct wifi_adapter_msgq *queue = handle;
+
+        esp_wifi_free(queue->buffer);
+        esp_wifi_free(queue);
     }
 }
 
-static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
     if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        return (int32_t)xQueueSend(queue, item, portMAX_DELAY);
+        ret = k_msgq_put(&queue->msgq, item, K_FOREVER);
     } else {
-        return (int32_t)xQueueSend(queue, item, block_time_tick);
+        ret = k_msgq_put(&queue->msgq, item, K_TICKS(block_time_tick));
     }
+
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *handle, void *item, void *hptw)
 {
-    return (int32_t)xQueueSendFromISR(queue, item, hptw);
+    int *hpt = (int *)hptw;
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put(&queue->msgq, item, K_NO_WAIT);
+    if (hpt) {
+        *hpt = 0;
+    }
+
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t queue_send_to_back_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_to_back_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_BACK);
+    return queue_send_wrapper(handle, item, block_time_tick);
 }
 
-static int32_t queue_send_to_front_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_send_to_front_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
-    return (int32_t)xQueueGenericSend(queue, item, block_time_tick, queueSEND_TO_FRONT);
+    ARG_UNUSED(block_time_tick);
+
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    ret = k_msgq_put_front(&queue->msgq, item);
+
+    return ret == 0 ? 1 : 0;
 }
 
-static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_tick)
+static int32_t queue_recv_wrapper(void *handle, void *item, uint32_t block_time_tick)
 {
+    int ret;
+
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
     if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        return (int32_t)xQueueReceive(queue, item, portMAX_DELAY);
+        ret = k_msgq_get(&queue->msgq, item, K_FOREVER);
     } else {
-        return (int32_t)xQueueReceive(queue, item, block_time_tick);
+        ret = k_msgq_get(&queue->msgq, item, K_TICKS(block_time_tick));
     }
+
+    return ret == 0 ? 1 : 0;
+}
+
+static uint32_t queue_msg_waiting_wrapper(void *handle)
+{
+    if (!handle) {
+        LOG_ERR("Received NULL queue handle");
+        return 0;
+    }
+
+    struct wifi_adapter_msgq *queue = handle;
+    return k_msgq_num_used_get(&queue->msgq);
 }
 
 static uint32_t event_group_wait_bits_wrapper(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick)
 {
-    if (block_time_tick == OSI_FUNCS_TIME_BLOCKING) {
-        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, portMAX_DELAY);
-    } else {
-        return (uint32_t)xEventGroupWaitBits(event, bits_to_wait_for, clear_on_exit, wait_for_all_bits, block_time_tick);
+    struct k_event *ev = event;
+    k_timeout_t timeout = (block_time_tick == UINT32_MAX) ?
+                  K_FOREVER : K_TICKS(block_time_tick);
+    uint32_t events;
+
+    if (ev == NULL) {
+        return 0;
     }
+
+    /*
+     * The blob follows the clear-on-exit convention: leave other bits
+     * untouched and clear only the matched bits after they are satisfied.
+     * Wait without resetting the whole mask, then clear the matched bits.
+     */
+    if (wait_for_all_bits) {
+        events = k_event_wait_all(ev, bits_to_wait_for, false, timeout);
+    } else {
+        events = k_event_wait(ev, bits_to_wait_for, false, timeout);
+    }
+
+    if (clear_on_exit && events != 0) {
+        k_event_clear(ev, events);
+    }
+
+    return events;
 }
 
 static int32_t task_create_pinned_to_core_wrapper(void *task_func, const char *name, uint32_t stack_depth, void *param, uint32_t prio, void *task_handle, uint32_t core_id)
 {
-    return (uint32_t)xTaskCreatePinnedToCore(task_func, name, stack_depth, param, prio, task_handle, (core_id < portNUM_PROCESSORS ? core_id : tskNO_AFFINITY));
+    ARG_UNUSED(core_id);
+
+    uint32_t stack_size = MAX(stack_depth, CONFIG_ESP32_WIFI_TASK_STACK_SIZE);
+    struct wifi_task *t = wifi_malloc(sizeof(*t));
+
+    if (t == NULL) {
+        return 0;
+    }
+
+    /*
+     * Clamp blob task priorities to the valid Zephyr preemptible range. Values
+     * above the range all collapse to the lowest preemptible priority, so their
+     * relative order is not preserved.
+     */
+    if (prio >= CONFIG_NUM_PREEMPT_PRIORITIES) {
+        prio = CONFIG_NUM_PREEMPT_PRIORITIES - 1;
+    }
+
+    t->stack = k_thread_stack_alloc(stack_size,
+                                    IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0);
+    if (t->stack == NULL) {
+        esp_wifi_free(t);
+        return 0;
+    }
+
+    k_tid_t tid = k_thread_create(&t->thread, t->stack, stack_size,
+                      (k_thread_entry_t)task_func, param, NULL, NULL,
+                      prio, K_INHERIT_PERMS, K_NO_WAIT);
+
+    k_thread_name_set(tid, name);
+
+    *(int32_t *)task_handle = (int32_t)tid;
+    return 1;
 }
 
 static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t stack_depth, void *param, uint32_t prio, void *task_handle)
 {
-    return (uint32_t)xTaskCreate(task_func, name, stack_depth, param, prio, task_handle);
+    return task_create_pinned_to_core_wrapper(task_func, name, stack_depth, param, prio, task_handle, 0);
+}
+
+static void task_delete_wrapper(void *handle)
+{
+    k_tid_t tid = handle ? (k_tid_t)handle : k_current_get();
+    struct wifi_task *t = CONTAINER_OF(tid, struct wifi_task, thread);
+
+    if (tid == k_current_get()) {
+        k_work_init(&t->cleanup_work, wifi_task_cleanup_work);
+        k_work_submit(&t->cleanup_work);
+        k_thread_abort(k_current_get());
+        CODE_UNREACHABLE;
+    }
+
+    k_thread_abort(tid);
+
+    if (tid->custom_data) {
+        esp_wifi_free(tid->custom_data);
+    }
+
+    k_thread_stack_free(t->stack);
+    k_object_release(tid);
+    esp_wifi_free(t);
+}
+
+static void task_delay_wrapper(uint32_t ticks)
+{
+    k_sleep(K_TICKS(ticks));
 }
 
 static int32_t IRAM_ATTR task_ms_to_tick_wrapper(uint32_t ms)
 {
-    return (int32_t)(ms / portTICK_PERIOD_MS);
+    return (int32_t)(k_ms_to_ticks_ceil32(ms));
 }
 
 static int32_t task_get_max_priority_wrapper(void)
 {
-    return (int32_t)(configMAX_PRIORITIES);
+    return (int32_t)(CONFIG_ESP32_WIFI_MAX_THREAD_PRIORITY);
 }
 
 static int32_t esp_event_post_wrapper(const char *event_base, int32_t event_id, void *event_data, size_t event_data_size, uint32_t ticks_to_wait)
 {
-    if (ticks_to_wait == OSI_FUNCS_TIME_BLOCKING) {
-        return (int32_t)esp_event_post(event_base, event_id, event_data, event_data_size, portMAX_DELAY);
-    } else {
-        return (int32_t)esp_event_post(event_base, event_id, event_data, event_data_size, ticks_to_wait);
-    }
+    return esp_event_post(event_base, event_id, event_data, event_data_size, ticks_to_wait);
 }
 
 static void IRAM_ATTR wifi_apb80m_request_wrapper(void)
@@ -397,41 +566,187 @@ static int get_time_wrapper(void *t)
 
 static void *IRAM_ATTR realloc_internal_wrapper(void *ptr, size_t size)
 {
-    return heap_caps_realloc(ptr, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+    return heap_caps_realloc(ptr, size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 }
 
 static void *IRAM_ATTR calloc_internal_wrapper(size_t n, size_t size)
 {
-    return heap_caps_calloc(n, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+    return k_calloc(n, size);
 }
 
 static void *IRAM_ATTR zalloc_internal_wrapper(size_t size)
 {
-    void *ptr = heap_caps_calloc(1, size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
-    return ptr;
+    return k_calloc(1, size);
 }
 
-static esp_err_t nvs_open_wrapper(const char *name, unsigned int open_mode, nvs_handle_t *out_handle)
+void *xEventGroupCreate(void)
 {
-    return nvs_open(name, (nvs_open_mode_t)open_mode, out_handle);
+    struct k_event *ev = wifi_malloc(sizeof(*ev));
+
+    if (ev == NULL) {
+        return NULL;
+    }
+
+    k_event_init(ev);
+    return ev;
 }
 
-static void esp_log_writev_wrapper(unsigned int level, const char *tag, const char *format, va_list args)
+void vEventGroupDelete(void *grp)
 {
-    return esp_log_writev((esp_log_level_t)level, tag, format, args);
+    if (grp != NULL) {
+        esp_wifi_free(grp);
+    }
 }
 
-static void esp_log_write_wrapper(unsigned int level, const char *tag, const char *format, ...)
+uint32_t xEventGroupSetBits(void *ptr, uint32_t data)
 {
+    if (ptr == NULL) {
+        return 0;
+    }
+
+    return k_event_post((struct k_event *)ptr, data);
+}
+
+uint32_t xEventGroupClearBits(void *ptr, uint32_t data)
+{
+    if (ptr == NULL) {
+        return 0;
+    }
+
+    return k_event_clear((struct k_event *)ptr, data);
+}
+
+void *xTaskGetCurrentTaskHandle(void)
+{
+    return (void *)k_current_get();
+}
+
+int32_t nvs_set_i8(uint32_t handle, const char *key, int8_t value)
+{
+    ARG_UNUSED(handle);
+    ARG_UNUSED(key);
+    ARG_UNUSED(value);
+
+    return 0;
+}
+
+int32_t nvs_get_i8(uint32_t handle, const char *key, int8_t *out_value)
+{
+    ARG_UNUSED(handle);
+    ARG_UNUSED(key);
+    ARG_UNUSED(out_value);
+
+    return 0;
+}
+
+int32_t nvs_set_u8(uint32_t handle, const char *key, uint8_t value)
+{
+    ARG_UNUSED(handle);
+    ARG_UNUSED(key);
+    ARG_UNUSED(value);
+
+    return 0;
+}
+
+int32_t nvs_get_u8(uint32_t handle, const char *key, uint8_t *out_value)
+{
+    ARG_UNUSED(handle);
+    ARG_UNUSED(key);
+    ARG_UNUSED(out_value);
+
+    return 0;
+}
+
+int32_t nvs_set_u16(uint32_t handle, const char *key, uint16_t value)
+{
+    ARG_UNUSED(handle);
+    ARG_UNUSED(key);
+    ARG_UNUSED(value);
+
+    return 0;
+}
+
+int32_t nvs_get_u16(uint32_t handle, const char *key, uint16_t *out_value)
+{
+    ARG_UNUSED(handle);
+    ARG_UNUSED(key);
+    ARG_UNUSED(out_value);
+
+    return 0;
+}
+
+int32_t nvs_open_wrapper(const char *name, uint32_t open_mode, uint32_t *out_handle)
+{
+    ARG_UNUSED(name);
+    ARG_UNUSED(open_mode);
+    ARG_UNUSED(out_handle);
+
+    return 0;
+}
+
+void nvs_close(uint32_t handle)
+{
+    ARG_UNUSED(handle);
+}
+
+int32_t nvs_commit(uint32_t handle)
+{
+    ARG_UNUSED(handle);
+
+    return 0;
+}
+
+int32_t nvs_set_blob(uint32_t handle, const char *key, const void *value, size_t length)
+{
+    ARG_UNUSED(handle);
+    ARG_UNUSED(key);
+    ARG_UNUSED(value);
+    ARG_UNUSED(length);
+
+    return 0;
+}
+
+int32_t nvs_get_blob(uint32_t handle, const char *key, void *out_value, size_t *length)
+{
+    /*
+     * No NVS backing store: report the key as absent so the caller (the mesh
+     * stack reads its saved layer/assoc state through here) starts from a
+     * clean state. Returning ESP_OK would make it treat the uninitialised
+     * output as valid saved state. 0x1102 is ESP_ERR_NVS_NOT_FOUND.
+     */
+    return 0x1102;
+}
+
+int32_t nvs_erase_key(uint32_t handle, const char *key)
+{
+    ARG_UNUSED(handle);
+    ARG_UNUSED(key);
+
+    return 0;
+}
+
+static void esp_log_writev_wrapper(uint32_t level, const char *tag, const char *format, va_list args)
+{
+#if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
+    esp_log_writev((esp_log_level_t)level, tag, format, args);
+#endif
+}
+
+static void esp_log_write_wrapper(uint32_t level, const char *tag, const char *format, ...)
+{
+#if CONFIG_WIFI_LOG_LEVEL >= LOG_LEVEL_DBG
     va_list list;
     va_start(list, format);
     esp_log_writev((esp_log_level_t)level, tag, format, list);
     va_end(list);
+#endif
 }
 
-static esp_err_t esp_read_mac_wrapper(uint8_t *mac, unsigned int type)
+uint32_t esp_get_free_heap_size(void)
 {
-    return esp_read_mac(mac, (esp_mac_type_t)type);
+    /* FIXME: API to get free heap size is not available in Zephyr. */
+    /* It is only used by ESP-MESH feature (not supported yet) */
+    return 10000;
 }
 
 static int coex_init_wrapper(void)
@@ -473,6 +788,13 @@ static IRAM_ATTR uint32_t coex_status_get_wrapper(void)
 #else
     return 0;
 #endif
+}
+
+static void coex_condition_set_wrapper(uint32_t type, bool dissatisfy)
+{
+    /* Not implemented - coex_condition_set not available in coex libs */
+    (void)type;
+    (void)dissatisfy;
 }
 
 static int coex_wifi_request_wrapper(uint32_t event, uint32_t latency, uint32_t duration)
@@ -570,7 +892,7 @@ static void *coex_schm_curr_phase_get_wrapper(void)
 #endif
 }
 
-static int coex_register_start_cb_wrapper(int (* cb)(void))
+static int coex_register_start_cb_wrapper(int (*cb)(void))
 {
 #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
     return coex_register_start_cb(cb);
@@ -588,7 +910,7 @@ static int coex_schm_process_restart_wrapper(void)
 #endif
 }
 
-static int coex_schm_register_cb_wrapper(int type, int(*cb)(int))
+static int coex_schm_register_cb_wrapper(int type, int (*cb)(int))
 {
 #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
     return coex_schm_register_callback(type, cb);
@@ -615,7 +937,7 @@ static uint8_t coex_schm_flexible_period_get_wrapper(void)
 #endif
 }
 
-static void * coex_schm_get_phase_by_idx_wrapper(int phase_idx)
+static void *coex_schm_get_phase_by_idx_wrapper(int phase_idx)
 {
 #if CONFIG_SW_COEXIST_ENABLE || CONFIG_EXTERNAL_COEX_ENABLE
     return coex_schm_get_phase_by_idx(phase_idx);
@@ -626,17 +948,16 @@ static void * coex_schm_get_phase_by_idx_wrapper(int phase_idx)
 
 static void IRAM_ATTR esp_empty_wrapper(void)
 {
-
 }
 
-extern void set_bb_wdg(bool busy_chk, bool srch_chk, uint16_t max_busy, uint16_t max_srch, bool rst_en, bool int_en, bool clr);
+extern void set_bb_wdg(bool busy_chk, bool srch_chk, uint16_t max_busy, uint16_t max_srch,
+		       bool rst_en, bool int_en, bool clr);
 
 static void esp_phy_enable_wrapper(void)
 {
     esp_phy_enable(PHY_MODEM_WIFI);
     phy_wifi_enable_set(1);
-    //disable bb idle check(max: 139ms) for temporary to avoid unexpected RXTXPANIC
-    //TODO
+    /* Disable bb idle check (max 139ms) to avoid unexpected RXTXPANIC */
     set_bb_wdg(true, false, 0x18, 0xaa, false, false, false);
 }
 
@@ -645,6 +966,18 @@ static void esp_phy_disable_wrapper(void)
     phy_wifi_enable_set(0);
     esp_phy_disable(PHY_MODEM_WIFI);
 }
+
+#if SOC_PM_MODEM_RETENTION_BY_REGDMA
+static void IRAM_ATTR regdma_link_set_write_wait_content_wrapper(void *addr, uint32_t value, uint32_t mask)
+{
+    regdma_link_set_write_wait_content(addr, value, mask);
+}
+
+static void *IRAM_ATTR sleep_retention_find_link_by_id_wrapper(int id)
+{
+    return sleep_retention_find_link_by_id(id);
+}
+#endif
 
 static bool esp_wifi_disable_ac_ax_wrapper(void)
 {
@@ -699,7 +1032,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._ints_off = disable_intr_wrapper,
     ._is_from_isr = is_from_isr_wrapper,
     ._spin_lock_create = esp_coex_common_spin_lock_create_wrapper,
-    ._spin_lock_delete = free,
+    ._spin_lock_delete = esp_wifi_free,
     ._wifi_int_disable = esp_coex_common_int_disable_wrapper,
     ._wifi_int_restore = esp_coex_common_int_restore_wrapper,
     ._task_yield_from_isr = esp_coex_common_task_yield_from_isr_wrapper,
@@ -720,24 +1053,24 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._queue_send_to_back = queue_send_to_back_wrapper,
     ._queue_send_to_front = queue_send_to_front_wrapper,
     ._queue_recv = queue_recv_wrapper,
-    ._queue_msg_waiting = (uint32_t(*)(void *))uxQueueMessagesWaiting,
+    ._queue_msg_waiting = queue_msg_waiting_wrapper,
     ._event_group_create = (void *(*)(void))xEventGroupCreate,
-    ._event_group_delete = (void(*)(void *))vEventGroupDelete,
-    ._event_group_set_bits = (uint32_t(*)(void *, uint32_t))xEventGroupSetBits,
-    ._event_group_clear_bits = (uint32_t(*)(void *, uint32_t))xEventGroupClearBits,
+    ._event_group_delete = (void (*)(void *))vEventGroupDelete,
+    ._event_group_set_bits = (uint32_t (*)(void *, uint32_t))xEventGroupSetBits,
+    ._event_group_clear_bits = (uint32_t (*)(void *, uint32_t))xEventGroupClearBits,
     ._event_group_wait_bits = event_group_wait_bits_wrapper,
     ._task_create_pinned_to_core = task_create_pinned_to_core_wrapper,
     ._task_create = task_create_wrapper,
-    ._task_delete = (void(*)(void *))vTaskDelete,
-    ._task_delay = vTaskDelay,
+    ._task_delete = task_delete_wrapper,
+    ._task_delay = task_delay_wrapper,
     ._task_ms_to_tick = task_ms_to_tick_wrapper,
-    ._task_get_current_task = (void *(*)(void))xTaskGetCurrentTaskHandle,
+    ._task_get_current_task = (void *(*)(void))k_current_get,
     ._task_get_max_priority = task_get_max_priority_wrapper,
-    ._malloc = malloc,
-    ._free = free,
+    ._malloc = wifi_malloc,
+    ._free = esp_wifi_free,
     ._event_post = esp_event_post_wrapper,
-    ._get_free_heap_size = esp_get_free_internal_heap_size,
-    ._rand = esp_random,
+    ._get_free_heap_size = esp_get_free_heap_size,
+    ._rand = sys_rand32_get,
     ._dport_access_stall_other_cpu_start_wrap = esp_empty_wrapper,
     ._dport_access_stall_other_cpu_end_wrap = esp_empty_wrapper,
     ._wifi_apb80m_request = wifi_apb80m_request_wrapper,
@@ -745,7 +1078,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._phy_disable = esp_phy_disable_wrapper,
     ._phy_enable = esp_phy_enable_wrapper,
     ._phy_update_country_info = esp_phy_update_country_info,
-    ._read_mac = esp_read_mac_wrapper,
+    ._read_mac = esp_read_mac,
     ._timer_arm = timer_arm_wrapper,
     ._timer_disarm = esp_coex_common_timer_disarm_wrapper,
     ._timer_done = esp_coex_common_timer_done_wrapper,
@@ -775,8 +1108,8 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
     ._log_write = esp_log_write_wrapper,
     ._log_writev = esp_log_writev_wrapper,
-    ._log_timestamp = esp_log_timestamp,
-    ._malloc_internal =  esp_coex_common_malloc_internal_wrapper,
+    ._log_timestamp = k_uptime_get_32,
+    ._malloc_internal = esp_coex_common_malloc_internal_wrapper,
     ._realloc_internal = realloc_internal_wrapper,
     ._calloc_internal = calloc_internal_wrapper,
     ._zalloc_internal = zalloc_internal_wrapper,
@@ -791,6 +1124,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._coex_enable = coex_enable_wrapper,
     ._coex_disable = coex_disable_wrapper,
     ._coex_status_get = coex_status_get_wrapper,
+    ._coex_condition_set = coex_condition_set_wrapper,
     ._coex_wifi_request = coex_wifi_request_wrapper,
     ._coex_wifi_release = coex_wifi_release_wrapper,
     ._coex_wifi_channel_set = coex_wifi_channel_set_wrapper,
@@ -804,8 +1138,8 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._coex_schm_curr_phase_get = coex_schm_curr_phase_get_wrapper,
     ._coex_register_start_cb = coex_register_start_cb_wrapper,
 #if SOC_PM_MODEM_RETENTION_BY_REGDMA
-    ._regdma_link_set_write_wait_content = regdma_link_set_write_wait_content,
-    ._sleep_retention_find_link_by_id = sleep_retention_find_link_by_id,
+    ._regdma_link_set_write_wait_content = regdma_link_set_write_wait_content_wrapper,
+    ._sleep_retention_find_link_by_id = sleep_retention_find_link_by_id_wrapper,
 #endif
     ._coex_schm_process_restart = coex_schm_process_restart_wrapper,
     ._coex_schm_register_cb = coex_schm_register_cb_wrapper,

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -51,7 +51,7 @@ zephyr_sources_ifdef(
   ../components/soc/dport_access_common.c
   )
 
-if(CONFIG_SOC_SERIES_ESP32C5 OR CONFIG_SOC_SERIES_ESP32C6 OR CONFIG_SOC_SERIES_ESP32H2 OR CONFIG_SOC_SERIES_ESP32P4)
+if(CONFIG_SOC_SERIES_ESP32C5 OR CONFIG_SOC_SERIES_ESP32C6 OR CONFIG_SOC_SERIES_ESP32C61 OR CONFIG_SOC_SERIES_ESP32H2 OR CONFIG_SOC_SERIES_ESP32P4)
   zephyr_sources(../components/esp_hal_security/apm_hal.c)
 endif()
 
@@ -59,6 +59,7 @@ add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32 esp32)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32C2 esp32c2)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32C3 esp32c3)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32C5 esp32c5)
+add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32C61 esp32c61)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32C6 esp32c6)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32H2 esp32h2)
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_ESP32P4 esp32p4)

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -38,6 +38,10 @@ if SOC_SERIES_ESP32C6
 rsource "../components/soc/esp32c6/include/soc/Kconfig.soc_caps.in"
 endif
 
+if SOC_SERIES_ESP32C61
+rsource "../components/soc/esp32c61/include/soc/Kconfig.soc_caps.in"
+endif
+
 if SOC_SERIES_ESP32H2
 rsource "../components/soc/esp32h2/include/soc/Kconfig.soc_caps.in"
 endif
@@ -171,6 +175,7 @@ config IDF_FIRMWARE_CHIP_ID
 	default 0x0005 if SOC_SERIES_ESP32C3
 	default 0x0017 if SOC_SERIES_ESP32C5
 	default 0x000D if SOC_SERIES_ESP32C6
+	default 0x0014 if SOC_SERIES_ESP32C61
 	default 0x0010 if SOC_SERIES_ESP32H2
 	default 0x0012 if SOC_SERIES_ESP32P4
 
@@ -226,6 +231,10 @@ config IDF_TARGET_ESP32C5
 config IDF_TARGET_ESP32C6
 	bool
 	default y if SOC_SERIES_ESP32C6
+
+config IDF_TARGET_ESP32C61
+	bool
+	default y if SOC_SERIES_ESP32C61
 
 config IDF_TARGET_ESP32H2
 	bool

--- a/zephyr/common/console_init.c
+++ b/zephyr/common/console_init.c
@@ -10,7 +10,6 @@
 #include "soc/io_mux_reg.h"
 #include "soc/gpio_periph.h"
 #include "soc/gpio_sig_map.h"
-#include "hal/clk_gate_ll.h"
 #include "hal/gpio_hal.h"
 #include "soc/rtc.h"
 #if CONFIG_SOC_SERIES_ESP32S2

--- a/zephyr/common/flash_init.c
+++ b/zephyr/common/flash_init.c
@@ -16,6 +16,7 @@
 #include <hal/efuse_hal.h>
 #include "esp_private/spi_flash_os.h"
 #include "esp_log.h"
+#include "esp_rom_sys.h"
 #if CONFIG_SOC_SERIES_ESP32S3
 #include <esp32s3/opi_flash_private.h>
 #endif

--- a/zephyr/esp32c61/CMakeLists.txt
+++ b/zephyr/esp32c61/CMakeLists.txt
@@ -1,0 +1,811 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_SOC_SERIES_ESP32C61)
+
+  zephyr_compile_options(-fstrict-volatile-bitfields)
+  zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
+  zephyr_compile_definitions_ifndef(asm asm=__asm__)
+  zephyr_compile_definitions_ifndef(typeof typeof=__typeof__)
+
+  # Derive the hal revision macros from CONFIG_SOC_ESP32C61_REV_MIN_FULL, the
+  # minimum supported chip revision in major * 100 + minor format. That symbol
+  # is defined in the soc Kconfig from the board-selected SOC_ESP32C61_REV_*
+  # symbols, with an unconditional default, so it is always set for an
+  # ESP32-C61 build.
+  set(esp32c61_rev_min_full ${CONFIG_SOC_ESP32C61_REV_MIN_FULL})
+
+  zephyr_compile_definitions(CONFIG_ESP_REV_MIN_FULL=${esp32c61_rev_min_full})
+  zephyr_compile_definitions(CONFIG_ESP32C61_REV_MIN_FULL=${esp32c61_rev_min_full})
+
+  if(CONFIG_MCUBOOT)
+    zephyr_compile_options(-fdump-rtl-expand)
+  endif()
+
+  zephyr_include_directories(
+    include
+    ../common/include
+    ../port/include
+    ../port/include/boot
+    ../../components/bootloader_support/bootloader_flash/include
+    ../../components/bootloader_support/include
+    ../../components/bootloader_support/private_include
+    # esp32c61 reuses the esp32c6 ble controller sources and headers
+    ../../components/bt/controller/esp32c6
+    ../../components/bt/include/esp32c6/include
+    ../../components/bt/porting/include
+    ../../components/bt/porting/npl/zephyr/include
+    ../../components/bt/porting/npl/zephyr/include/nimble
+    ../../components/bt/porting/transport/include
+    ../../components/efuse/include
+    ../../components/efuse/private_include
+    ../../components/efuse/${CONFIG_SOC_SERIES}/include
+    ../../components/efuse/${CONFIG_SOC_SERIES}/private_include
+    ../../components/esp_coex/include
+    ../../components/esp_common/include
+    ../../components/esp_driver_gpio/include
+    ../../components/esp_event/include
+    ../../components/esp_hal_ana_conv/include
+    ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_clock/include
+    ../../components/esp_hal_clock/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_dma/include
+    ../../components/esp_hal_dma/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_gpio/include
+    ../../components/esp_hal_gpio/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_gpspi/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_gpspi/include
+    ../../components/esp_hal_i2c/include
+    ../../components/esp_hal_i2c/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_i2s/include
+    ../../components/esp_hal_i2s/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_ledc/include
+    ../../components/esp_hal_ledc/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_mspi/include
+    ../../components/esp_hal_mspi/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_pmu/include
+    ../../components/esp_hal_pmu/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_regi2c/include
+    ../../components/esp_hal_regi2c/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_rtc_timer/include
+    ../../components/esp_hal_rtc_timer/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_sd/include
+    ../../components/esp_hal_sd/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_security/include
+    ../../components/esp_hal_security/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_systimer/include
+    ../../components/esp_hal_systimer/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_timg/include
+    ../../components/esp_hal_timg/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_uart/include
+    ../../components/esp_hal_uart/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_usb/include
+    ../../components/esp_hal_usb/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_wdt/include
+    ../../components/esp_hal_wdt/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hw_support/etm/include
+    ../../components/esp_hw_support/include
+    ../../components/esp_hw_support/include/esp_private
+    ../../components/esp_hw_support/include/hal
+    ../../components/esp_hw_support/include/soc
+    ../../components/esp_hw_support/ldo/include
+    ../../components/esp_hw_support/modem/include
+    ../../components/esp_hw_support/mspi/mspi_intr/include
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/include
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/port/${CONFIG_SOC_SERIES}
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/tuning_scheme_impl/include
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/private_include
+    ../../components/esp_hw_support/port/include
+    ../../components/esp_hw_support/power_supply/include
+    ../../components/esp_mm/include
+    ../../components/esp_phy/include
+    ../../components/esp_phy/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_phy/include/esp_private
+    ../../components/esp_pm/include
+    ../../components/esp_psram/device/include
+    ../../components/esp_psram/include
+    ../../components/esp_psram/xip_impl/include
+    ../../components/esp_rom/${CONFIG_SOC_SERIES}
+    ../../components/esp_rom/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_rom/include
+    ../../components/esp_rom/${CONFIG_SOC_SERIES}/include/${CONFIG_SOC_SERIES}
+    ../../components/esp_rom/${CONFIG_SOC_SERIES}/ld
+    ../../components/esp_system/include
+    ../../components/esp_system/include/esp_private
+    ../../components/esp_system/port/include
+    ../../components/esp_system/port/include/private
+    ../../components/esp_system/port/include/private/esp_private
+    ../../components/esp_timer/include
+    ../../components/esp_timer/private_include
+    ../../components/esp_wifi/include
+    ../../components/esp_wifi/include/local
+    ../../components/hal/${CONFIG_SOC_SERIES}/include
+    ../../components/hal/include
+    ../../components/hal/platform_port/include
+    ../../components/heap/include
+    ../../components/ieee802154/include
+    ../../components/ieee802154/private_include
+    ../../components/riscv/include
+    ../../components/riscv/include/esp_private
+    ../../components/soc/${CONFIG_SOC_SERIES}/include
+    ../../components/soc/include
+    ../../components/soc/${CONFIG_SOC_SERIES}/ld
+    ../../components/soc/${CONFIG_SOC_SERIES}/register
+    ../../components/spi_flash/include
+    ../../components/spi_flash/include/esp_private
+  )
+
+  if(CONFIG_WIFI_ESP32)
+    zephyr_include_directories(
+      ../../components/mbedtls/port/include
+      ../../components/mbedtls/port/psa_driver/include
+      ../../components/wpa_supplicant/esp_supplicant/include
+      ../../components/wpa_supplicant/esp_supplicant/src
+      ../../components/wpa_supplicant/include
+      ../../components/wpa_supplicant/port/include
+      ../../components/wpa_supplicant/src
+      ../../components/wpa_supplicant/src/crypto
+      ../../components/wpa_supplicant/src/eap_peer
+      ../../components/wpa_supplicant/src/utils
+    )
+    zephyr_include_directories_ifdef(
+      CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT
+      ${ZEPHYR_MBEDTLS_MODULE_DIR}/library
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/core
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/src
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/extras
+    )
+  endif()
+
+  zephyr_link_libraries(
+    gcc
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/soc/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.peripherals.ld
+  )
+
+  zephyr_link_libraries(
+    -T${CMAKE_CURRENT_SOURCE_DIR}/src/linker/${CONFIG_SOC_SERIES}.rom.alias.ld
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.ld
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.api.ld
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.rvfp.ld
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.newlib.ld
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.version.ld
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.libc.ld
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.libc-suboptimal_for_misaligned_mem.ld
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.libgcc.ld
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_hal_wdt/${CONFIG_SOC_SERIES}/rom.wdt.ld
+    -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/riscv/ld/rom.api.ld
+  )
+
+  # Revisions from v1.1 add a set of rom routines, mostly wi-fi and coex,
+  # that earlier silicon does not provide. The eco4 script maps them, so
+  # link it only when the build targets those revisions.
+  if(esp32c61_rev_min_full GREATER_EQUAL 101)
+    zephyr_link_libraries(
+      -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.eco4.ld
+    )
+  endif()
+
+  zephyr_compile_definitions(ESP_PLATFORM)
+
+  zephyr_sources(
+    ../../components/efuse/src/esp_efuse_api.c
+    ../../components/efuse/src/esp_efuse_fields.c
+    ../../components/efuse/src/esp_efuse_utility.c
+    ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_table.c
+    ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_fields.c
+    ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_utility.c
+    ../../components/efuse/src/efuse_controller/keys/with_key_purposes/esp_efuse_api_key.c
+  )
+
+  if(CONFIG_ESP32_SPIM)
+    zephyr_sources(
+      ../../components/esp_hal_gpspi/spi_hal.c
+      ../../components/esp_hal_gpspi/spi_hal_iram.c
+      ../../components/esp_hal_gpspi/${CONFIG_SOC_SERIES}/spi_periph.c
+      ../../components/esp_hal_dma/gdma_hal_top.c
+      )
+  endif()
+
+  if(CONFIG_SOC_FLASH_ESP32 OR NOT CONFIG_BOOTLOADER_MCUBOOT)
+    zephyr_sources(
+    ../../components/esp_mm/esp_mmu_map.c
+    ../../components/esp_mm/esp_cache_utils.c
+    ../../components/esp_mm/port/${CONFIG_SOC_SERIES}/ext_mem_layout.c
+    ../../components/bootloader_support/src/flash_encrypt.c
+    ../../components/esp_hw_support/esp_gpio_reserve.c
+    ../../components/hal/cache_hal.c
+    ../../components/hal/mmu_hal.c
+    ../../components/esp_hal_mspi/spi_flash_encrypt_hal_iram.c
+    ../../components/esp_hal_mspi/spi_flash_hal.c
+    ../../components/esp_hal_mspi/spi_flash_hal_iram.c
+    ../../components/esp_hal_mspi/spi_flash_hal_gpspi.c
+    ../../components/esp_hal_mspi/${CONFIG_SOC_SERIES}/mspi_periph.c
+    ../../components/spi_flash/esp_flash_api.c
+    ../../components/spi_flash/esp_flash_spi_init.c
+    ../../components/spi_flash/flash_mmap.c
+    ../../components/spi_flash/flash_ops.c
+    ../../components/spi_flash/memspi_host_driver.c
+    ../../components/spi_flash/spi_flash_chip_boya.c
+    ../../components/spi_flash/spi_flash_chip_drivers.c
+    ../../components/spi_flash/spi_flash_chip_gd.c
+    ../../components/spi_flash/spi_flash_chip_generic.c
+    ../../components/spi_flash/spi_flash_chip_issi.c
+    ../../components/spi_flash/spi_flash_chip_mxic.c
+    ../../components/spi_flash/spi_flash_chip_mxic_opi.c
+    ../../components/spi_flash/spi_flash_chip_th.c
+    ../../components/spi_flash/spi_flash_chip_winbond.c
+    ../../components/spi_flash/spi_flash_os_func_noos.c
+    ../../components/spi_flash/spi_flash_os_func_app.c
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/mspi_timing_tuning.c
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/port/${CONFIG_SOC_SERIES}/mspi_timing_config.c
+    ../../components/esp_hw_support/mspi/mspi_timing_tuning/tuning_scheme_impl/mspi_timing_by_mspi_delay.c
+    ../../components/esp_hw_support/mspi/mspi_intr/mspi_intr.c
+    )
+  endif()
+
+  if(CONFIG_PM OR CONFIG_POWEROFF)
+  zephyr_sources(
+    ../common/pm_impl_zephyr.c
+    ../common/pm_locks_zephyr.c
+    ../../components/esp_driver_gpio/src/gpio.c
+    ../../components/esp_driver_gpio/src/rtc_io.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_sleep.c
+    ../../components/esp_hw_support/pmu_share_hw.c
+    ../../components/esp_hw_support/port/pau_regdma.c
+    ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_clock.c
+    ../../components/esp_hw_support/sleep_gpio.c
+    ../../components/esp_hw_support/sleep_event.c
+    ../../components/esp_hw_support/sleep_console.c
+    ../../components/esp_hw_support/sleep_modem.c
+    ../../components/esp_hw_support/sleep_modes.c
+    ../../components/esp_hw_support/sleep_cache.c
+    ../../components/esp_hw_support/sleep_retention.c
+    ../../components/esp_hw_support/sleep_system_peripheral.c
+    ../../components/soc/${CONFIG_SOC_SERIES}/system_retention_periph.c
+    ../../components/esp_hal_pmu/${CONFIG_SOC_SERIES}/pau_hal.c
+    ../../components/esp_hal_pmu/${CONFIG_SOC_SERIES}/pmu_hal.c
+    ../../components/esp_hal_gpio/rtc_io_hal.c
+    ../../components/esp_hw_support/sleep_uart.c
+    ../../components/esp_hw_support/clk_utils.c
+    ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_modem_state.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/peripheral_domain_pd.c
+    )
+
+    if(CONFIG_ESP32_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP)
+      zephyr_sources(
+        ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_cpu.c
+        ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_cpu_asm.S
+        )
+      zephyr_sources_ifdef(CONFIG_ESP32_PM_CPU_RETENTION_DYNAMIC
+        ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_cpu_dynamic.c
+        )
+      zephyr_sources_ifdef(CONFIG_ESP32_PM_CPU_RETENTION_STATIC
+        ../../components/esp_hw_support/lowpower/port/${CONFIG_SOC_SERIES}/sleep_cpu_static.c
+        )
+    endif()
+
+    zephyr_sources_ifdef(CONFIG_ESP32_SLEEP_SET_FLASH_DPD
+      ../../components/spi_flash/spi_flash_dpd_enable.c
+    )
+  endif()
+
+  if(CONFIG_DMA_ESP32)
+    zephyr_sources(
+      ../../components/soc/lldesc.c
+      ../../components/esp_hal_dma/gdma_hal_top.c
+      ../../components/esp_hal_dma/gdma_hal_ahb_v2.c
+      )
+
+    if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_sources(
+        ../../components/esp_hal_dma/${CONFIG_SOC_SERIES}/gdma_periph.c
+        )
+    endif()
+  endif()
+
+  if(CONFIG_WDT_ESP32 AND CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+    zephyr_sources(
+      ../../components/esp_hal_wdt/${CONFIG_SOC_SERIES}/mwdt_periph.c
+      )
+  endif()
+
+  if (CONFIG_ESP_SPIRAM)
+    zephyr_compile_definitions(CONFIG_SPIRAM)
+    zephyr_sources(
+      ../../components/esp_psram/system_layer/esp_psram.c
+      ../../components/esp_psram/system_layer/esp_psram_mspi.c
+      ../../components/esp_hw_support/esp_memory_utils.c
+      ../../components/esp_hw_support/esp_gpio_reserve.c
+      )
+
+    zephyr_sources_ifdef(CONFIG_SPIRAM_MODE_QUAD
+      ../../components/esp_psram/device/esp_psram_impl_ap_quad.c
+      )
+  endif()
+
+  if (CONFIG_MCUBOOT)
+    zephyr_sources(
+        ../port/boot/esp_image_loader.c
+        )
+  endif()
+
+  if (CONFIG_MCUBOOT OR NOT CONFIG_BOOTLOADER_MCUBOOT)
+    zephyr_include_directories(
+      ../../components/esp_rom/${CONFIG_SOC_SERIES}
+      )
+
+    zephyr_sources(
+      ../../components/bootloader_support/src/bootloader_clock_init.c
+      ../../components/bootloader_support/bootloader_flash/src/flash_qio_mode.c
+      ../common/console_init.c
+      ../common/soc_init.c
+      )
+  endif()
+
+  zephyr_sources(
+    ../../components/bootloader_support/bootloader_flash/src/bootloader_flash_config_${CONFIG_SOC_SERIES}.c
+    ../../components/esp_driver_gpio/src/rtc_io.c
+    ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/temperature_sensor_periph.c
+    ../../components/esp_hal_ana_conv/adc_hal_common.c
+    ../../components/esp_hal_ana_conv/temperature_sensor_hal.c
+    ../../components/esp_hal_clock/${CONFIG_SOC_SERIES}/clk_tree_hal.c
+    ../../components/esp_hal_gpio/${CONFIG_SOC_SERIES}/rtc_io_periph.c
+    ../../components/esp_hal_gpio/rtc_io_hal.c
+    ../../components/esp_hal_regi2c/${CONFIG_SOC_SERIES}/regi2c_impl.c
+    ../../components/esp_hal_systimer/systimer_hal.c
+    ../../components/esp_hal_wdt/wdt_hal_iram.c
+    ../../components/esp_hw_support/adc_share_hw_ctrl.c
+    ../../components/esp_hw_support/clk_ctrl_os.c
+    ../../components/esp_hw_support/cpu.c
+    ../../components/esp_hw_support/esp_clk.c
+    ../../components/esp_hw_support/esp_memory_utils.c
+    ../../components/esp_hw_support/hw_random.c
+    ../../components/esp_hw_support/mac_addr.c
+    ../../components/esp_hw_support/modem/modem_clock.c
+    ../../components/esp_hw_support/modem/port/${CONFIG_SOC_SERIES}/modem_clock_impl.c
+    ../../components/esp_hw_support/periph_ctrl.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/cpu_region_protect.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/esp_clk_tree.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/esp_cpu_intr.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/io_mux.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/ocode_init.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_init.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_param.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_sleep.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/rtc_clk.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/rtc_clk_init.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/rtc_time.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/sar_periph_ctrl.c
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/systimer.c
+    ../../components/esp_hw_support/port/esp_clk_tree_common.c
+    ../../components/esp_hw_support/port/regdma_link.c
+    ../../components/esp_hw_support/regi2c_ctrl.c
+    ../../components/esp_hw_support/rtc_module.c
+    ../../components/esp_hw_support/sar_periph_ctrl_common.c
+    ../../components/esp_hw_support/sar_tsens_ctrl.c
+    ../../components/esp_hw_support/sleep_cache.c
+    ../../components/esp_hw_support/sleep_modes.c
+    ../../components/esp_hw_support/sleep_retention.c
+    ../../components/esp_mm/esp_cache_msync.c
+    ../../components/esp_rom/patches/esp_rom_crc.c
+    ../../components/esp_rom/patches/esp_rom_efuse.c
+    ../../components/esp_rom/patches/esp_rom_gpio.c
+    ../../components/esp_rom/patches/esp_rom_print.c
+    ../../components/esp_rom/patches/esp_rom_serial_output.c
+    ../../components/esp_rom/patches/esp_rom_spiflash.c
+    ../../components/esp_rom/patches/esp_rom_sys.c
+    ../../components/esp_system/esp_err.c
+    ../../components/esp_system/port/soc/${CONFIG_SOC_SERIES}/clk.c
+    ../../components/esp_system/port/soc/${CONFIG_SOC_SERIES}/reset_reason.c
+    ../../components/esp_system/port/soc/${CONFIG_SOC_SERIES}/system_internal.c
+    ../../components/esp_timer/src/esp_timer.c
+    ../../components/esp_timer/src/esp_timer_etm.c
+    ../../components/esp_timer/src/esp_timer_impl_common.c
+    ../../components/esp_timer/src/esp_timer_impl_systimer.c
+    ../../components/esp_timer/src/esp_timer_init.c
+    ../../components/esp_timer/src/ets_timer_legacy.c
+    ../../components/esp_timer/src/system_time.c
+    ../../components/hal/${CONFIG_SOC_SERIES}/efuse_hal.c
+    ../../components/hal/${CONFIG_SOC_SERIES}/modem_clock_hal.c
+    ../../components/hal/efuse_hal.c
+    ../../components/riscv/instruction_decode.c
+    ../../components/riscv/interrupt.c
+    ../../components/riscv/interrupt_clic.c
+    ../../components/riscv/rv_utils.c
+    ../../components/soc/${CONFIG_SOC_SERIES}/gpio_periph.c
+    ../../components/spi_flash/cache_utils.c
+    ../common/esp_restart.c
+    ../common/flash_init.c
+    ../port/bootloader/bootloader_flash.c
+    ../port/heap/heap_caps_zephyr.c
+    src/soc_flash_init.c
+    src/soc_init.c
+    src/soc_random.c
+  )
+
+  zephyr_sources_ifdef(CONFIG_SOC_ESP32_ENABLE_PVT
+    ../../components/esp_hw_support/port/${CONFIG_SOC_SERIES}/pmu_pvt.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_I2C_ESP32
+    ../../components/esp_hal_i2c/i2c_hal_iram.c
+    ../../components/esp_hal_i2c/i2c_hal.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_I2S_ESP32
+    ../../components/esp_hal_i2s/i2s_hal.c
+    ../../components/hal/hal_utils.c
+    )
+
+  if(CONFIG_COUNTER_TMR_ESP32)
+    zephyr_sources(
+      ../../components/esp_hal_timg/timer_hal.c
+      )
+    if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_sources(
+        ../../components/esp_hal_timg/${CONFIG_SOC_SERIES}/timer_periph.c
+        )
+    endif()
+  endif()
+
+  zephyr_sources_ifdef(CONFIG_UART_ESP32
+    ../../components/esp_hal_uart/uart_hal.c
+    ../../components/esp_hal_uart/uart_hal_iram.c
+    ../../components/esp_hal_uart/${CONFIG_SOC_SERIES}/uart_periph.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_PWM_LED_ESP32
+    ../../components/esp_hal_ledc/${CONFIG_SOC_SERIES}/ledc_periph.c
+    ../../components/esp_hal_ledc/ledc_hal_iram.c
+    ../../components/esp_hal_ledc/ledc_hal.c
+    )
+
+  if (CONFIG_ESP32_TEMP)
+    zephyr_include_directories(
+    ../../components/esp_driver_tsens/include
+    ../../components/esp_driver_tsens/src
+    )
+
+    zephyr_sources(
+    ../../components/esp_driver_tsens/src/temperature_sensor.c
+    ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_rtc_calib.c
+    )
+
+    if(CONFIG_ESP32_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP)
+      zephyr_sources(
+        ../../components/esp_driver_tsens/${CONFIG_SOC_SERIES}/temperature_sensor_retention.c
+        )
+    endif()
+  endif()
+
+  if (CONFIG_ADC_ESP32)
+    zephyr_include_directories(
+    ../../components/esp_adc/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_adc/include
+    ../../components/esp_adc/interface
+    )
+
+    zephyr_sources(
+    ../../components/esp_hal_ana_conv/adc_hal.c
+    ../../components/esp_hal_ana_conv/adc_oneshot_hal.c
+    ../../components/esp_adc/adc_cali.c
+    ../../components/esp_adc/adc_cali_curve_fitting.c
+    ../../components/esp_adc/${CONFIG_SOC_SERIES}/curve_fitting_coefficients.c
+    ../../components/esp_hal_ana_conv/${CONFIG_SOC_SERIES}/adc_periph.c
+    ../../components/efuse/${CONFIG_SOC_SERIES}/esp_efuse_rtc_calib.c
+    )
+  endif()
+
+  # shared WIFI/BT resources
+  if (CONFIG_BT OR CONFIG_WIFI_ESP32)
+    zephyr_compile_definitions(CONFIG_ESP_COEX_ENABLED)
+
+    zephyr_sources(
+      ../../components/esp_phy/src/phy_init.c
+      ../../components/esp_phy/src/lib_printf.c
+      ../../components/esp_phy/src/phy_common.c
+      ../../components/esp_phy/src/phy_override.c
+      ../../components/esp_phy/${CONFIG_SOC_SERIES}/phy_init_data.c
+      ../../components/esp_coex/${CONFIG_SOC_SERIES}/esp_coex_adapter.c
+      )
+
+    if(CONFIG_ESP32_SW_COEXIST_ENABLE)
+      zephyr_sources(../../components/esp_coex/src/lib_printf.c)
+      zephyr_sources_ifdef(CONFIG_BUILD_ONLY_NO_BLOBS ../port/stubs/coex_stubs.c)
+
+      zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
+        coexist
+          -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
+          -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.coexist.ld
+        )
+    endif()
+
+    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
+      net80211
+      espnow
+      core
+      pp
+      phy
+      mesh
+      # wifi libs refer gcc libs symbols, so linked in libgcc
+      gcc
+        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.pp.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.phy.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.net80211.ld
+      )
+  endif()
+
+  # BT definitions
+  if (CONFIG_BT)
+
+    # esp32c61 reuses the esp32c6 ble controller sources, matching
+    # the vendor build which compiles the esp32c6 controller for it
+    zephyr_sources(
+      ../../components/esp_phy/src/btbb_init.c
+      ../../components/bt/porting/mem/bt_osi_mem.c
+      ../../components/bt/porting/mem/os_mempool.c
+      ../../components/bt/porting/mem/os_msys_init.c
+      ../../components/bt/porting/npl/zephyr/src/npl_os_zephyr.c
+      ../../components/bt/porting/transport/driver/vhci/hci_driver_standard.c
+      ../../components/bt/porting/transport/src/hci_transport.c
+      ../../components/bt/controller/esp32c6/ble.c
+      ../../components/bt/controller/esp32c6/bt.c
+      )
+
+    zephyr_compile_definitions(CONFIG_BT_ENABLED=1)
+    zephyr_compile_definitions(CONFIG_BT_CONTROLLER_ENABLED=1)
+
+    zephyr_sources_ifdef(CONFIG_BUILD_ONLY_NO_BLOBS
+      ../port/stubs/bt_stubs.c
+      ../port/stubs/phy_stubs.c
+      )
+
+    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
+      # ble, with btbb after ble_app to resolve its baseband calls
+      ble_app
+      btbb
+        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
+      )
+
+  endif()
+
+  # WIFI definitions
+  if (CONFIG_WIFI_ESP32)
+
+    set(WPA_SUPPLICANT_COMPONENT_DIR "../../components/wpa_supplicant")
+    set(WPA_SUPPLICANT_SRCS "${WPA_SUPPLICANT_COMPONENT_DIR}/port/os_xtensa.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/port/eloop.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/ap_config.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/ieee802_1x.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/wpa_auth.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/wpa_auth_ie.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/pmksa_cache_auth.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/sta_info.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/ieee802_11.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/ap/comeback_token.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/common/sae.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/common/dragonfly.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/common/wpa_common.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/bitfield.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-siv.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha256-kdf.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/ccmp.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-gcm.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/crypto_ops.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/dh_group5.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/dh_groups.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/ms_funcs.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha1-tlsprf.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha256-tlsprf.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha384-tlsprf.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha256-prf.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha1-prf.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha384-prf.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/md4-internal.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha1-tprf.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_common/eap_wsc_common.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/common/ieee802_11_common.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_peer/chap.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_peer/eap.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_peer/eap_common.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_peer/eap_mschapv2.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_peer/eap_peap.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_peer/eap_peap_common.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_peer/eap_tls.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_peer/eap_tls_common.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_peer/eap_ttls.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_peer/mschapv2.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_peer/eap_fast.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/eap_peer/eap_fast_common.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/pmksa_cache.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/wpa.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/rsn_supp/wpa_ie.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/common.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/ext_password.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/uuid.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/wpabuf.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/wpa_debug.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/utils/json.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/wps/wps.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/wps/wps_attr_build.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/wps/wps_attr_parse.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/wps/wps_attr_process.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/wps/wps_common.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/wps/wps_dev_attr.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/src/wps/wps_enrollee.c"
+      )
+
+    if(CONFIG_ESP32_WIFI_ENABLE_SAE_PK)
+      set(WPA_SUPPLICANT_SRCS ${WPA_SUPPLICANT_SRCS}
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/common/sae_pk.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/common/bss.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/common/scan.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_scan.c"
+        )
+    endif()
+
+    set(ESP_SUPPLICANT_SRCS "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_eap_client.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wpa2_api_port.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wpa_main.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wpas_glue.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_common.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wps.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_wpa3.c"
+      "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_owe.c"
+      )
+    if(CONFIG_ESP32_WIFI_SOFTAP_SUPPORT)
+        set(ESP_SUPPLICANT_SRCS ${ESP_SUPPLICANT_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/esp_hostap.c")
+    endif()
+
+    if(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT)
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/tls_mbedtls.c"
+        )
+    else()
+      set(TLS_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/asn1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/bignum.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs5.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/pkcs8.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/rsa.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/tls_internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_read.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_write.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_common.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_cred.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_record.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/tlsv1_client_ocsp.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/tls/x509v3.c"
+        )
+    endif()
+
+    if(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO)
+      set(CRYPTO_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-bignum.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-rsa.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/crypto_mbedtls-ec.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/esp_supplicant/src/crypto/fastpbkdf2.c"
+         # Add internal RC4 as RC4 has been removed from mbedtls
+         "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/rc4.c"
+        )
+        if(NOT CONFIG_MBEDTLS_CIPHER_DES_ENABLED)
+          set(CRYPTO_SRCS ${CRYPTO_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/des-internal.c")
+        endif()
+        if(NOT CONFIG_MBEDTLS_MAC_CMAC_ENABLED AND NOT CONFIG_MBEDTLS_CMAC AND NOT CONFIG_PSA_WANT_ALG_CMAC)
+            set(CRYPTO_SRCS ${CRYPTO_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-omac1.c")
+        endif()
+        if(NOT CONFIG_MBEDTLS_NIST_KW_C)
+            set(CRYPTO_SRCS ${CRYPTO_SRCS}
+            "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-wrap.c"
+            "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-unwrap.c")
+        endif()
+        if(NOT CONFIG_MBEDTLS_NIST_KW_C OR NOT CONFIG_MBEDTLS_CMAC_C OR NOT CONFIG_MBEDTLS_CCM_C)
+            set(CRYPTO_SRCS ${CRYPTO_SRCS} "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-ccm.c")
+        endif()
+    else()
+      set(CRYPTO_SRCS
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/rc4.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-ctr.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-cbc.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-ccm.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-internal-dec.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-internal-enc.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-omac1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-unwrap.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/aes-wrap.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/crypto_internal-cipher.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/crypto_internal-modexp.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/crypto_internal-rsa.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/crypto_internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/des-internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/md4-internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/md5-internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/md5.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha1-internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha1-pbkdf2.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha1.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha256-internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha256.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha384-internal.c"
+        "${WPA_SUPPLICANT_COMPONENT_DIR}/src/crypto/sha512-internal.c"
+        )
+    endif()
+
+    zephyr_sources_ifdef(CONFIG_BUILD_ONLY_NO_BLOBS
+      ../port/stubs/wifi_stubs.c
+      ../port/stubs/esp_now_stubs.c
+      ../port/stubs/phy_stubs.c
+      ../port/stubs/mesh_stubs.c
+      )
+
+    zephyr_sources(
+      ../../components/esp_wifi/${CONFIG_SOC_SERIES}/esp_adapter.c
+      ../../components/esp_wifi/regulatory/esp_wifi_regulatory.c
+      ../../components/esp_wifi/src/wifi_init.c
+      ../../components/esp_wifi/src/lib_printf.c
+      ../port/stubs/wifi_compat_stubs.c
+      ${WPA_SUPPLICANT_SRCS}
+      ${ESP_SUPPLICANT_SRCS}
+      ${TLS_SRCS}
+      ${CRYPTO_SRCS}
+      )
+
+    zephyr_sources_ifdef(CONFIG_WIFI_ESP32_MESH
+      ../../components/esp_wifi/src/mesh_event.c
+      )
+
+    zephyr_compile_definitions(
+      __ets__
+      ESP_SUPPLICANT
+      ESPRESSIF_USE
+      IEEE8021X_EAPOL
+      EAP_PEER_METHOD
+      EAP_MSCHAPv2
+      EAP_TTLS
+      EAP_TLS
+      EAP_PEAP
+      USE_WPA2_TASK
+      CONFIG_WPS
+      USE_WPS_TASK
+      CONFIG_ECC
+      CONFIG_IEEE80211W
+      CONFIG_SHA256
+      CONFIG_NO_RADIUS
+      CONFIG_CRYPTO_INTERNAL
+      )
+
+    zephyr_compile_definitions(CONFIG_ESP_WIFI_ENABLED)
+    zephyr_compile_definitions(CONFIG_SOC_WIFI_SUPPORTED)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_MBEDTLS_CRYPTO CONFIG_CRYPTO_MBEDTLS)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_ENABLED)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_MBEDTLS_TLS_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA)
+    zephyr_compile_definitions_ifdef(CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK)
+    zephyr_compile_definitions_ifndef(CONFIG_ESP32_WIFI_ENTERPRISE_MBEDTLS_TLS_CLIENT CONFIG_TLS_INTERNAL_CLIENT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_GCMP)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GCMP_SUPPORT CONFIG_ESP_WIFI_GCMP_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_GMAC)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_GMAC_SUPPORT CONFIG_ESP_WIFI_GMAC_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B CONFIG_SUITEB)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SUITE_B_192 CONFIG_SUITEB192)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_BSS_MAX_IDLE_SUPPORT CONFIG_ESP_WIFI_BSS_MAX_IDLE_SUPPORT)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE CONFIG_WPA3_SAE)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_WPA3_OWE_STA CONFIG_OWE_STA)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_SAE_H2E CONFIG_SAE_H2E)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_ENABLE_SAE_PK CONFIG_SAE_PK)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_SOFTAP_SAE_SUPPORT CONFIG_SAE)
+    zephyr_compile_definitions_ifdef(CONFIG_ESP32_WIFI_WPA3_COMPATIBLE CONFIG_WPA3_COMPAT)
+
+  endif()
+
+  zephyr_link_libraries_ifdef(CONFIG_NEWLIB_LIBC c)
+
+endif()

--- a/zephyr/esp32c61/include/esp_key_mgr.h
+++ b/zephyr/esp32c61/include/esp_key_mgr.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Stub header: key manager API not yet supported in Zephyr.
+ */
+
+#pragma once

--- a/zephyr/esp32c61/src/linker/esp32c61.rom.alias.ld
+++ b/zephyr/esp32c61/src/linker/esp32c61.rom.alias.ld
@@ -1,0 +1,13 @@
+/* Aliases used on Zephyr environment */
+
+PROVIDE ( esp_rom_uart_tx_one_char = uart_tx_one_char );
+PROVIDE ( esp_rom_uart_rx_one_char = uart_rx_one_char );
+PROVIDE ( esp_rom_uart_tx_wait_idle = uart_tx_wait_idle );
+PROVIDE ( esp_rom_intr_matrix_set = intr_matrix_set );
+PROVIDE ( esp_rom_ets_set_user_start = ets_set_user_start );
+PROVIDE ( esp_rom_ets_printf = ets_printf );
+PROVIDE ( esp_rom_ets_delay_us = ets_delay_us );
+PROVIDE ( esp_rom_cache_set_idrom_mmu_size = Cache_Set_IDROM_MMU_Size );
+PROVIDE ( esp_rom_Cache_Invalidate_Addr = Cache_Invalidate_Addr );
+PROVIDE ( esp_rom_gpio_matrix_in = rom_gpio_matrix_in );
+PROVIDE ( esp_rom_gpio_matrix_out = rom_gpio_matrix_out );

--- a/zephyr/esp32c61/src/soc_flash_init.c
+++ b/zephyr/esp32c61/src/soc_flash_init.c
@@ -1,0 +1,250 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdbool.h>
+#include <assert.h>
+#include <string.h>
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_rom_gpio.h"
+#include "esp_rom_efuse.h"
+#include "esp32c61/rom/gpio.h"
+#include "esp32c61/rom/spi_flash.h"
+#include "esp32c61/rom/efuse.h"
+#include "soc/gpio_periph.h"
+#include "soc/efuse_reg.h"
+#include "soc/spi_reg.h"
+#include "soc/spi_mem_reg.h"
+#include "soc/soc_caps.h"
+#include "soc/spi_pins.h"
+
+/* Legacy SPI pin macro compatibility */
+#define SPI_CLK_GPIO_NUM   MSPI_IOMUX_PIN_NUM_CLK
+#define SPI_Q_GPIO_NUM     MSPI_IOMUX_PIN_NUM_MISO
+#define SPI_D_GPIO_NUM     MSPI_IOMUX_PIN_NUM_MOSI
+#define SPI_CS0_GPIO_NUM   MSPI_IOMUX_PIN_NUM_CS0
+#define SPI_HD_GPIO_NUM    MSPI_IOMUX_PIN_NUM_HD
+#define SPI_WP_GPIO_NUM    MSPI_IOMUX_PIN_NUM_WP
+#define MAX_PAD_GPIO_NUM   SOC_GPIO_PIN_COUNT
+#include "flash_qio_mode.h"
+#include "bootloader_flash_config.h"
+#include "bootloader_common.h"
+#include "bootloader_flash_priv.h"
+#include "bootloader_init.h"
+#include "hal/mmu_hal.h"
+#include "hal/cache_hal.h"
+#include "hal/cache_ll.h"
+#include "hal/mmu_ll.h"
+
+#define TAG "flash_init"
+
+extern esp_image_header_t bootloader_image_hdr;
+
+void flash_update_id(void)
+{
+	esp_rom_spiflash_chip_t *chip = &rom_spiflash_legacy_data->chip;
+
+	chip->device_id = bootloader_read_flash_id();
+}
+
+void flash_cs_timing_config(void)
+{
+	SET_PERI_REG_MASK(SPI_MEM_USER_REG(0), SPI_MEM_CS_HOLD_M | SPI_MEM_CS_SETUP_M);
+	SET_PERI_REG_BITS(SPI_MEM_CTRL2_REG(0), SPI_MEM_CS_HOLD_TIME_V, 0, SPI_MEM_CS_HOLD_TIME_S);
+	SET_PERI_REG_BITS(SPI_MEM_CTRL2_REG(0), SPI_MEM_CS_SETUP_TIME_V, 0,
+			  SPI_MEM_CS_SETUP_TIME_S);
+}
+
+void flash_clock_config(const esp_image_header_t *pfhdr)
+{
+	uint32_t spi_clk_div = 0;
+
+	switch (pfhdr->spi_speed) {
+	case ESP_IMAGE_SPI_SPEED_DIV_1:
+		spi_clk_div = 1;
+		break;
+	case ESP_IMAGE_SPI_SPEED_DIV_2:
+		spi_clk_div = 2;
+		break;
+	case ESP_IMAGE_SPI_SPEED_DIV_3:
+		spi_clk_div = 3;
+		break;
+	case ESP_IMAGE_SPI_SPEED_DIV_4:
+		spi_clk_div = 4;
+		break;
+	default:
+		break;
+	}
+	esp_rom_spiflash_config_clk(spi_clk_div, 0);
+}
+
+void configure_spi_pins(int drv)
+{
+	uint8_t clk_gpio_num = SPI_CLK_GPIO_NUM;
+	uint8_t q_gpio_num = SPI_Q_GPIO_NUM;
+	uint8_t d_gpio_num = SPI_D_GPIO_NUM;
+	uint8_t cs0_gpio_num = SPI_CS0_GPIO_NUM;
+	uint8_t hd_gpio_num = SPI_HD_GPIO_NUM;
+	uint8_t wp_gpio_num = SPI_WP_GPIO_NUM;
+
+	esp_rom_gpio_pad_set_drv(clk_gpio_num, drv);
+	esp_rom_gpio_pad_set_drv(q_gpio_num, drv);
+	esp_rom_gpio_pad_set_drv(d_gpio_num, drv);
+	esp_rom_gpio_pad_set_drv(cs0_gpio_num, drv);
+	esp_rom_gpio_pad_set_drv(hd_gpio_num, drv);
+	esp_rom_gpio_pad_set_drv(wp_gpio_num, drv);
+}
+
+static void update_flash_config(const esp_image_header_t *bootloader_hdr)
+{
+	volatile uint32_t size;
+
+	switch (bootloader_hdr->spi_size) {
+	case ESP_IMAGE_FLASH_SIZE_1MB:
+		size = 1;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_2MB:
+		size = 2;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_4MB:
+		size = 4;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_8MB:
+		size = 8;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_16MB:
+		size = 16;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_32MB:
+		size = 32;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_64MB:
+		size = 64;
+		break;
+	case ESP_IMAGE_FLASH_SIZE_128MB:
+		size = 128;
+		break;
+	default:
+		size = 2;
+	}
+	cache_hal_disable(CACHE_LL_LEVEL_EXT_MEM, CACHE_TYPE_ALL);
+	/* Set flash chip size */
+	esp_rom_spiflash_config_param(rom_spiflash_legacy_data->chip.device_id, size * 0x100000,
+				      0x10000, 0x1000, 0x100, 0xffff);
+	cache_hal_enable(CACHE_LL_LEVEL_EXT_MEM, CACHE_TYPE_ALL);
+}
+
+static void print_flash_info(const esp_image_header_t *bootloader_hdr)
+{
+	ESP_EARLY_LOGD(TAG, "magic %02x", bootloader_hdr->magic);
+	ESP_EARLY_LOGD(TAG, "segments %02x", bootloader_hdr->segment_count);
+	ESP_EARLY_LOGD(TAG, "spi_mode %02x", bootloader_hdr->spi_mode);
+	ESP_EARLY_LOGD(TAG, "spi_speed %02x", bootloader_hdr->spi_speed);
+	ESP_EARLY_LOGD(TAG, "spi_size %02x", bootloader_hdr->spi_size);
+
+	const char *str;
+
+	switch (bootloader_hdr->spi_speed) {
+	case ESP_IMAGE_SPI_SPEED_DIV_2:
+		str = "40MHz";
+		break;
+	case ESP_IMAGE_SPI_SPEED_DIV_3:
+		str = "26.7MHz";
+		break;
+	case ESP_IMAGE_SPI_SPEED_DIV_4:
+		str = "20MHz";
+		break;
+	case ESP_IMAGE_SPI_SPEED_DIV_1:
+		str = "80MHz";
+		break;
+	default:
+		str = "20MHz";
+		break;
+	}
+	ESP_EARLY_LOGI(TAG, "SPI Speed      : %s", str);
+
+	/* SPI mode could have been set to QIO during boot already,
+	 * so test the SPI registers not the flash header
+	 */
+	uint32_t spi_ctrl = REG_READ(SPI_MEM_CTRL_REG(0));
+
+	if (spi_ctrl & SPI_MEM_FREAD_QIO) {
+		str = "QIO";
+	} else if (spi_ctrl & SPI_MEM_FREAD_QUAD) {
+		str = "QOUT";
+	} else if (spi_ctrl & SPI_MEM_FREAD_DIO) {
+		str = "DIO";
+	} else if (spi_ctrl & SPI_MEM_FREAD_DUAL) {
+		str = "DOUT";
+	} else if (spi_ctrl & SPI_MEM_FASTRD_MODE) {
+		str = "FAST READ";
+	} else {
+		str = "SLOW READ";
+	}
+	ESP_EARLY_LOGI(TAG, "SPI Mode       : %s", str);
+
+	switch (bootloader_hdr->spi_size) {
+	case ESP_IMAGE_FLASH_SIZE_1MB:
+		str = "1MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_2MB:
+		str = "2MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_4MB:
+		str = "4MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_8MB:
+		str = "8MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_16MB:
+		str = "16MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_32MB:
+		str = "32MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_64MB:
+		str = "64MB";
+		break;
+	case ESP_IMAGE_FLASH_SIZE_128MB:
+		str = "128MB";
+		break;
+	default:
+		str = "2MB";
+		break;
+	}
+	ESP_EARLY_LOGI(TAG, "SPI Flash Size : %s", str);
+}
+
+static void init_flash_configure(void)
+{
+	configure_spi_pins(1);
+	flash_cs_timing_config();
+}
+
+static void spi_flash_resume(void)
+{
+	bootloader_execute_flash_command(CMD_RESUME, 0, 0, 0);
+	esp_rom_spiflash_wait_idle(&g_rom_flashchip);
+}
+
+esp_err_t init_spi_flash(void)
+{
+	init_flash_configure();
+	spi_flash_resume();
+	bootloader_flash_unlock();
+
+#if CONFIG_ESPTOOLPY_FLASHMODE_QIO || CONFIG_ESPTOOLPY_FLASHMODE_QOUT
+	bootloader_enable_qio_mode();
+#endif
+
+#if CONFIG_ESPTOOLPY_FLASHFREQ_80M
+	bootloader_image_hdr.spi_speed = ESP_IMAGE_SPI_SPEED_DIV_1;
+#endif
+	print_flash_info(&bootloader_image_hdr);
+	update_flash_config(&bootloader_image_hdr);
+	/* ensure the flash is write-protected */
+	bootloader_enable_wp();
+	return ESP_OK;
+}

--- a/zephyr/esp32c61/src/soc_init.c
+++ b/zephyr/esp32c61/src/soc_init.c
@@ -1,0 +1,289 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdbool.h>
+#include <assert.h>
+#include "soc_init.h"
+#include "esp32c61/rom/rtc.h"
+#include <soc/soc.h>
+#include "soc/lp_analog_peri_reg.h"
+#include "soc/regi2c_saradc.h"
+#include "hal/clk_tree_ll.h"
+#include "hal/brownout_ll.h"
+#include "hal/regi2c_ctrl_ll.h"
+#include "hal/pmu_ll.h"
+#include "hal/modem_syscon_ll.h"
+#include "hal/modem_lpcon_ll.h"
+#include "hal/mspi_ll.h"
+#include "esp_private/esp_pmu.h"
+#include "esp32c61/rom/spi_flash.h"
+#include "modem/modem_lpcon_reg.h"
+#include "soc/system_reg.h"
+#include "soc/assist_debug_reg.h"
+#include "soc/hp_apm_reg.h"
+#include "soc/lp_apm_reg.h"
+#include "soc/pcr_reg.h"
+#include "soc/lp_wdt_reg.h"
+#include "hal/lpwdt_ll.h"
+#include "hal/axi_icm_ll.h"
+#include "esp_log.h"
+
+const static char *TAG = "soc_init";
+
+void soc_hw_init(void)
+{
+#if CONFIG_ESP_HAL_EARLY_LOG_LEVEL == 0
+	rtc_suppress_rom_log();
+#endif
+
+	/*
+	 * Ensure the system bus resets properly during a core reset (WDT).
+	 * Prevents bus freezing caused by an incorrect MSPI core reset in ROM.
+	 */
+	axi_icm_ll_reset_with_core_reset(true);
+
+	/* Enable analog I2C master clock */
+	_regi2c_ctrl_ll_master_enable_clock(true);
+	regi2c_ctrl_ll_master_configure_clock();
+
+	/*
+	 * Configure modem ICG code in PMU_ACTIVE state so the I2C master
+	 * clock is not gated. Required before any REGI2C operations.
+	 */
+	pmu_ll_hp_set_icg_modem(&PMU, PMU_MODE_HP_ACTIVE, PMU_HP_ICG_MODEM_CODE_ACTIVE);
+	modem_syscon_ll_set_modem_apb_icg_bitmap(&MODEM_SYSCON, BIT(PMU_HP_ICG_MODEM_CODE_ACTIVE));
+	modem_lpcon_ll_set_i2c_master_icg_bitmap(&MODEM_LPCON, BIT(PMU_HP_ICG_MODEM_CODE_ACTIVE));
+	modem_lpcon_ll_set_lp_apb_icg_bitmap(&MODEM_LPCON, BIT(PMU_HP_ICG_MODEM_CODE_ACTIVE));
+	pmu_ll_imm_update_dig_icg_modem_code(&PMU, true);
+	pmu_ll_imm_update_dig_icg_switch(&PMU, true);
+}
+
+void ana_super_wdt_reset_config(bool enable)
+{
+	(void)enable;
+}
+
+void ana_bod_reset_config(bool enable)
+{
+	brownout_ll_ana_reset_enable(enable);
+}
+
+void ana_power_glitch_reset_config(bool enable)
+{
+	/* Only the VDDPST power glitch is detected */
+	SET_PERI_REG_MASK(PMU_RF_PWC_REG, PMU_PERIF_I2C_RSTB);
+	SET_PERI_REG_MASK(PMU_RF_PWC_REG, PMU_XPD_PERIF_I2C);
+	REGI2C_WRITE_MASK(I2C_SAR_ADC, POWER_GLITCH_XPD_VDET_PERIF, 0);
+	REGI2C_WRITE_MASK(I2C_SAR_ADC, POWER_GLITCH_XPD_VDET_PLLBB, 0);
+	REGI2C_WRITE_MASK(I2C_SAR_ADC, POWER_GLITCH_XPD_VDET_PLL, 0);
+
+	REG_SET_FIELD(LP_ANA_FIB_ENABLE_REG, LP_ANA_ANA_FIB_PWR_GLITCH_ENA, 0);
+	if (enable) {
+		REG_SET_FIELD(LP_ANA_POWER_GLITCH_CNTL_REG,
+			      LP_ANA_POWER_GLITCH_RESET_ENA, 0xf);
+	} else {
+		REG_SET_FIELD(LP_ANA_POWER_GLITCH_CNTL_REG,
+			      LP_ANA_POWER_GLITCH_RESET_ENA, 0);
+	}
+}
+
+void ana_reset_config(void)
+{
+	ana_super_wdt_reset_config(true);
+	ana_bod_reset_config(true);
+	ana_power_glitch_reset_config(true);
+}
+
+void super_wdt_auto_feed(void)
+{
+	REG_WRITE(LP_WDT_SWD_WPROTECT_REG, LP_WDT_SWD_WKEY_VALUE);
+	REG_SET_BIT(LP_WDT_SWD_CONFIG_REG, LP_WDT_SWD_AUTO_FEED_EN);
+	REG_WRITE(LP_WDT_SWD_WPROTECT_REG, 0);
+}
+
+void wdt_reset_cpu0_info_enable(void)
+{
+	REG_SET_BIT(PCR_ASSIST_CONF_REG, PCR_ASSIST_CLK_EN);
+	REG_CLR_BIT(PCR_ASSIST_CONF_REG, PCR_ASSIST_RST_EN);
+	REG_WRITE(ASSIST_DEBUG_CORE_0_RCD_EN_REG,
+		  ASSIST_DEBUG_CORE_0_RCD_PDEBUGEN | ASSIST_DEBUG_CORE_0_RCD_RECORDEN);
+}
+
+void check_wdt_reset(void)
+{
+	int wdt_rst = 0;
+	soc_reset_reason_t rst_reas;
+
+	rst_reas = esp_rom_get_reset_reason(0);
+	if (rst_reas == RESET_REASON_CORE_RTC_WDT || rst_reas == RESET_REASON_CORE_MWDT0 ||
+	    rst_reas == RESET_REASON_CORE_MWDT1 || rst_reas == RESET_REASON_CPU0_MWDT0 ||
+	    rst_reas == RESET_REASON_CPU0_MWDT1 || rst_reas == RESET_REASON_CPU0_RTC_WDT) {
+		ESP_EARLY_LOGW(TAG, "PRO CPU has been reset by WDT.");
+		wdt_rst = 1;
+	}
+
+	(void)wdt_rst;
+	wdt_reset_cpu0_info_enable();
+}
+
+/* Not supported but common bootloader calls the function. Do nothing */
+void ana_clock_glitch_reset_config(bool enable)
+{
+	(void)enable;
+}
+
+#include "soc/pmu_reg.h"
+#include "soc/rtc.h"
+#include "soc/lp_clkrst_reg.h"
+#include "soc/regi2c_dig_reg.h"
+#include "esp_rom_serial_output.h"
+#include "esp_rom_regi2c.h"
+#include "soc/regi2c_bbpll.h"
+#include "pmu_param.h"
+
+/*
+ * Custom bootloader_clock_configure() for the ESP32-C61 bootloader stage.
+ *
+ * The bootloader (simple boot or MCUboot) enables PLL and switches the CPU
+ * clock source so that flash can run at higher speeds. The ROM bootloader
+ * leaves the CPU on XTAL. The default weak bootloader_clock_configure()
+ * skips this on a software reset, which would leave the BBPLL un-brought-up
+ * and hang the application clock driver's REGI2C re-calibration; this
+ * override always brings the PLL up so a software reboot recovers cleanly.
+ *
+ * Cannot use rtc_clk_init() or REGI2C_WRITE/REGI2C_WRITE_MASK here
+ * because without BOOTLOADER_BUILD they go through
+ * ANALOG_CLOCK_ENABLE() -> PERIPH_RCC_ACQUIRE_ATOMIC -> irq_lock
+ * which requires kernel infrastructure not available during early boot.
+ *
+ * Instead, use _regi2c_impl_write/write_mask directly for BBPLL
+ * register configuration, and LL functions for calibration control
+ * and clock source switching.
+ */
+void bootloader_clock_configure(void)
+{
+	uint32_t xtal_freq;
+	uint8_t div_ref, div7_0;
+	uint8_t dchgp = 5, dbias = 3, href = 3, lref = 1;
+
+	esp_rom_output_tx_wait_idle(0);
+
+	xtal_freq = clk_ll_xtal_get_freq_mhz();
+
+	/* Reset I2C master in case it was left in a bad state (e.g. after WDT reset) */
+	_regi2c_ctrl_ll_master_reset();
+
+	/* Force-enable I2C master clock for REGI2C operations */
+	regi2c_ctrl_ll_master_force_enable_clock(true);
+
+	/* Set tuning parameters for RC_FAST and RC_SLOW clocks,
+	 * following the vendor clock init sequence.
+	 */
+	REG_SET_FIELD(LP_CLKRST_FOSC_CNTL_REG, LP_CLKRST_FOSC_DFREQ, 100);
+	REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_SCK_DCAP, 128);
+	REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_ENIF_RTC_DREG, 1);
+	REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_ENIF_DIG_DREG, 1);
+	REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_XPD_DIG_REG, 0);
+	REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_XPD_RTC_REG, 0);
+
+	/* DIG regulator DBIAS handoff to PMU, using calibrated values from eFuse.
+	 * Without this, voltage regulation stays at ROM defaults which may be
+	 * insufficient at 160 MHz in worst-case conditions.
+	 */
+	uint32_t hp_cali_dbias = get_act_hp_dbias();
+	uint32_t lp_cali_dbias = get_act_lp_dbias();
+
+	SET_PERI_REG_MASK(PMU_HP_ACTIVE_HP_REGULATOR0_REG, PMU_DIG_REGULATOR0_DBIAS_SEL);
+	SET_PERI_REG_BITS(PMU_HP_ACTIVE_HP_REGULATOR0_REG, PMU_HP_ACTIVE_HP_REGULATOR_DBIAS,
+			  hp_cali_dbias, PMU_HP_ACTIVE_HP_REGULATOR_DBIAS_S);
+	SET_PERI_REG_BITS(PMU_HP_MODEM_HP_REGULATOR0_REG, PMU_HP_MODEM_HP_REGULATOR_DBIAS,
+			  hp_cali_dbias, PMU_HP_MODEM_HP_REGULATOR_DBIAS_S);
+	SET_PERI_REG_BITS(PMU_HP_SLEEP_LP_REGULATOR0_REG, PMU_HP_SLEEP_LP_REGULATOR_DBIAS,
+			  lp_cali_dbias, PMU_HP_SLEEP_LP_REGULATOR_DBIAS_S);
+
+	/* Enable BBPLL power */
+	clk_ll_bbpll_enable();
+
+	/* Start BBPLL self-calibration */
+	clk_ll_bbpll_calibration_start();
+
+	/*
+	 * Configure BBPLL for 480MHz using direct ROM regi2c calls.
+	 * This bypasses REGI2C_WRITE/REGI2C_WRITE_MASK macros which
+	 * would call ANALOG_CLOCK_ENABLE() -> irq_lock during early boot.
+	 */
+	switch (xtal_freq) {
+	case SOC_XTAL_FREQ_40M:
+	default:
+		div_ref = 0;
+		div7_0 = 8;
+		break;
+	}
+
+	uint8_t i2c_bbpll_lref = (dchgp << I2C_BBPLL_OC_DCHGP_LSB) | div_ref;
+	_regi2c_impl_write(I2C_BBPLL, I2C_BBPLL_HOSTID,
+			     I2C_BBPLL_OC_REF_DIV, i2c_bbpll_lref);
+	_regi2c_impl_write(I2C_BBPLL, I2C_BBPLL_HOSTID,
+			     I2C_BBPLL_OC_DIV_7_0, div7_0);
+	_regi2c_impl_write_mask(I2C_BBPLL, I2C_BBPLL_HOSTID,
+				  I2C_BBPLL_OC_DLREF_SEL,
+				  I2C_BBPLL_OC_DLREF_SEL_MSB,
+				  I2C_BBPLL_OC_DLREF_SEL_LSB, lref);
+	_regi2c_impl_write_mask(I2C_BBPLL, I2C_BBPLL_HOSTID,
+				  I2C_BBPLL_OC_DHREF_SEL,
+				  I2C_BBPLL_OC_DHREF_SEL_MSB,
+				  I2C_BBPLL_OC_DHREF_SEL_LSB, href);
+	_regi2c_impl_write_mask(I2C_BBPLL, I2C_BBPLL_HOSTID,
+				  I2C_BBPLL_OC_VCO_DBIAS,
+				  I2C_BBPLL_OC_VCO_DBIAS_MSB,
+				  I2C_BBPLL_OC_VCO_DBIAS_LSB, dbias);
+
+	/* Wait for calibration to complete */
+	while (!clk_ll_bbpll_calibration_is_done()) {
+		;
+	}
+	esp_rom_delay_us(10);
+	clk_ll_bbpll_calibration_stop();
+	regi2c_ctrl_ll_master_force_enable_clock(false);
+
+	/* Switch CPU to PLL_F160M at 160MHz */
+	clk_ll_cpu_set_divider(1);
+	clk_ll_ahb_set_divider(4);
+	clk_ll_cpu_set_src(SOC_CPU_CLK_SRC_PLL_F160M);
+	clk_ll_bus_update();
+	esp_rom_set_cpu_ticks_per_us(160);
+
+	/*
+	 * Configure the MSPI flash clock now that the 480 MHz SPLL is up.
+	 * Point the MSPI function clock at the SPLL and set the divider so
+	 * flash runs at the configured frequency (480 MHz / 6 = 80 MHz).
+	 * This must happen after the SPLL is brought up: doing it earlier
+	 * (against the XTAL source) would leave the flash clock far too low
+	 * and the flash HAL would abort on the source-vs-target check.
+	 */
+	_mspi_timing_ll_set_flash_clk_src(0, FLASH_CLK_SRC_SPLL);
+	mspi_timing_ll_set_core_clock(0, 80);
+#if CONFIG_ESPTOOLPY_FLASHFREQ_80M
+	esp_rom_spiflash_config_clk(1, 0);
+	esp_rom_spiflash_config_clk(1, 1);
+#endif
+
+	/* Keep RC_FAST running so RNG has an entropy source during boot */
+	rtc_clk_8m_enable(true);
+	rtc_clk_fast_src_set(SOC_RTC_FAST_CLK_SRC_RC_FAST);
+
+	/* Clear any pending LP/RTC interrupts */
+	CLEAR_PERI_REG_MASK(LP_WDT_INT_ENA_REG, LP_WDT_SUPER_WDT_INT_ENA);
+	CLEAR_PERI_REG_MASK(LP_ANA_LP_INT_ENA_REG,
+			    LP_ANA_BOD_MODE0_LP_INT_ENA);
+	CLEAR_PERI_REG_MASK(LP_WDT_INT_ENA_REG, LP_WDT_LP_WDT_INT_ENA);
+	CLEAR_PERI_REG_MASK(PMU_HP_INT_ENA_REG, PMU_SOC_WAKEUP_INT_ENA);
+	CLEAR_PERI_REG_MASK(PMU_HP_INT_ENA_REG, PMU_SOC_SLEEP_REJECT_INT_ENA);
+
+	SET_PERI_REG_MASK(LP_WDT_INT_CLR_REG, LP_WDT_SUPER_WDT_INT_CLR);
+	SET_PERI_REG_MASK(LP_ANA_LP_INT_CLR_REG,
+			  LP_ANA_BOD_MODE0_LP_INT_CLR);
+	SET_PERI_REG_MASK(LP_WDT_INT_CLR_REG, LP_WDT_LP_WDT_INT_CLR);
+}

--- a/zephyr/esp32c61/src/soc_random.c
+++ b/zephyr/esp32c61/src/soc_random.c
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include "soc_random.h"
+#include <esp_private/regi2c_ctrl.h>
+#include <esp_private/sar_periph_ctrl.h>
+#include <hal/adc_ll.h>
+#include <hal/adc_types.h>
+#include <hal/temperature_sensor_ll.h>
+#include <hal/regi2c_ctrl_ll.h>
+#include <hal/rng_ll.h>
+
+#define I2C_SAR_ADC_INIT_CODE_VAL       2150
+#define ADC_RNG_CLKM_DIV_NUM            0
+#define ADC_RNG_CLKM_DIV_B              0
+#define ADC_RNG_CLKM_DIV_A              0
+
+void soc_random_enable(void)
+{
+	tsens_ll_reg_values_t saved_tsens_regs = {};
+	tsens_ll_backup_registers(&saved_tsens_regs);
+	adc_ll_reset_register();
+	/* Restore temperature sensor related register values after ADC reset */
+	temperature_sensor_ll_reset_module();
+	tsens_ll_restore_registers(&saved_tsens_regs);
+
+	adc_ll_enable_bus_clock(true);
+	adc_ll_enable_func_clock(true);
+	adc_ll_digi_clk_sel(ADC_DIGI_CLK_SRC_XTAL);
+	adc_ll_digi_controller_clk_div(ADC_RNG_CLKM_DIV_NUM, ADC_RNG_CLKM_DIV_B, ADC_RNG_CLKM_DIV_A);
+
+	/* Some ADC sensor registers are in power group PERIF_I2C and need to be enabled via PMU */
+	regi2c_saradc_enable();
+
+	/* Enable analog I2C master clock for RNG runtime */
+	ANALOG_CLOCK_ENABLE();
+
+	adc_ll_regi2c_init();
+	adc_ll_set_calibration_param(ADC_UNIT_1, I2C_SAR_ADC_INIT_CODE_VAL);
+	adc_ll_set_calibration_param(ADC_UNIT_2, I2C_SAR_ADC_INIT_CODE_VAL);
+
+	/* Use reserved channels to get internal voltage */
+	adc_digi_pattern_config_t pattern_config = {};
+
+	pattern_config.unit = ADC_UNIT_1;
+	pattern_config.atten = ADC_ATTEN_DB_12;
+	pattern_config.channel = ADC_CHANNEL_7;
+	adc_ll_digi_set_pattern_table(ADC_UNIT_1, 0, pattern_config);
+	pattern_config.unit = ADC_UNIT_2;
+	pattern_config.atten = ADC_ATTEN_DB_12;
+	pattern_config.channel = ADC_CHANNEL_1;
+	adc_ll_digi_set_pattern_table(ADC_UNIT_2, 1, pattern_config);
+
+	adc_ll_digi_set_pattern_table_len(ADC_UNIT_1, 2);
+
+	adc_ll_digi_set_clk_div(15);
+	adc_ll_digi_set_trigger_interval(200);
+	adc_ll_digi_trigger_enable();
+	rng_ll_enable();
+}
+
+void soc_random_disable(void)
+{
+	rng_ll_disable();
+
+	adc_ll_digi_trigger_disable();
+	adc_ll_digi_reset_pattern_table();
+	adc_ll_set_calibration_param(ADC_UNIT_1, 0x0);
+	adc_ll_set_calibration_param(ADC_UNIT_2, 0x0);
+	adc_ll_regi2c_adc_deinit();
+	regi2c_saradc_disable();
+
+	/* Disable analog I2C master clock */
+	ANALOG_CLOCK_DISABLE();
+	adc_ll_digi_controller_clk_div(4, 0, 0);
+	adc_ll_digi_clk_sel(ADC_DIGI_CLK_SRC_XTAL);
+}

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -25,6 +25,14 @@ blobs:
     url: https://github.com/espressif/esp32c6-bt-lib/raw/e7be018522c85e67c298effc8ffa7f5b84887a7b/esp32c6/libble_app.a
     description: "Binary libraries supporting the ESP32 series RF subsystems"
     doc-url: https://github.com/espressif/esp32c6-bt-lib
+  - path: lib/esp32c61/libble_app.a
+    sha256: ca193f51e532ac6746da947fe2959dd3552706af63bf1a16d826e0b591f4ca09
+    type: lib
+    version: '1.0'
+    license-path: zephyr/blobs/license.txt
+    url: https://github.com/espressif/esp32c6-bt-lib/raw/e7be018522c85e67c298effc8ffa7f5b84887a7b/esp32c61/libble_app.a
+    description: "Binary libraries supporting the ESP32 series RF subsystems"
+    doc-url: https://github.com/espressif/esp32c6-bt-lib
   - path: lib/esp32c2/libble_app.a
     sha256: dad17b0b3f005aa9bc23daba202fa5f83e1502e247d019cfcff9427a845218cd
     type: lib
@@ -257,6 +265,46 @@ blobs:
     url: https://github.com/espressif/esp32-wifi-lib/raw/cde32e0a504ec4083261156f807babf702967bb2/esp32c6/libpp.a
     description: "Binary libraries supporting the ESP32 series RF subsystems"
     doc-url: https://github.com/espressif/esp32-wifi-lib
+  - path: lib/esp32c61/libcore.a
+    sha256: 2158e05cf4aec990c3fd0b54a25eb6d787fcfb3b6d0455ffd4e64b29555ad728
+    type: lib
+    version: '1.0'
+    license-path: zephyr/blobs/license.txt
+    url: https://github.com/espressif/esp32-wifi-lib/raw/cde32e0a504ec4083261156f807babf702967bb2/esp32c61/libcore.a
+    description: "Binary libraries supporting the ESP32 series RF subsystems"
+    doc-url: https://github.com/espressif/esp32-wifi-lib
+  - path: lib/esp32c61/libespnow.a
+    sha256: 3ef74c2c213d21c19f8c9a37ecc797d0a2a22189fc43d2c045b7f18a8801d40c
+    type: lib
+    version: '1.0'
+    license-path: zephyr/blobs/license.txt
+    url: https://github.com/espressif/esp32-wifi-lib/raw/cde32e0a504ec4083261156f807babf702967bb2/esp32c61/libespnow.a
+    description: "Binary libraries supporting the ESP32 series RF subsystems"
+    doc-url: https://github.com/espressif/esp32-wifi-lib
+  - path: lib/esp32c61/libmesh.a
+    sha256: 259f4272862c880e3ca7861b36480ef188a62fed058d70df7b3fea6ec5f0a7b9
+    type: lib
+    version: '1.0'
+    license-path: zephyr/blobs/license.txt
+    url: https://github.com/espressif/esp32-wifi-lib/raw/cde32e0a504ec4083261156f807babf702967bb2/esp32c61/libmesh.a
+    description: "Binary libraries supporting the ESP32 series RF subsystems"
+    doc-url: https://github.com/espressif/esp32-wifi-lib
+  - path: lib/esp32c61/libnet80211.a
+    sha256: 482487c6560528c63daad74ed4b007047d5ba706e467146516aad136412d4be5
+    type: lib
+    version: '1.0'
+    license-path: zephyr/blobs/license.txt
+    url: https://github.com/espressif/esp32-wifi-lib/raw/cde32e0a504ec4083261156f807babf702967bb2/esp32c61/libnet80211.a
+    description: "Binary libraries supporting the ESP32 series RF subsystems"
+    doc-url: https://github.com/espressif/esp32-wifi-lib
+  - path: lib/esp32c61/libpp.a
+    sha256: 72df286383f5b32c9be07fe25a9738cdbf4b093ec1d9cd25eade5e8ad394cdf4
+    type: lib
+    version: '1.0'
+    license-path: zephyr/blobs/license.txt
+    url: https://github.com/espressif/esp32-wifi-lib/raw/cde32e0a504ec4083261156f807babf702967bb2/esp32c61/libpp.a
+    description: "Binary libraries supporting the ESP32 series RF subsystems"
+    doc-url: https://github.com/espressif/esp32-wifi-lib
   - path: lib/esp32s2/libcore.a
     sha256: 67a186e362840a93336a099f138f50b66519339cc10ea840f90255372b0b94f6
     type: lib
@@ -409,12 +457,28 @@ blobs:
     url: https://github.com/espressif/esp-phy-lib/raw/e37ecdc9c1e93fefda5b1a99f09bd979046d0720/esp32c6/libbtbb.a
     description: "Binary libraries supporting the ESP32 series RF subsystems"
     doc-url: https://github.com/espressif/esp-phy-lib
+  - path: lib/esp32c61/libbtbb.a
+    sha256: 591f66f61c3dad227f9b2db69dd8b5b4b22a377ed11e76085aa80ffcb9580c4a
+    type: lib
+    version: '1.0'
+    license-path: zephyr/blobs/license.txt
+    url: https://github.com/espressif/esp-phy-lib/raw/e37ecdc9c1e93fefda5b1a99f09bd979046d0720/esp32c61/libbtbb.a
+    description: "Binary libraries supporting the ESP32 series RF subsystems"
+    doc-url: https://github.com/espressif/esp-phy-lib
   - path: lib/esp32c6/libphy.a
     sha256: fdba95c59c03560620c399f43a72a16230a8ab6fced172f3103ac6a29c36f43a
     type: lib
     version: '1.0'
     license-path: zephyr/blobs/license.txt
     url: https://github.com/espressif/esp-phy-lib/raw/e37ecdc9c1e93fefda5b1a99f09bd979046d0720/esp32c6/libphy.a
+    description: "Binary libraries supporting the ESP32 series RF subsystems"
+    doc-url: https://github.com/espressif/esp-phy-lib
+  - path: lib/esp32c61/libphy.a
+    sha256: 461c1b191fa5c6403c7e13092be9dfbc04f34c85f9d250acc31d2765427c8507
+    type: lib
+    version: '1.0'
+    license-path: zephyr/blobs/license.txt
+    url: https://github.com/espressif/esp-phy-lib/raw/e37ecdc9c1e93fefda5b1a99f09bd979046d0720/esp32c61/libphy.a
     description: "Binary libraries supporting the ESP32 series RF subsystems"
     doc-url: https://github.com/espressif/esp-phy-lib
   - path: lib/esp32h2/libbtbb.a
@@ -495,6 +559,14 @@ blobs:
     version: '1.0'
     license-path: zephyr/blobs/license.txt
     url: https://github.com/espressif/esp-coex-lib/raw/3c490f8059e0a7eeedda30aaa1e4b3afad06f632/esp32c6/libcoexist.a
+    description: "Binary libraries supporting the ESP32 series RF subsystems"
+    doc-url: https://github.com/espressif/esp-coex-lib
+  - path: lib/esp32c61/libcoexist.a
+    sha256: cc6d92fc2293328dcf15e6e3a2287e3671365832cf97a0d128af1327f24f1c6f
+    type: lib
+    version: '1.0'
+    license-path: zephyr/blobs/license.txt
+    url: https://github.com/espressif/esp-coex-lib/raw/3c490f8059e0a7eeedda30aaa1e4b3afad06f632/esp32c61/libcoexist.a
     description: "Binary libraries supporting the ESP32 series RF subsystems"
     doc-url: https://github.com/espressif/esp-coex-lib
   - path: lib/esp32h2/libcoexist.a

--- a/zephyr/port/boot/esp_image_loader.c
+++ b/zephyr/port/boot/esp_image_loader.c
@@ -18,6 +18,7 @@
 	!defined(CONFIG_SOC_SERIES_ESP32C3) &&	\
 	!defined(CONFIG_SOC_SERIES_ESP32C5) &&	\
 	!defined(CONFIG_SOC_SERIES_ESP32C6) &&	\
+	!defined(CONFIG_SOC_SERIES_ESP32C61) &&	\
 	!defined(CONFIG_SOC_SERIES_ESP32H2) &&	\
 	!defined(CONFIG_SOC_SERIES_ESP32P4)
 #include "soc/dport_reg.h"
@@ -32,6 +33,7 @@
 #include "soc/gpio_periph.h"
 #include "soc/rtc_periph.h"
 #if !defined(CONFIG_SOC_SERIES_ESP32C5) && !defined(CONFIG_SOC_SERIES_ESP32C6) && \
+	!defined(CONFIG_SOC_SERIES_ESP32C61) && \
 	!defined(CONFIG_SOC_SERIES_ESP32H2) && !defined(CONFIG_SOC_SERIES_ESP32P4)
 #include "soc/rtc_cntl_reg.h"
 #endif
@@ -58,6 +60,9 @@
 #define LP_RTC_PREFIX "LP"
 #elif CONFIG_SOC_SERIES_ESP32C6
 #include "esp32c6/rom/uart.h"
+#define LP_RTC_PREFIX "LP"
+#elif CONFIG_SOC_SERIES_ESP32C61
+#include "esp32c61/rom/uart.h"
 #define LP_RTC_PREFIX "LP"
 #elif CONFIG_SOC_SERIES_ESP32H2
 #include "esp32h2/rom/uart.h"

--- a/zephyr/port/bootloader/bootloader_flash.c
+++ b/zephyr/port/bootloader/bootloader_flash.c
@@ -124,6 +124,8 @@ esp_err_t bootloader_flash_erase_range(uint32_t start_addr, uint32_t size)
 #include "esp32p4/rom/opi_flash.h"
 #elif CONFIG_IDF_TARGET_ESP32C5
 #include "esp32c5/rom/opi_flash.h"
+#elif CONFIG_IDF_TARGET_ESP32C61
+#include "esp32c61/rom/opi_flash.h"
 #endif
 #include "esp_flash_chips/spi_flash_defs.h"
 

--- a/zephyr/port/pincfgs/esp32c61.yml
+++ b/zephyr/port/pincfgs/esp32c61.yml
@@ -1,0 +1,245 @@
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# Notes:
+# - ESP32-C61 has 30 GPIO pads (GPIO0-GPIO29)
+# - GPIO15-GPIO21 are the MSPI flash pads (CS0, MISO, WP, VDD_SPI, HD,
+#   CLK, MOSI) and are excluded from the peripheral mux ranges
+
+uart0:
+  tx:
+    sigo: u0txd_out
+    gpio: [[0, 14], [22, 29]]
+  rx:
+    sigi: u0rxd_in
+    gpio: [[0, 14], [22, 29]]
+  rts:
+    sigo: u0rts_out
+    gpio: [[0, 14], [22, 29]]
+  cts:
+    sigi: u0cts_in
+    gpio: [[0, 14], [22, 29]]
+  dtr:
+    sigo: u0dtr_out
+    gpio: [[0, 14], [22, 29]]
+  dsr:
+    sigi: u0dsr_in
+    gpio: [[0, 14], [22, 29]]
+
+uart1:
+  tx:
+    sigo: u1txd_out
+    gpio: [[0, 14], [22, 29]]
+  rx:
+    sigi: u1rxd_in
+    gpio: [[0, 14], [22, 29]]
+  rts:
+    sigo: u1rts_out
+    gpio: [[0, 14], [22, 29]]
+  cts:
+    sigi: u1cts_in
+    gpio: [[0, 14], [22, 29]]
+  dtr:
+    sigo: u1dtr_out
+    gpio: [[0, 14], [22, 29]]
+  dsr:
+    sigi: u1dsr_in
+    gpio: [[0, 14], [22, 29]]
+
+uart2:
+  tx:
+    sigo: u2txd_out
+    gpio: [[0, 14], [22, 29]]
+  rx:
+    sigi: u2rxd_in
+    gpio: [[0, 14], [22, 29]]
+  rts:
+    sigo: u2rts_out
+    gpio: [[0, 14], [22, 29]]
+  cts:
+    sigi: u2cts_in
+    gpio: [[0, 14], [22, 29]]
+  dtr:
+    sigo: u2dtr_out
+    gpio: [[0, 14], [22, 29]]
+  dsr:
+    sigi: u2dsr_in
+    gpio: [[0, 14], [22, 29]]
+
+spim2:
+  miso:
+    sigi: fspiq_in
+    gpio: [[0, 14], [22, 29]]
+  mosi:
+    sigo: fspid_out
+    gpio: [[0, 14], [22, 29]]
+  sclk:
+    sigo: fspiclk_out
+    gpio: [[0, 14], [22, 29]]
+  csel:
+    sigo: fspics0_out
+    gpio: [[0, 14], [22, 29]]
+  csel1:
+    sigo: fspics1_out
+    gpio: [[0, 14], [22, 29]]
+  csel2:
+    sigo: fspics2_out
+    gpio: [[0, 14], [22, 29]]
+  csel3:
+    sigo: fspics3_out
+    gpio: [[0, 14], [22, 29]]
+  csel4:
+    sigo: fspics4_out
+    gpio: [[0, 14], [22, 29]]
+  csel5:
+    sigo: fspics5_out
+    gpio: [[0, 14], [22, 29]]
+  hd:
+    sigi: fspihd_in
+    sigo: fspihd_out
+    gpio: [[0, 14], [22, 29]]
+  wp:
+    sigi: fspiwp_in
+    sigo: fspiwp_out
+    gpio: [[0, 14], [22, 29]]
+
+spis2:
+  miso:
+    sigo: fspiq_out
+    gpio: [[0, 14], [22, 29]]
+  mosi:
+    sigi: fspid_in
+    gpio: [[0, 14], [22, 29]]
+  sclk:
+    sigi: fspiclk_in
+    gpio: [[0, 14], [22, 29]]
+  csel:
+    sigi: fspics0_in
+    gpio: [[0, 14], [22, 29]]
+
+ledc:
+  ch0:
+    sigo: ledc_ls_sig_out0
+    gpio: [[0, 14], [22, 29]]
+  ch1:
+    sigo: ledc_ls_sig_out1
+    gpio: [[0, 14], [22, 29]]
+  ch2:
+    sigo: ledc_ls_sig_out2
+    gpio: [[0, 14], [22, 29]]
+  ch3:
+    sigo: ledc_ls_sig_out3
+    gpio: [[0, 14], [22, 29]]
+  ch4:
+    sigo: ledc_ls_sig_out4
+    gpio: [[0, 14], [22, 29]]
+  ch5:
+    sigo: ledc_ls_sig_out5
+    gpio: [[0, 14], [22, 29]]
+
+i2c0:
+  sda:
+    sigi: i2cext0_sda_in
+    sigo: i2cext0_sda_out
+    gpio: [[0, 14], [22, 29]]
+  scl:
+    sigi: i2cext0_scl_in
+    sigo: i2cext0_scl_out
+    gpio: [[0, 14], [22, 29]]
+
+i2s:
+  mclk:
+    sigi: i2s_mclk_in
+    sigo: i2s_mclk_out
+    gpio: [[0, 14], [22, 29]]
+  i_bck:
+    sigi: i2si_bck_in
+    sigo: i2si_bck_out
+    gpio: [[0, 14], [22, 29]]
+  i_ws:
+    sigi: i2si_ws_in
+    sigo: i2si_ws_out
+    gpio: [[0, 14], [22, 29]]
+  i_sd:
+    sigi: i2si_sd_in
+    gpio: [[0, 14], [22, 29]]
+  o_bck:
+    sigi: i2so_bck_in
+    sigo: i2so_bck_out
+    gpio: [[0, 14], [22, 29]]
+  o_ws:
+    sigi: i2so_ws_in
+    sigo: i2so_ws_out
+    gpio: [[0, 14], [22, 29]]
+  o_sd:
+    sigo: i2so_sd_out
+    gpio: [[0, 14], [22, 29]]
+  o_sd1:
+    sigo: i2so_sd1_out
+    gpio: [[0, 14], [22, 29]]
+
+antsel:
+  ant0:
+    sigo: ant_sel0
+    gpio: [[0, 14], [22, 29]]
+  ant1:
+    sigo: ant_sel1
+    gpio: [[0, 14], [22, 29]]
+  ant2:
+    sigo: ant_sel2
+    gpio: [[0, 14], [22, 29]]
+  ant3:
+    sigo: ant_sel3
+    gpio: [[0, 14], [22, 29]]
+  ant4:
+    sigo: ant_sel4
+    gpio: [[0, 14], [22, 29]]
+  ant5:
+    sigo: ant_sel5
+    gpio: [[0, 14], [22, 29]]
+  ant6:
+    sigo: ant_sel6
+    gpio: [[0, 14], [22, 29]]
+  ant7:
+    sigo: ant_sel7
+    gpio: [[0, 14], [22, 29]]
+  ant8:
+    sigo: ant_sel8
+    gpio: [[0, 14], [22, 29]]
+  ant9:
+    sigo: ant_sel9
+    gpio: [[0, 14], [22, 29]]
+  ant10:
+    sigo: ant_sel10
+    gpio: [[0, 14], [22, 29]]
+  ant11:
+    sigo: ant_sel11
+    gpio: [[0, 14], [22, 29]]
+  ant12:
+    sigo: ant_sel12
+    gpio: [[0, 14], [22, 29]]
+  ant13:
+    sigo: ant_sel13
+    gpio: [[0, 14], [22, 29]]
+  ant14:
+    sigo: ant_sel14
+    gpio: [[0, 14], [22, 29]]
+  ant15:
+    sigo: ant_sel15
+    gpio: [[0, 14], [22, 29]]
+
+clkout:
+  out1:
+    sigo: clk_out_out1
+    gpio: [[0, 14], [22, 29]]
+  out2:
+    sigo: clk_out_out2
+    gpio: [[0, 14], [22, 29]]
+  out3:
+    sigo: clk_out_out3
+    gpio: [[0, 14], [22, 29]]
+
+sdio:
+  int:
+    sigo: sdio_tohost_int_out
+    gpio: [[0, 14], [22, 29]]

--- a/zephyr/port/stubs/bt_stubs.c
+++ b/zephyr/port/stubs/bt_stubs.c
@@ -296,7 +296,8 @@ void ble_enc_funcs_reset(void)
 }
 
 #if defined(CONFIG_SOC_SERIES_ESP32C2) || defined(CONFIG_SOC_SERIES_ESP32C5) || \
-	defined(CONFIG_SOC_SERIES_ESP32C6) ||defined(CONFIG_SOC_SERIES_ESP32H2)
+	defined(CONFIG_SOC_SERIES_ESP32C6) || defined(CONFIG_SOC_SERIES_ESP32C61) || \
+	defined(CONFIG_SOC_SERIES_ESP32H2)
 
 /* Forward declarations of opaque types */
 struct osi_coex_funcs_t;
@@ -744,7 +745,8 @@ int ble_controller_disable(void)
 
 #endif /* CONFIG_SOC_SERIES_ESP32C2 */
 
-#if defined(CONFIG_SOC_SERIES_ESP32H2) || defined(CONFIG_SOC_SERIES_ESP32C5) || defined(CONFIG_SOC_SERIES_ESP32C6)
+#if defined(CONFIG_SOC_SERIES_ESP32H2) || defined(CONFIG_SOC_SERIES_ESP32C5) || \
+	defined(CONFIG_SOC_SERIES_ESP32C6) || defined(CONFIG_SOC_SERIES_ESP32C61)
 
 uint32_t bt_bb_get_rssi_comp(void)
 {
@@ -833,7 +835,8 @@ void pawrSync_stack_disable(void)
 {
 }
 
-#endif /* CONFIG_SOC_SERIES_ESP32H2 || CONFIG_SOC_SERIES_ESP32C6 */
+#endif /* CONFIG_SOC_SERIES_ESP32H2 || CONFIG_SOC_SERIES_ESP32C5 ||
+	  CONFIG_SOC_SERIES_ESP32C6 || CONFIG_SOC_SERIES_ESP32C61 */
 
 #if defined(CONFIG_SOC_SERIES_ESP32H2)
 

--- a/zephyr/port/stubs/phy_stubs.c
+++ b/zephyr/port/stubs/phy_stubs.c
@@ -24,6 +24,18 @@ uint32_t phy_get_rf_cal_version(void)
 	return 0;
 }
 
+void set_bb_wdg(bool busy_chk, bool srch_chk, uint16_t max_busy, uint16_t max_srch,
+		bool rst_en, bool int_en, bool clr)
+{
+	ARG_UNUSED(busy_chk);
+	ARG_UNUSED(srch_chk);
+	ARG_UNUSED(max_busy);
+	ARG_UNUSED(max_srch);
+	ARG_UNUSED(rst_en);
+	ARG_UNUSED(int_en);
+	ARG_UNUSED(clr);
+}
+
 void phy_set_wifi_mode_only(bool wifi_only)
 {
 	ARG_UNUSED(wifi_only);

--- a/zephyr/port/stubs/wifi_compat_stubs.c
+++ b/zephyr/port/stubs/wifi_compat_stubs.c
@@ -8,9 +8,13 @@
 
 #include <zephyr/kernel.h>
 
-/* Regulatory domain data - required by blob */
-const void *regdomain_table = NULL;
-const void *regulatory_data = NULL;
+/*
+ * Regulatory domain data required by the Wi-Fi blob. Provided as weak NULL
+ * fallbacks so a soc that compiles the real esp_wifi_regulatory.c tables
+ * overrides them with valid data.
+ */
+const void *__attribute__((weak)) regdomain_table;
+const void *__attribute__((weak)) regulatory_data;
 
 void __attribute__((weak)) pm_beacon_offset_funcs_empty_init(void)
 {

--- a/zephyr/scripts/pinctrl/esp_genpinctrl.py
+++ b/zephyr/scripts/pinctrl/esp_genpinctrl.py
@@ -48,22 +48,6 @@ file_out_head = (
  * For example, `I2C0_SCL_GPIO1` corresponds to the `SCL` signal of `I2C0`
  * mapped to `GPIO1`.
  *
- * @code{.dts}
- * #include <zephyr/dt-bindings/pinctrl/{soc}-pinctrl.h>
- *
- * &pinctrl {
- *     uart0_default: uart0_default {
- *         group1 {
- *             pinmux = <UART0_TX_GPIO21>;
- *         };
- *         group2 {
- *             pinmux = <UART0_RX_GPIO20>;
- *             bias-pull-up;
- *         };
- *     };
- * };
- * @endcode
- *
  * @{
  */
 


### PR DESCRIPTION
This PR adds ESP32-C61 support to hal_espressif: the Zephyr port
layer, the Zephyr-build adaptations to the C61 components, and the
Wi-Fi and BLE integration with their prebuilt libraries.