### PR TITLE
zephyr: scripts: fix esp_genpartition.py

### DIFF
--- a/zephyr/scripts/partitions/esp_genpartition.py
+++ b/zephyr/scripts/partitions/esp_genpartition.py
@@ -149,7 +149,7 @@ def generate_partition_table_dtsi(flash_size_mb, flash_offset_kb, scheme, scheme
 
         output.append("")
         output.append(f"\t\t{name.replace('-', '_')}_partition: partition@{current_offset:x} {{")
-        output.append(f"\t\t\tcompatible = \"zephyr,mapped-partitions\";")
+        output.append(f"\t\t\tcompatible = \"zephyr,mapped-partition\";")
         output.append(f"\t\t\tlabel = \"{label}\";")
         output.append(f"\t\t\treg = <0x{current_offset:X} DT_SIZE_K({int(size_kb)})>;")
         output.append("\t\t};")


### PR DESCRIPTION
Fix typo on generated compatible name; it should be singular instead of plural.