### PR TITLE
esp_wifi: fix null deref in wifi thread semaphore wrapper

### DIFF
--- a/components/esp_wifi/esp32/esp_adapter.c
+++ b/components/esp_wifi/esp32/esp_adapter.c
@@ -213,11 +213,10 @@ static void *wifi_thread_semphr_get_wrapper(void)
         sem = (struct k_sem *) wifi_malloc(sizeof(struct k_sem));
         if (sem == NULL) {
             LOG_ERR("wifi_thread_semphr_get_wrapper allocation failed");
+            return NULL;
         }
         k_sem_init(sem, 0, 1);
-        if (sem) {
-            k_thread_custom_data_set(sem);
-        }
+        k_thread_custom_data_set(sem);
     }
     return (void *)sem;
 }

--- a/components/esp_wifi/esp32s3/esp_adapter.c
+++ b/components/esp_wifi/esp32s3/esp_adapter.c
@@ -209,11 +209,10 @@ static void *wifi_thread_semphr_get_wrapper(void)
 		sem = (struct k_sem *)wifi_malloc(sizeof(struct k_sem));
 		if (sem == NULL) {
 			LOG_ERR("wifi_thread_semphr_get_wrapper allocation failed");
+			return NULL;
 		}
 		k_sem_init(sem, 0, 1);
-		if (sem) {
-			k_thread_custom_data_set(sem);
-		}
+		k_thread_custom_data_set(sem);
 	}
 	return (void *)sem;
 }


### PR DESCRIPTION
The esp32 and esp32s3 adapters logged the allocation failure in wifi_thread_semphr_get_wrapper() but kept going, so k_sem_init() ran on a null pointer. The null check placed after that call shows the early return was lost at some point.

Return null on the failed allocation, matching every other target.
