### PR TITLE
esp32p4: add ppa sources and fix double promotion warnings

### DIFF
--- a/components/esp_hal_lcd/mipi_dsi_hal.c
+++ b/components/esp_hal_lcd/mipi_dsi_hal.c
@@ -271,6 +271,7 @@ uint32_t mipi_dsi_hal_host_dpi_calculate_divider(mipi_dsi_hal_context_t *hal, fl
     hal->expect_dpi_clock_freq_mhz = expect_dpi_clk_mhz;
     hal->real_dpi_clock_freq_mhz = clk_src_mhz / (float)div;
     HAL_LOGD(TAG, "dpi clk: src=%.2f MHz, expect=%.2f MHz, div=%" PRIu32 ", real=%.2f MHz",
-             clk_src_mhz, expect_dpi_clk_mhz, div, hal->real_dpi_clock_freq_mhz);
+             (double)clk_src_mhz, (double)expect_dpi_clk_mhz, div,
+             (double)hal->real_dpi_clock_freq_mhz);
     return div;
 }

--- a/zephyr/esp32p4/CMakeLists.txt
+++ b/zephyr/esp32p4/CMakeLists.txt
@@ -85,6 +85,8 @@ if(CONFIG_SOC_SERIES_ESP32P4)
     ../../components/esp_hal_parlio/${CONFIG_SOC_SERIES}/include
     ../../components/esp_hal_pmu/include
     ../../components/esp_hal_pmu/${CONFIG_SOC_SERIES}/include
+    ../../components/esp_hal_ppa/include
+    ../../components/esp_hal_ppa/${CONFIG_SOC_SERIES}/include
     ../../components/esp_hal_regi2c/include
     ../../components/esp_hal_regi2c/${CONFIG_SOC_SERIES}/include
     ../../components/esp_hal_rmt/include


### PR DESCRIPTION
1) Add ESP32-P4 PPA sources for the MIPI-DSI driver integration
2) Fixes HAL_LOGD double promotion build warnings.