### PR TITLE
zephyr: import blobs as targets instead of -l/-L

### DIFF
--- a/zephyr/cmake/esp_blobs.cmake
+++ b/zephyr/cmake/esp_blobs.cmake
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# esp_blobs_link(<name> [<name> ...])
+#
+# Import lib<name>.a from the blob directory of the SoC series being built and
+# link it, in the order given. No-op when building without blobs.
+function(esp_blobs_link)
+  if(CONFIG_BUILD_ONLY_NO_BLOBS)
+    return()
+  endif()
+
+  set(blobs_dir ${ZEPHYR_HAL_ESPRESSIF_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES})
+
+  foreach(name ${ARGV})
+    if(NOT TARGET esp_blob_${name})
+      add_library(esp_blob_${name} STATIC IMPORTED GLOBAL)
+      set_target_properties(esp_blob_${name} PROPERTIES
+        IMPORTED_LOCATION ${blobs_dir}/lib${name}.a
+      )
+    endif()
+    zephyr_link_libraries(esp_blob_${name})
+  endforeach()
+endfunction()

--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 if(CONFIG_SOC_SERIES_ESP32)
 
+  include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/esp_blobs.cmake)
+
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
@@ -451,29 +453,19 @@ if(CONFIG_SOC_SERIES_ESP32)
         ../../components/esp_coex/src/lib_printf.c
         )
 
-      zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-        btdm_app
-        coexist
-          -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32
-        )
+      esp_blobs_link(btdm_app coexist)
     endif()
 
+    esp_blobs_link(net80211 espnow core pp phy rtc)
+
     zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      net80211
-      espnow
-      core
-      pp
-      phy
-      rtc
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
       gcc
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32
       )
 
-    zephyr_link_libraries_ifdef(CONFIG_WIFI_ESP32_MESH
-      mesh
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32
-      )
+    if(CONFIG_WIFI_ESP32_MESH)
+      esp_blobs_link(mesh)
+    endif()
   endif()
 
   ## BT definitions
@@ -492,11 +484,8 @@ if(CONFIG_SOC_SERIES_ESP32)
       ../port/stubs/phy_stubs.c
       )
 
-    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      ## ble
-      btdm_app
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32
-      )
+    ## ble
+    esp_blobs_link(btdm_app)
 
   endif()
 

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 if(CONFIG_SOC_SERIES_ESP32C2)
 
+  include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/esp_blobs.cmake)
+
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
@@ -404,21 +406,14 @@ if(CONFIG_SOC_SERIES_ESP32C2)
       zephyr_sources(../../components/esp_coex/src/lib_printf.c)
       zephyr_sources_ifdef(CONFIG_BUILD_ONLY_NO_BLOBS ../port/stubs/coex_stubs.c)
 
-      zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-        coexist
-          -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-        )
+      esp_blobs_link(coexist)
     endif()
 
+    esp_blobs_link(net80211 espnow core pp phy)
+
     zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      net80211
-      espnow
-      core
-      pp
-      phy
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
       gcc
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
       )
   endif()
 
@@ -450,12 +445,8 @@ if(CONFIG_SOC_SERIES_ESP32C2)
       ../port/stubs/phy_stubs.c
       )
 
-    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      ## ble
-      btbb
-      ble_app
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-      )
+    ## ble
+    esp_blobs_link(btbb ble_app)
 
   endif()
 

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 if(CONFIG_SOC_SERIES_ESP32C3)
 
+  include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/esp_blobs.cmake)
+
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
@@ -426,22 +428,14 @@ if(CONFIG_SOC_SERIES_ESP32C3)
         ../../components/esp_coex/src/lib_printf.c
         )
 
-      zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-        coexist
-          -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32c3
-        )
+      esp_blobs_link(coexist)
     endif()
 
+    esp_blobs_link(net80211 espnow core pp phy mesh)
+
     zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      net80211
-      espnow
-      core
-      pp
-      phy
-      mesh
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
       gcc
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32c3
       )
   endif()
 
