### PR TITLE
zephyr: use rom printf for hal logs until kernel is up

### DIFF
--- a/zephyr/common/include/esp_log.h
+++ b/zephyr/common/include/esp_log.h
@@ -9,6 +9,7 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <esp_rom_sys.h>
 
@@ -53,33 +54,46 @@ static inline void esp_log_level_set(const char *tag, esp_log_level_t level)
     (void)level;
 }
 
-/* Normal logging - printk, gated by ESP_HAL_LOG_LEVEL */
+/* Boot-stage code may run before the flash cache is mapped, where
+ * entering the Zephyr logging path can fetch flash-resident code.
+ * Print through the ROM routines until the kernel is up.
+ */
+#define ESP_LOG_PRINT(...)                   \
+    do {                                     \
+        if (k_is_pre_kernel()) {             \
+            esp_rom_printf(__VA_ARGS__);     \
+        } else {                             \
+            printk(__VA_ARGS__);             \
+        }                                    \
+    } while (0)
+
+/* Normal logging - gated by ESP_HAL_LOG_LEVEL */
 #if ESP_HAL_LOG_LEVEL >= 1
-#define ESP_LOGE(tag, fmt, ...) printk("E (%s): " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGE(tag, fmt, ...) ESP_LOG_PRINT("E (%s): " fmt "\n", (tag), ##__VA_ARGS__)
 #else
 #define ESP_LOGE(tag, fmt, ...) _ESP_LOG_NOOP(tag, fmt, ##__VA_ARGS__)
 #endif
 
 #if ESP_HAL_LOG_LEVEL >= 2
-#define ESP_LOGW(tag, fmt, ...) printk("W (%s): " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGW(tag, fmt, ...) ESP_LOG_PRINT("W (%s): " fmt "\n", (tag), ##__VA_ARGS__)
 #else
 #define ESP_LOGW(tag, fmt, ...) _ESP_LOG_NOOP(tag, fmt, ##__VA_ARGS__)
 #endif
 
 #if ESP_HAL_LOG_LEVEL >= 3
-#define ESP_LOGI(tag, fmt, ...) printk("I (%s): " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGI(tag, fmt, ...) ESP_LOG_PRINT("I (%s): " fmt "\n", (tag), ##__VA_ARGS__)
 #else
 #define ESP_LOGI(tag, fmt, ...) _ESP_LOG_NOOP(tag, fmt, ##__VA_ARGS__)
 #endif
 
 #if ESP_HAL_LOG_LEVEL >= 4
-#define ESP_LOGD(tag, fmt, ...) printk("D (%s): " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGD(tag, fmt, ...) ESP_LOG_PRINT("D (%s): " fmt "\n", (tag), ##__VA_ARGS__)
 #else
 #define ESP_LOGD(tag, fmt, ...) _ESP_LOG_NOOP(tag, fmt, ##__VA_ARGS__)
 #endif
 
 #if ESP_HAL_LOG_LEVEL >= 5
-#define ESP_LOGV(tag, fmt, ...) printk("V (%s): " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGV(tag, fmt, ...) ESP_LOG_PRINT("V (%s): " fmt "\n", (tag), ##__VA_ARGS__)
 #else
 #define ESP_LOGV(tag, fmt, ...) _ESP_LOG_NOOP(tag, fmt, ##__VA_ARGS__)
 #endif


### PR DESCRIPTION
Hal code can log from the boot loader stage, before the flash cache is mapped. With CONFIG_LOG enabled, ESP_LOGx expands to printk, which is redirected into the deferred logging path whose buffer code resides in flash-mapped memory.

Route ESP_LOGx through the ROM printf while k_is_pre_kernel() is true and through printk afterwards. The boot entry zeroes bss before the loader runs, so the check is reliable in every boot stage and covers all current and future hal log call sites.
