### PR TITLE
hal: adc: bound the oneshot conversion completion wait

### DIFF
--- a/components/esp_hal_ana_conv/adc_oneshot_hal.c
+++ b/components/esp_hal_ana_conv/adc_oneshot_hal.c
@@ -37,6 +37,7 @@ void adc_oneshot_hal_init(adc_oneshot_hal_ctx_t *hal, const adc_oneshot_hal_cfg_
     hal->clk_src = config->clk_src;
     hal->clk_src_freq_hz = config->clk_src_freq_hz;
     hal->disable_dac_output = config->disable_dac_output;
+    hal->conv_timeout_us = config->conv_timeout_us;
 }
 
 void adc_oneshot_hal_channel_config(adc_oneshot_hal_ctx_t *hal, const adc_oneshot_hal_chan_cfg_t *config, adc_channel_t chan)
@@ -137,6 +138,9 @@ static void adc_hal_onetime_start(adc_unit_t unit, uint32_t clk_src_freq_hz, uin
 #endif // SOC_ADC_DIG_CTRL_SUPPORTED && !SOC_ADC_RTC_CTRL_SUPPORTED
 }
 
+/* Default upper bound for a single oneshot conversion, in microseconds */
+#define ADC_ONESHOT_READ_TIMEOUT_US    (2 * 1000)
+
 bool adc_oneshot_hal_convert(adc_oneshot_hal_ctx_t *hal, int *out_raw)
 {
     bool valid = true;
@@ -152,8 +156,18 @@ bool adc_oneshot_hal_convert(adc_oneshot_hal_ctx_t *hal, int *out_raw)
     adc_oneshot_ll_enable(hal->unit);
 
     adc_hal_onetime_start(hal->unit, hal->clk_src_freq_hz, &read_delay_us);
+    /* The conversion done event never fires if a shared analog block
+     * (SAR power, regi2c clock or the modem ADC front-end) is gated by
+     * a concurrent user such as the Wi-Fi modem sleep, so bound the
+     * wait instead of polling forever.
+     */
+    uint32_t timeout_us = hal->conv_timeout_us ? hal->conv_timeout_us : ADC_ONESHOT_READ_TIMEOUT_US;
     while (!adc_oneshot_ll_get_event(event)) {
-        ;
+        if (timeout_us-- == 0) {
+            adc_oneshot_ll_disable_all_unit();
+            return false;
+        }
+        esp_rom_delay_us(1);
     }
     esp_rom_delay_us(read_delay_us);
     *out_raw = adc_oneshot_ll_get_raw_result(hal->unit);

--- a/components/esp_hal_ana_conv/include/hal/adc_oneshot_hal.h
+++ b/components/esp_hal_ana_conv/include/hal/adc_oneshot_hal.h
@@ -23,6 +23,7 @@ typedef struct adc_oneshot_hal_cfg_t {
     adc_oneshot_clk_src_t clk_src;   ///< Clock source
     uint32_t clk_src_freq_hz;        ///< Clock source frequency in hz
     bool disable_dac_output;         ///< Whether to disable DAC output, only for chips supporting DAC
+    uint32_t conv_timeout_us;        ///< Conversion completion timeout in microseconds, 0 to use the default
 } adc_oneshot_hal_cfg_t;
 
 /**
@@ -45,6 +46,7 @@ typedef struct adc_oneshot_hal_ctx_t {
     adc_oneshot_clk_src_t clk_src;   ///< Clock source
     uint32_t clk_src_freq_hz;        ///< Clock source frequency in hz
     bool disable_dac_output;         ///< Whether to disable DAC output, only for chips supporting DAC
+    uint32_t conv_timeout_us;        ///< Conversion completion timeout in microseconds, 0 to use the default
 } adc_oneshot_hal_ctx_t;
 
 /**


### PR DESCRIPTION
The conversion done event never fires while a shared analog block is gated by a concurrent user such as the Wi-Fi modem sleep, and a pending trigger is discarded when the modem wakes up again. The unbounded polling loop then spins forever. Bound the wait and report the failure to the caller instead. The bound defaults to 2 ms and follows the Zephyr driver option ADC_ESP32_CONVERSION_TIMEOUT_US when it is defined.
