### PR TITLE
esp32c5: remove hardcoded bootloader offset fallback

### DIFF
--- a/zephyr/esp32c5/include/sdkconfig.h
+++ b/zephyr/esp32c5/include/sdkconfig.h
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#ifndef CONFIG_BOOTLOADER_OFFSET_IN_FLASH
-#define CONFIG_BOOTLOADER_OFFSET_IN_FLASH 0x2000
-#endif


### PR DESCRIPTION
The per-soc sdkconfig.h defined a 0x2000 fallback for CONFIG_BOOTLOADER_OFFSET_IN_FLASH. The value always comes from Kconfig now, derived from the boot partition address in the devicetree, so the fallback is dead code and could mask a missing configuration. All other socs already use the common header only.