### PR TITLE
esp_hal_mspi: esp32p4: fix flash timing adjust clock enable

### DIFF
--- a/components/esp_hal_mspi/esp32p4/include/hal/mspi_ll.h
+++ b/components/esp_hal_mspi/esp32p4/include/hal/mspi_ll.h
@@ -403,7 +403,7 @@ static inline void mspi_timinng_ll_enable_flash_timing_adjust_clk(uint8_t spi_nu
     HAL_ASSERT(spi_num == MSPI_TIMING_LL_MSPI_ID_0);
     // Should set ie always on to ensure it can read flash sr2
     REG_SET_BIT(SPI_MEM_C_CTRL_REG, SPI_MEM_C_DATA_IE_ALWAYS_ON);
-    REG_GET_BIT(SPI_MEM_C_TIMING_CALI_REG, SPI_MEM_C_TIMING_CLK_ENA);
+    REG_SET_BIT(SPI_MEM_C_TIMING_CALI_REG, SPI_MEM_C_TIMING_CLK_ENA);
 }
 
 /**


### PR DESCRIPTION
The enable helper only read the timing calibration clock enable bit instead of setting it, leaving the clock disabled and raising an unused-value warning wherever the header is included. Set the bit, matching the equivalent helpers on the other socs.
