### PR TITLE
zephyr: gate rmt hal sources on pulse_io backend symbol

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -280,7 +280,7 @@ if(CONFIG_SOC_SERIES_ESP32)
     ../../components/esp_driver_dac/dac_common.c
     )
 
-  zephyr_sources_ifdef(CONFIG_ESPRESSIF_RMT
+  zephyr_sources_ifdef(CONFIG_PULSE_IO_ESP32_RMT
     ../../components/esp_hal_rmt/rmt_hal.c
     ../../components/esp_hal_gpio/gpio_hal.c
     ../../components/esp_driver_gpio/src/gpio.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -246,7 +246,7 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     ../../components/esp_hal_ledc/ledc_hal.c
     )
 
-  zephyr_sources_ifdef(CONFIG_ESPRESSIF_RMT
+  zephyr_sources_ifdef(CONFIG_PULSE_IO_ESP32_RMT
     ../../components/esp_hal_rmt/rmt_hal.c
     ../../components/esp_hal_gpio/gpio_hal.c
     ../../components/esp_driver_gpio/src/gpio.c

--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -254,7 +254,7 @@ if(CONFIG_SOC_SERIES_ESP32C5)
     )
   endif()
 
-  zephyr_sources_ifdef(CONFIG_ESPRESSIF_RMT
+  zephyr_sources_ifdef(CONFIG_PULSE_IO_ESP32_RMT
     ../../components/esp_hal_rmt/rmt_hal.c
     ../../components/esp_hal_gpio/gpio_hal.c
     ../../components/esp_driver_gpio/src/gpio.c

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -249,7 +249,7 @@ if(CONFIG_SOC_SERIES_ESP32C6)
     )
   endif()
 
-  zephyr_sources_ifdef(CONFIG_ESPRESSIF_RMT
+  zephyr_sources_ifdef(CONFIG_PULSE_IO_ESP32_RMT
     ../../components/esp_hal_rmt/rmt_hal.c
     ../../components/esp_hal_gpio/gpio_hal.c
     ../../components/esp_driver_gpio/src/gpio.c

--- a/zephyr/esp32h2/CMakeLists.txt
+++ b/zephyr/esp32h2/CMakeLists.txt
@@ -443,7 +443,7 @@ if(CONFIG_SOC_SERIES_ESP32H2)
     ../../components/esp_driver_gpio/src/gpio.c
     )
 
-  zephyr_sources_ifdef(CONFIG_ESPRESSIF_RMT
+  zephyr_sources_ifdef(CONFIG_PULSE_IO_ESP32_RMT
     ../../components/esp_hal_rmt/rmt_hal.c
     ../../components/esp_hal_gpio/gpio_hal.c
     ../../components/esp_driver_gpio/src/gpio.c

--- a/zephyr/esp32p4/CMakeLists.txt
+++ b/zephyr/esp32p4/CMakeLists.txt
@@ -272,7 +272,7 @@ if(CONFIG_SOC_SERIES_ESP32P4)
     )
   endif()
 
-  zephyr_sources_ifdef(CONFIG_ESPRESSIF_RMT
+  zephyr_sources_ifdef(CONFIG_PULSE_IO_ESP32_RMT
     ../../components/esp_hal_rmt/rmt_hal.c
     ../../components/esp_hal_gpio/gpio_hal.c
     ../../components/esp_driver_gpio/src/gpio.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -289,7 +289,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     endif()
   endif()
 
-  zephyr_sources_ifdef(CONFIG_ESPRESSIF_RMT
+  zephyr_sources_ifdef(CONFIG_PULSE_IO_ESP32_RMT
     ../../components/esp_hal_rmt/rmt_hal.c
     ../../components/esp_hal_gpio/gpio_hal.c
     ../../components/esp_driver_gpio/src/gpio.c

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -341,7 +341,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     ../../components/esp_hal_lcd/lcd_hal.c
     )
 
-  zephyr_sources_ifdef(CONFIG_ESPRESSIF_RMT
+  zephyr_sources_ifdef(CONFIG_PULSE_IO_ESP32_RMT
     ../../components/esp_hal_rmt/rmt_hal.c
     ../../components/esp_hal_gpio/gpio_hal.c
     ../../components/esp_driver_gpio/src/gpio.c


### PR DESCRIPTION
Replace the CONFIG_ESPRESSIF_RMT gate with the Zephyr driver symbol CONFIG_PULSE_IO_ESP32_RMT, matching how the other hal sources are gated. The extra hidden Kconfig symbol on the Zephyr side is no longer needed.