### PR TITLE
esp_wifi: use os_random in wifi os adapters

### DIFF
--- a/components/esp_wifi/esp32/esp_adapter.c
+++ b/components/esp_wifi/esp32/esp_adapter.c
@@ -606,11 +606,6 @@ uint32_t esp_get_free_heap_size(void)
     return 10000;
 }
 
-unsigned long random(void)
-{
-    return sys_rand32_get();
-}
-
 int32_t nvs_set_i8(uint32_t handle, const char *key, int8_t value)
 {
     return 0;
@@ -989,7 +984,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._nvs_erase_key = nvs_erase_key,
     ._get_random = os_get_random,
     ._get_time = get_time_wrapper,
-    ._random = random,
+    ._random = os_random,
     ._log_write = esp_log_write_wrapper,
     ._log_writev = esp_log_writev_wrapper,
     ._log_timestamp = k_uptime_get_32,

--- a/components/esp_wifi/esp32s2/esp_adapter.c
+++ b/components/esp_wifi/esp32s2/esp_adapter.c
@@ -597,11 +597,6 @@ static uint32_t esp_get_free_heap_size_wrapper(void)
     return 10000;
 }
 
-static unsigned long random_wrapper(void)
-{
-    return sys_rand32_get();
-}
-
 static int coex_init_wrapper(void)
 {
 #if CONFIG_EXTERNAL_COEX_ENABLE
@@ -974,7 +969,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
     ._nvs_erase_key = nvs_erase_key,
     ._get_random = os_get_random,
     ._get_time = get_time_wrapper,
-    ._random = random_wrapper,
+    ._random = os_random,
     ._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
     ._log_write = esp_log_write_wrapper,
     ._log_writev = esp_log_writev_wrapper,

--- a/components/esp_wifi/esp32s3/esp_adapter.c
+++ b/components/esp_wifi/esp32s3/esp_adapter.c
@@ -611,11 +611,6 @@ uint32_t esp_get_free_heap_size(void)
 	return 10000;
 }
 
-unsigned long random(void)
-{
-	return sys_rand32_get();
-}
-
 int32_t nvs_set_i8(uint32_t handle, const char *key, int8_t value)
 {
 	return 0;
@@ -997,7 +992,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs = {
 	._nvs_erase_key = nvs_erase_key,
 	._get_random = os_get_random,
 	._get_time = get_time_wrapper,
-	._random = random,
+	._random = os_random,
 	._slowclk_cal_get = esp_coex_common_clk_slowclk_cal_get_wrapper,
 	._log_write = esp_log_write_wrapper,
 	._log_writev = esp_log_writev_wrapper,


### PR DESCRIPTION
The esp32, esp32s2 and esp32s3 Wi-Fi adapters defined a global random() that collides with the libc random() declared by Zephyr's minimal libc and picolibc.