@@ -475,12 +469,8 @@ if(CONFIG_SOC_SERIES_ESP32C3)
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.eco3_bt_funcs.ld
       )
 
-    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      ## ble
-      btbb
-      btdm_app
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32c3
-      )
+    ## ble
+    esp_blobs_link(btbb btdm_app)
   endif()
 
   ## WIFI definitions

--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 if(CONFIG_SOC_SERIES_ESP32C5)
 
+  include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/esp_blobs.cmake)
+
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
@@ -603,23 +605,18 @@ if(CONFIG_SOC_SERIES_ESP32C5)
       zephyr_sources(../../components/esp_coex/src/lib_printf.c)
       zephyr_sources_ifdef(CONFIG_BUILD_ONLY_NO_BLOBS ../port/stubs/coex_stubs.c)
 
+      esp_blobs_link(coexist)
+
       zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-        coexist
-          -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-          -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.coexist.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.coexist.ld
         )
     endif()
 
+    esp_blobs_link(net80211 espnow core pp phy mesh)
+
     zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      net80211
-      espnow
-      core
-      pp
-      phy
-      mesh
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
       gcc
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.pp.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.phy.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.net80211.ld
@@ -649,12 +646,8 @@ if(CONFIG_SOC_SERIES_ESP32C5)
       ../port/stubs/phy_stubs.c
       )
 
-    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      ## ble
-      ble_app
-      btbb
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-      )
+    ## ble
+    esp_blobs_link(ble_app btbb)
 
   endif()
 
@@ -921,10 +914,7 @@ if(CONFIG_SOC_SERIES_ESP32C5)
     zephyr_compile_definitions(CONFIG_IEEE802154_PENDING_TABLE_SIZE=${CONFIG_IEEE802154_ESP32_PENDING_TABLE_SIZE})
     zephyr_compile_definitions(CONFIG_IEEE802154_INTERFACE_NUM=1)
 
-    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      btbb
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-      )
+    esp_blobs_link(btbb)
   endif()
 
   zephyr_link_libraries_ifdef(CONFIG_NEWLIB_LIBC c)

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 if(CONFIG_SOC_SERIES_ESP32C6)
 
+  include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/esp_blobs.cmake)
+
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
@@ -571,23 +573,18 @@ if(CONFIG_SOC_SERIES_ESP32C6)
       zephyr_sources(../../components/esp_coex/src/lib_printf.c)
       zephyr_sources_ifdef(CONFIG_BUILD_ONLY_NO_BLOBS ../port/stubs/coex_stubs.c)
 
+      esp_blobs_link(coexist)
+
       zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-        coexist
-          -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-          -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.coexist.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.coexist.ld
         )
     endif()
 
+    esp_blobs_link(net80211 espnow core pp phy mesh)
+
     zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      net80211
-      espnow
-      core
-      pp
-      phy
-      mesh
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
       gcc
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.pp.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.phy.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.net80211.ld
@@ -617,12 +614,8 @@ if(CONFIG_SOC_SERIES_ESP32C6)
       ../port/stubs/phy_stubs.c
       )
 
-    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      ## ble
-      btbb
-      ble_app
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-      )
+    ## ble
+    esp_blobs_link(btbb ble_app)
 
   endif()
 
@@ -895,10 +888,7 @@ if(CONFIG_SOC_SERIES_ESP32C6)
     zephyr_compile_definitions(CONFIG_IEEE802154_PENDING_TABLE_SIZE=${CONFIG_IEEE802154_ESP32_PENDING_TABLE_SIZE})
     zephyr_compile_definitions(CONFIG_IEEE802154_INTERFACE_NUM=1)
 
-    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      btbb
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-      )
+    esp_blobs_link(btbb)
   endif()
 
   zephyr_link_libraries_ifdef(CONFIG_NEWLIB_LIBC c)

--- a/zephyr/esp32c61/CMakeLists.txt
+++ b/zephyr/esp32c61/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 if(CONFIG_SOC_SERIES_ESP32C61)
 
