### PR TITLE
spi_flash: skip SPI1 mutex when called pre-kernel

### DIFF
--- a/components/spi_flash/spi_flash_os_func_app.c
+++ b/components/spi_flash/spi_flash_os_func_app.c
@@ -128,7 +128,13 @@ static IRAM_ATTR esp_err_t spi1_start(void *arg, uint32_t flags)
     //use the lock to disable the cache and interrupts before using the SPI bus
     ret = acquire_spi_bus_lock(arg);
 #elif SPI_FLASH_CACHE_NO_DISABLE
-    k_mutex_lock(&s_spi1_flash_mutex, K_FOREVER);
+    /* k_mutex_lock requires an active thread context. Skip the lock if the
+     * kernel is not yet running (esp_flash_config() runs pre-kernel, where
+     * execution is single-threaded and no arbitration is needed).
+     */
+    if (!k_is_pre_kernel()) {
+        k_mutex_lock(&s_spi1_flash_mutex, K_FOREVER);
+    }
 #else
     //directly disable the cache and interrupts when lock is not used
     cache_disable(NULL);
@@ -163,7 +169,10 @@ static IRAM_ATTR esp_err_t spi1_end(void *arg)
 #if CONFIG_SPI_FLASH_SHARE_SPI1_BUS
     ret = release_spi_bus_lock(arg);
 #elif SPI_FLASH_CACHE_NO_DISABLE
-    k_mutex_unlock(&s_spi1_flash_mutex);
+    /* See spi1_start: no lock is taken pre-kernel. */
+    if (!k_is_pre_kernel()) {
+        k_mutex_unlock(&s_spi1_flash_mutex);
+    }
 #else
     cache_enable(NULL);
 #endif


### PR DESCRIPTION
When `SPI_FLASH_CACHE_NO_DISABLE` evaluates true (`CONFIG_SPI_FLASH_AUTO_SUSPEND`, `CONFIG_SPIRAM_FETCH_INSTRUCTIONS && CONFIG_SPIRAM_RODATA`, or `CONFIG_APP_BUILD_TYPE_RAM`), `spi1_start()`/`spi1_end()` arbitrate SPI1 flash access with `s_spi1_flash_mutex` instead of disabling the cache.

These hooks also run before the Zephyr kernel is up:

```
loader.c: __esp_platform_app_start()          (before z_prep_c)
└─ esp_flash_config()                          zephyr/common/flash_init.c
   ├─ esp_flash_app_init()                     installs esp_flash_spi1_default_os_functions
   └─ esp_flash_init_default_chip()
        └─ esp_flash_init() → detect_spi_flash_chip() / read_id_core()
             └─ rom_spiflash_api_funcs->start(chip)
                  └─ chip->os_func->start(...) = spi1_start()
                       └─ k_mutex_lock(&s_spi1_flash_mutex, K_FOREVER)   ← pre-kernel
```

Confirmed by instrumentation on ESP32-S3 with an XIP-from-PSRAM configuration: the `k_mutex_lock()` in `spi1_start()` executes ~0.2 s into boot, before `z_prep_c()`.

Kernel objects require a running kernel; taking a mutex pre-kernel is invalid API use. It currently happens to work because pre-kernel execution is single-threaded, so the mutex is never contended and the fast path never blocks — but it stores whatever `_current` holds pre-kernel as the mutex owner, and relies on the kernel never adding stricter checks to that path. This is a hardening/correctness fix, not a fix for an observed crash.

The fix skips the mutex while `k_is_pre_kernel()`: no arbitration is needed while single-threaded. It mirrors the existing pre-kernel guard around `k_sleep()` in `spi_flash_os_yield()` in the same file.

**Testing** (esp32s3_devkitc, ESP32-S3-WROOM-1 N16R8 octal PSRAM; `CONFIG_ESP_SPIRAM=y`, `CONFIG_SPIRAM_MODE_OCT=y`, `CONFIG_SPIRAM_SPEED_40M=y`, `CONFIG_SPIRAM_FETCH_INSTRUCTIONS=y`, `CONFIG_SPIRAM_RODATA=y`, `CONFIG_ASSERT=y`):

- Zephyr main (7fe0fd9b787c) + hal_espressif 3d4d922a4d + this patch (clean cherry-pick): boots and runs.
- Same without the patch: also boots today (latent issue, as described above).
