### PR TITLE
esp32c61: spi target sources and include update

### DIFF
--- a/components/esp_hw_support/lowpower/port/esp32c61/sleep_cpu.c
+++ b/components/esp_hw_support/lowpower/port/esp32c61/sleep_cpu.c
@@ -15,8 +15,7 @@
 #include "esp_sleep.h"
 #include "esp_log.h"
 #include "esp_rom_crc.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
+#include <zephyr/kernel.h>
 #include "riscv/csr.h"
 #include "soc/soc_caps.h"
 #include "soc/rtc_periph.h"

--- a/zephyr/esp32c61/CMakeLists.txt
+++ b/zephyr/esp32c61/CMakeLists.txt
@@ -207,6 +207,11 @@ if(CONFIG_SOC_SERIES_ESP32C61)
       )
   endif()
 
+  zephyr_sources_ifdef(CONFIG_ESP32_SPI_TARGET
+    ../../components/esp_hal_gpspi/spi_slave_hal.c
+    ../../components/esp_hal_gpspi/spi_slave_hal_iram.c
+    )
+
   if(CONFIG_SOC_FLASH_ESP32 OR NOT CONFIG_BOOTLOADER_MCUBOOT)
     zephyr_sources(
     ../../components/esp_mm/esp_mmu_map.c


### PR DESCRIPTION
Add spi-slave target sources and fix freertos include leftover.