+  include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/esp_blobs.cmake)
+
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
@@ -519,23 +521,18 @@ if(CONFIG_SOC_SERIES_ESP32C61)
       zephyr_sources(../../components/esp_coex/src/lib_printf.c)
       zephyr_sources_ifdef(CONFIG_BUILD_ONLY_NO_BLOBS ../port/stubs/coex_stubs.c)
 
+      esp_blobs_link(coexist)
+
       zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-        coexist
-          -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-          -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.coexist.ld
+        -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.coexist.ld
         )
     endif()
 
+    esp_blobs_link(net80211 espnow core pp phy mesh)
+
     zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      net80211
-      espnow
-      core
-      pp
-      phy
-      mesh
       # wifi libs refer gcc libs symbols, so linked in libgcc
       gcc
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.pp.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.phy.ld
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.net80211.ld
@@ -567,12 +564,8 @@ if(CONFIG_SOC_SERIES_ESP32C61)
       ../port/stubs/phy_stubs.c
       )
 
-    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      # ble, with btbb after ble_app to resolve its baseband calls
-      ble_app
-      btbb
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-      )
+    # ble, with btbb after ble_app to resolve its baseband calls
+    esp_blobs_link(ble_app btbb)
 
   endif()
 

--- a/zephyr/esp32h2/CMakeLists.txt
+++ b/zephyr/esp32h2/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 if(CONFIG_SOC_SERIES_ESP32H2)
 
+  include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/esp_blobs.cmake)
+
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
@@ -516,10 +518,7 @@ if(CONFIG_SOC_SERIES_ESP32H2)
       ../port/stubs/ieee802154_stubs.c
       )
 
-    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      btbb
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-      )
+    esp_blobs_link(btbb)
   endif()
 
   ## BT definitions
@@ -545,12 +544,8 @@ if(CONFIG_SOC_SERIES_ESP32H2)
       ../port/stubs/phy_stubs.c
       )
 
-    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      ## ble
-      btbb
-      ble_app
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-      )
+    ## ble
+    esp_blobs_link(btbb ble_app)
 
   endif()
 
@@ -579,17 +574,14 @@ if(CONFIG_SOC_SERIES_ESP32H2)
       zephyr_sources(../../components/esp_coex/src/lib_printf.c)
       zephyr_sources_ifdef(CONFIG_BUILD_ONLY_NO_BLOBS ../port/stubs/coex_stubs.c)
 
-      zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-        coexist
-          -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
-        )
+      esp_blobs_link(coexist)
     endif()
 
+    esp_blobs_link(phy)
+
     zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      phy
       ## esp-idf libs refer gcc libs symbols, so linked in libgcc
       gcc
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/${CONFIG_SOC_SERIES}
       )
   endif()
 

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 if(CONFIG_SOC_SERIES_ESP32S2)
 
+  include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/esp_blobs.cmake)
+
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
@@ -693,27 +695,19 @@ if(CONFIG_SOC_SERIES_ESP32S2)
       zephyr_sources(../../components/esp_coex/src/lib_printf.c)
       zephyr_sources_ifdef(CONFIG_BUILD_ONLY_NO_BLOBS ../port/stubs/coex_stubs.c)
 
-      zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-        coexist
-          -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32s2
-        )
+      esp_blobs_link(coexist)
     endif()
 
+    esp_blobs_link(net80211 espnow core pp phy)
+
     zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      net80211
-      espnow
-      core
-      pp
-      phy
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
       gcc
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32s2
     )
 
-    zephyr_link_libraries_ifdef(CONFIG_WIFI_ESP32_MESH
-      mesh
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32s2
-      )
+    if(CONFIG_WIFI_ESP32_MESH)
+      esp_blobs_link(mesh)
+    endif()
 
   endif() ## CONFIG_WIFI_ESP32
 

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 if(CONFIG_SOC_SERIES_ESP32S3)
 
