### PR TITLE
zephyr: build the wi-fi regulatory tables

### DIFF
--- a/zephyr/esp32/CMakeLists.txt
+++ b/zephyr/esp32/CMakeLists.txt
@@ -671,6 +671,7 @@ if(CONFIG_SOC_SERIES_ESP32)
     zephyr_sources(
       ../../components/esp_wifi/esp32/esp_adapter.c
       ../../components/esp_coex/esp32/esp_coex_adapter.c
+      ../../components/esp_wifi/regulatory/esp_wifi_regulatory.c
       ../../components/esp_wifi/src/wifi_init.c
       ../port/stubs/wifi_compat_stubs.c
       ../../components/esp_wifi/src/lib_printf.c

--- a/zephyr/esp32c2/CMakeLists.txt
+++ b/zephyr/esp32c2/CMakeLists.txt
@@ -635,6 +635,7 @@ if(CONFIG_SOC_SERIES_ESP32C2)
     zephyr_sources(
       ../../components/esp_wifi/esp32c2/esp_adapter.c
       ../../components/esp_coex/esp32c2/esp_coex_adapter.c
+      ../../components/esp_wifi/regulatory/esp_wifi_regulatory.c
       ../../components/esp_wifi/src/wifi_init.c
       ../../components/esp_wifi/src/lib_printf.c
       ../port/stubs/wifi_compat_stubs.c

--- a/zephyr/esp32c3/CMakeLists.txt
+++ b/zephyr/esp32c3/CMakeLists.txt
@@ -661,6 +661,7 @@ if(CONFIG_SOC_SERIES_ESP32C3)
     zephyr_sources(
       ../../components/esp_wifi/esp32c3/esp_adapter.c
       ../../components/esp_coex/esp32c3/esp_coex_adapter.c
+      ../../components/esp_wifi/regulatory/esp_wifi_regulatory.c
       ../../components/esp_wifi/src/wifi_init.c
       ../../components/esp_wifi/src/lib_printf.c
       ${WPA_SUPPLICANT_SRCS}

--- a/zephyr/esp32c5/CMakeLists.txt
+++ b/zephyr/esp32c5/CMakeLists.txt
@@ -826,6 +826,7 @@ if(CONFIG_SOC_SERIES_ESP32C5)
 
     zephyr_sources(
       ../../components/esp_wifi/${CONFIG_SOC_SERIES}/esp_adapter.c
+      ../../components/esp_wifi/regulatory/esp_wifi_regulatory.c
       ../../components/esp_wifi/src/wifi_init.c
       ../../components/esp_wifi/src/lib_printf.c
       ../port/stubs/wifi_compat_stubs.c

--- a/zephyr/esp32c6/CMakeLists.txt
+++ b/zephyr/esp32c6/CMakeLists.txt
@@ -800,6 +800,7 @@ if(CONFIG_SOC_SERIES_ESP32C6)
 
     zephyr_sources(
       ../../components/esp_wifi/esp32c6/esp_adapter.c
+      ../../components/esp_wifi/regulatory/esp_wifi_regulatory.c
       ../../components/esp_wifi/src/wifi_init.c
       ../../components/esp_wifi/src/lib_printf.c
       ../port/stubs/wifi_compat_stubs.c

--- a/zephyr/esp32s2/CMakeLists.txt
+++ b/zephyr/esp32s2/CMakeLists.txt
@@ -450,6 +450,7 @@ if(CONFIG_SOC_SERIES_ESP32S2)
     zephyr_sources(
       ../../components/esp_wifi/esp32s2/esp_adapter.c
       ../../components/esp_coex/esp32s2/esp_coex_adapter.c
+      ../../components/esp_wifi/regulatory/esp_wifi_regulatory.c
       ../../components/esp_wifi/src/wifi_init.c
       ../../components/esp_wifi/src/lib_printf.c
       ../../components/esp_phy/src/phy_init.c

--- a/zephyr/esp32s3/CMakeLists.txt
+++ b/zephyr/esp32s3/CMakeLists.txt
@@ -731,6 +731,7 @@ if(CONFIG_SOC_SERIES_ESP32S3)
     zephyr_sources(
       ../../components/esp_wifi/esp32s3/esp_adapter.c
       ../../components/esp_coex/esp32s3/esp_coex_adapter.c
+      ../../components/esp_wifi/regulatory/esp_wifi_regulatory.c
       ../../components/esp_wifi/src/wifi_init.c
       ../../components/esp_wifi/src/lib_printf.c
       ../../components/esp_phy/esp32s3/phy_init_data.c


### PR DESCRIPTION
Compile esp_wifi_regulatory.c for the Wi-Fi capable SoCs so the blob resolves the real regdomain_table and regulatory_data symbols instead of the weak NULL fallbacks in the compat stubs. Without the tables the blob has no channel plan to apply, so a country code set through the Wi-Fi management API is rejected with ESP_ERR_INVALID_ARG.
