### PR TITLE
esp_wifi: add modem sleep default params stub for no-blobs builds

### DIFF
--- a/zephyr/port/stubs/wifi_stubs.c
+++ b/zephyr/port/stubs/wifi_stubs.c
@@ -743,6 +743,10 @@ void esp_wifi_internal_update_light_sleep_default_params(int min_freq_mhz, int m
 	ARG_UNUSED(max_freq_mhz);
 }
 
+void esp_wifi_internal_update_modem_sleep_default_params(void)
+{
+}
+
 void esp_wifi_set_sleep_min_active_time(uint32_t min_active_time)
 {
 	ARG_UNUSED(min_active_time);


### PR DESCRIPTION
Builds with CONFIG_BUILD_ONLY_NO_BLOBS=y fail to link on the esp32c6 because esp_wifi_init() calls
esp_wifi_internal_update_modem_sleep_default_params() when the Wi-Fi SLP IRAM optimization is enabled without PM. Provide the missing stub next to the other sleep parameter stubs.