+  include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/esp_blobs.cmake)
+
   zephyr_compile_options(-fstrict-volatile-bitfields)
   zephyr_compile_definitions_ifndef(CONFIG_MCUBOOT CONFIG_APP_BUILD_USE_FLASH_SECTIONS)
   zephyr_compile_definitions_ifndef(asm asm=__asm__)
@@ -504,27 +506,19 @@ if(CONFIG_SOC_SERIES_ESP32S3)
       zephyr_sources(../../components/esp_coex/src/lib_printf.c)
       zephyr_sources_ifdef(CONFIG_BUILD_ONLY_NO_BLOBS ../port/stubs/coex_stubs.c)
 
-      zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-        coexist
-          -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32s3
-        )
+      esp_blobs_link(coexist)
     endif()
 
+    esp_blobs_link(net80211 espnow core pp phy)
+
     zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      net80211
-      espnow
-      core
-      pp
-      phy
       ## esp-idf wifi libs refer gcc libs symbols, so linked in libgcc
       gcc
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32s3
       )
 
-    zephyr_link_libraries_ifdef(CONFIG_WIFI_ESP32_MESH
-      mesh
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32s3
-      )
+    if(CONFIG_WIFI_ESP32_MESH)
+      esp_blobs_link(mesh)
+    endif()
   endif()
 
   ## BT definitions
@@ -550,12 +544,8 @@ if(CONFIG_SOC_SERIES_ESP32S3)
         -T${CMAKE_CURRENT_SOURCE_DIR}/../../components/esp_rom/${CONFIG_SOC_SERIES}/ld/${CONFIG_SOC_SERIES}.rom.bt_funcs.ld
       )
 
-    zephyr_link_libraries_ifndef(CONFIG_BUILD_ONLY_NO_BLOBS
-      ## ble
-      btbb
-      btdm_app
-        -L${CMAKE_CURRENT_SOURCE_DIR}/../blobs/lib/esp32s3
-      )
+    ## ble
+    esp_blobs_link(btbb btdm_app)
   endif()
 
     ## WIFI definitions


### PR DESCRIPTION
Blobs are linked by bare library name plus a `-L` at the SoC's blob directory. A bare name is not a file as far as CMake is concerned, so nothing in the build graph depends on the archives: after `west blobs fetch` pulls updated blobs, or a module revision shipping different ones is checked out, the previously linked copies stay in the image because no relink is triggered. `-L` search also resolves very generic names — `core`, `pp`, `phy`, `rtc` — against whatever else is on the library search path.

Adds `zephyr/cmake/esp_blobs.cmake` with an `esp_blobs_link()` helper that imports each blob as a `STATIC IMPORTED` target and links it, so the link step depends on the archive. Same shape `hal_silabs` uses (`add_prebuilt_library`) and `hal_afbr`.

The imported targets are attached to `zephyr_interface` rather than `ZEPHYR_LIBS`, which is why `zephyr_library_import()` is not used: Zephyr links `ZEPHYR_LIBS` with `--whole-archive`, which would pull every object of `libnet80211.a` / `libpp.a` / `libphy.a` into the image.

Preserved: link order including `gcc` after the esp libs, all `-T` linker script arguments, and `CONFIG_BUILD_ONLY_NO_BLOBS` behaviour (the helper is a no-op there, stubs untouched).

## Testing

Every SoC's blob list was diffed against the pre-conversion source: identical set and identical order in all nine, and every name resolves to a `lib/<soc>/lib<name>.a` declared in `zephyr/module.yml`.

`samples/net/wifi/shell` on `esp32c5_devkitc//hpcore`, built against `main` and against this branch:

- Identical memory report, and `nm -S --defined-only` gives the same 8177 symbols at the same sizes — no `--whole-archive` or link-order regression.
- The link line drops `-lcore -lespnow -lmesh -lnet80211 -lphy -lpp` and the `-L .../blobs/lib/esp32c5`, and gains the six archives by absolute path. `-lgcc` is untouched.
- `touch`ing `libpp.a` and re-running ninja: `main` reports **no work to do** and keeps the stale blob in the image; this branch relinks and regenerates the image.

